### PR TITLE
Enable basic ESP32S2 support, prepare for ESP32S3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.13"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
  "atty",
  "bitflags",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.12"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -342,9 +342,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "linked-hash-map"
@@ -661,7 +661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e99ea9c86b72d3ff88b6c925821d19c9f1586557e967de7f11cf9a333633e90c"
 dependencies = [
  "anyhow",
- "clap 3.0.13",
+ "clap 3.0.14",
  "commands",
  "env_logger 0.9.0",
  "globset",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -859,7 +859,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 3.0.13",
+ "clap 3.0.14",
  "form",
  "strum",
  "strum_macros",

--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -28,7 +28,7 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.8.0", optional = true }
+xtensa-lx-rt = { version = "0.9.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32"]

--- a/esp32s2/Cargo.toml
+++ b/esp32s2/Cargo.toml
@@ -29,9 +29,9 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.8.0", optional = true }
+xtensa-lx-rt = { version = "0.9.0", optional = true }
 
 [features]
 # NOTE: these features will need to be updated when support for LX7 is added.
 default = ["xtensa-lx/esp32"]
-rt = ["xtensa-lx-rt/esp32"]
+rt = ["xtensa-lx-rt/esp32s2"]

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -31,3 +31,12 @@ IO_MUX:
       - U0TXD
       - U0RXD
       - SPICLK
+
+INTERRUPT:
+  _modify:
+    "PRO_INTR_STATUS_REG_0":
+      name: "PRO_INTR_STATUS_0"
+    "PRO_INTR_STATUS_REG_1":
+      name: "PRO_INTR_STATUS_1"
+    "PRO_INTR_STATUS_REG_2":
+      name: "PRO_INTR_STATUS_2"

--- a/esp32s3/Cargo.toml
+++ b/esp32s3/Cargo.toml
@@ -29,9 +29,9 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.8.0", optional = true }
+xtensa-lx-rt = { version = "0.9.0", optional = true }
 
 [features]
 # NOTE: these features will need to be updated when support for LX7 is added.
 default = ["xtensa-lx/esp32"]
-rt = ["xtensa-lx-rt/esp32"]
+rt = ["xtensa-lx-rt/esp32s3"]

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -32,3 +32,25 @@ GPIO:
       "DATA":
         access: read-write
         name: data_next
+
+INTERRUPT_CORE0:
+  _modify:
+    "MAC_INTR_MAP":
+      name: "PRO_MAC_INTR_MAP"
+    "INTR_STATUS_0":
+      name: "PRO_INTR_STATUS_0"
+    "INTR_STATUS_1":
+      name: "PRO_INTR_STATUS_1"
+    "INTR_STATUS_2":
+      name: "PRO_INTR_STATUS_2"
+
+INTERRUPT_CORE1:
+  _modify:
+    "MAC_INTR_MAP":
+      name: "APP_MAC_INTR_MAP"
+    "INTR_STATUS_0":
+      name: "APP_INTR_STATUS_0"
+    "INTR_STATUS_1":
+      name: "APP_INTR_STATUS_1"
+    "INTR_STATUS_2":
+      name: "APP_INTR_STATUS_2"


### PR DESCRIPTION
* ESP32S2 support
* prepare for ESP32S3
* use `xtensa-lx-rt` version _0.9.0_ 

Note: After this also `esp-hal` needs an update
