### PR TITLE
Rename I2C to I2C0 for ESP32C3

### DIFF
--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -13,3 +13,7 @@ SYSTEM:
     _modify:
       EXT0_RST:
         name: I2C_EXT0_RST
+
+_modify:
+  I2C:
+    name: I2C0


### PR DESCRIPTION
This is to align the naming of the peripherals