### PR TITLE
Align timer interrupt register names

### DIFF
--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -17,3 +17,16 @@ SYSTEM:
 _modify:
   I2C:
     name: I2C0
+
+TIMG0:
+  _modify:
+    INT_ENA_TIMG:
+      name: INT_ENA_TIMERS
+    INT_ST_TIMG:
+      name: INT_ST_TIMERS
+TIMG1:
+  _modify:
+    INT_ENA_TIMG:
+      name: INT_ENA_TIMERS
+    INT_ST_TIMG:
+      name: INT_ST_TIMERS


### PR DESCRIPTION
This aligns the naming of `INT_ENA_TIMERS` and `INT_ST_TIMERS` registers.

This is in preparation for (simple) timer interrupt support.