### PR TITLE
Patch in the register for the hardware RNG for each chip

### DIFF
--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -32,3 +32,19 @@ DPORT:
         bitOffset: 7
         bitWidth: 1
         access: read-write
+
+_modify:
+  WDEV:
+    name: RNG
+    groupName: RNG
+    description: Hardware random number generator
+    baseAddress: 0x60035000
+
+RNG:
+  _modify:
+    RND:
+      name: DATA
+      description: Random number data
+      access: read-only
+      addressOffset: 0x144
+      size: 0x20

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -30,3 +30,18 @@ TIMG1:
       name: INT_ENA_TIMERS
     INT_ST_TIMG:
       name: INT_ST_TIMERS
+
+_add:
+  RNG:
+    name: RNG
+    groupName: RNG
+    description: Hardware random number generator
+    baseAddress: 0x60026000
+
+RNG:
+  _add:
+    DATA:
+      description: Random number data
+      access: read-only
+      addressOffset: 0xb0
+      size: 0x20

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -5,3 +5,18 @@ I2C0:
     _modify:
       FIFO_RDATA:
         access: read-write
+
+_add:
+  RNG:
+    name: RNG
+    groupName: RNG
+    description: Hardware random number generator
+    baseAddress: 0x60035000
+
+RNG:
+  _add:
+    DATA:
+      description: Random number data
+      access: read-only
+      addressOffset: 0x110
+      size: 0x20

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -3,3 +3,18 @@ _svd: ../esp32s3.base.svd
 RTC_CNTL:
   _strip:
     - "RTC_"
+
+_add:
+  RNG:
+    name: RNG
+    groupName: RNG
+    description: Hardware random number generator
+    baseAddress: 0x60034F6C
+
+RNG:
+  _add:
+    DATA:
+      description: Random number data
+      access: read-only
+      addressOffset: 0x110
+      size: 0x20


### PR DESCRIPTION
This is a simple peripheral with only a single register.

`baseAddress` and `addressOffset` values were deduced by a combination of searching ESP-IDF with `ripgrep` for the term __WDEV_RND_REG__ and referring to the TRM.

@bjoernQ everything seems to be working as expected in my examples, but whenever you get a moment could you please confirm these values are correct?