### PR TITLE
Update xtensa-lx-rt version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,8 +160,8 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -213,8 +213,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
  "synstructure",
 ]
 
@@ -333,9 +333,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "linked-hash-map"
@@ -345,9 +345,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -400,8 +400,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
  "version_check",
 ]
 
@@ -412,7 +412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "quote 1.0.17",
  "version_check",
 ]
 
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2 1.0.36",
 ]
@@ -528,8 +528,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -582,9 +582,9 @@ checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck",
  "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "quote 1.0.17",
  "rustversion",
- "syn 1.0.86",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -636,12 +636,12 @@ dependencies = [
  "inflections",
  "log",
  "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "quote 1.0.17",
  "serde_json",
  "serde_yaml",
  "svd-parser",
  "svd-rs",
- "syn 1.0.86",
+ "syn 1.0.90",
  "thiserror",
 ]
 
@@ -682,12 +682,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "quote 1.0.17",
  "unicode-xid 0.2.2",
 ]
 
@@ -698,8 +698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
  "unicode-xid 0.2.2",
 ]
 
@@ -743,8 +743,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "quote 1.0.17",
+ "syn 1.0.90",
 ]
 
 [[package]]

--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -28,7 +28,7 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.9.0", optional = true }
+xtensa-lx-rt = { version = "0.10.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32"]

--- a/esp32s2/Cargo.toml
+++ b/esp32s2/Cargo.toml
@@ -29,7 +29,7 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.9.0", optional = true }
+xtensa-lx-rt = { version = "0.10.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32"]

--- a/esp32s3/Cargo.toml
+++ b/esp32s3/Cargo.toml
@@ -29,7 +29,7 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.9.0", optional = true }
+xtensa-lx-rt = { version = "0.10.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32"]

--- a/esp8266/Cargo.toml
+++ b/esp8266/Cargo.toml
@@ -31,7 +31,7 @@ license = "MIT OR Apache-2.0"
 bare-metal = "1.0"
 vcell = "0.1"
 xtensa-lx = "0.6.0"
-xtensa-lx-rt = { version = "0.9.0", optional = true }
+xtensa-lx-rt = { version = "0.10.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp8266"]


### PR DESCRIPTION
This just updates the xtensa-lx-rt dependency to 0.10.0 in preparation of the next PR in esp-hal
