### PR TITLE
Align TIMG field names

### DIFF
--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -23,3 +23,18 @@ DPORT:
        value: 8
       RWBLE_NMI:
        value: 9
+
+TIMG0:
+  "T0*":
+    _strip:
+      - "T0_"    
+  "T1*":
+    _strip:
+      - "T1_" 
+TIMG1:
+  "T0*":
+    _strip:
+      - "T0_"
+  "*":
+    _strip:
+      - "T0_"    

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -33,3 +33,13 @@ INTERRUPT_CORE0:
        value: 9
       RWBLE_NMI:
        value: 10
+
+TIMG0:
+  "T0*":
+    _strip:
+      - "T0_"    
+
+TIMG1:
+  "T0*":
+    _strip:
+      - "T0_"

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -49,3 +49,21 @@ RTCIO:
     _modify:
       REG_RTCIO_REG_GPIO_ENABLE_W1TC:
         name: ENABLE_W1TC
+
+TIMG0:
+  "T%s*":
+    _strip:
+      - "T0_"    
+  WDTCONFIG1:
+    _modify:
+      WDT_CLK_PRESCALER:
+        name: WDT_CLK_PRESCALE
+
+TIMG1:
+  "T%s*":
+    _strip:
+      - "T0_"    
+  WDTCONFIG1:
+    _modify:
+      WDT_CLK_PRESCALER:
+        name: WDT_CLK_PRESCALE

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -44,3 +44,13 @@ RTCIO:
     _modify:
       RTC_GPIO_ENABLE_W1TC:
         name: ENABLE_W1TC
+
+TIMG0:
+  "T%s*":
+    _strip:
+      - "T0_"    
+
+TIMG1:
+  "T%s*":
+    _strip:
+      - "T0_"    


### PR DESCRIPTION
Problem was that on S2 and S3 there were names like `T1CONFIG/T0_xxxx` ... this strips the `Tn_` prefix from the field names.
Unfortunately, this PR will break the current HAL version so I will pin the dependencies there to a commit instead of just using the branch `with_sources`