### PR TITLE
Align LEDC register and field names across chips

### DIFF
--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -4,25 +4,25 @@ DPORT:
   _add:
     _interrupts:
       WIFI_MAC:
-       value: 0
+        value: 0
       WIFI_NMI:
-       value: 1
+        value: 1
       WIFI_BB:
-       value: 2
+        value: 2
       BT_MAC:
-       value: 3
+        value: 3
       BT_BB:
-       value: 4
+        value: 4
       BT_BB_NMI:
-       value: 5
+        value: 5
       RWBT:
-       value: 6
+        value: 6
       RWBLE:
-       value: 7
+        value: 7
       RWBT_NMI:
-       value: 8
+        value: 8
       RWBLE_NMI:
-       value: 9
+        value: 9
 
 TIMG0:
   "T0*":
@@ -40,133 +40,74 @@ TIMG1:
       - "T0_"
 
 LEDC:
+  _array:
+    "HSCH*_CONF0": {}
+    "HSCH*_HPOINT": {}
+    "HSCH*_DUTY": {}
+    "HSCH*_CONF1": {}
+    "HSCH*_DUTY_R": {}
+    "LSCH*_CONF0": {}
+    "LSCH*_HPOINT": {}
+    "LSCH*_DUTY": {}
+    "LSCH*_CONF1": {}
+    "LSCH*_DUTY_R": {}
+    "HSTIMER*_CONF": {}
+    "HSTIMER*_VALUE": {}
+    "LSTIMER*_CONF": {}
+    "LSTIMER*_VALUE": {}
+
+  "*":
+    _strip_end:
+      - "_HSCH0"
+      - "_LSCH0"
+
+  "HSCH0_CONF0":
+    _delete: "CLK_EN"
+
+  "HSCH*_DUTY_R":
+    _add:
+      DUTY_R:
+        description: "This register represents the current duty cycle of the output signal for high-speed channel %s"
+        bitOffset: 0
+        bitWidth: 25
+        access: read-only
+
   _modify:
-    _registers:
-      HSCH0_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH0:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH1_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH1:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH2_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH2:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH3_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH3:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH4_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH4:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH5_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH5:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH6_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH6:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      HSCH7_DUTY:
-        access: read-write
-        fields:
-          DUTY_HSCH7:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH0_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH0:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH1_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH1:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH2_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH2:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH3_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH3:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH4_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH4:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH5_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH5:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH6_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH6:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-      LSCH7_DUTY:
-        access: read-write
-        fields:
-          DUTY_LSCH7:
-            bitOffset: 0
-            bitWidth: 25
-            access: read-write
-  LSTIMER0_CONF:
+    "HSCH*_DUTY":
+      access: read-write
+
+  "HSCH*_DUTY":
     _modify:
-      DIV_NUM_LSTIMER0:
-        name: CLK_DIV_LSTIMER0
-  LSTIMER1_CONF:
+      DUTY:
+        access: read-write
+
+  _modify:
+    "LSCH*_DUTY":
+      access: read-write
+
+  "LSCH*_DUTY":
     _modify:
-      DIV_NUM_LSTIMER1:
-        name: CLK_DIV_LSTIMER1
-  LSTIMER2_CONF:
-    _modify:
-      DIV_NUM_LSTIMER2:
-        name: CLK_DIV_LSTIMER2
-  LSTIMER3_CONF:
-    _modify:
-      DIV_NUM_LSTIMER3:
-        name: CLK_DIV_LSTIMER3
+      DUTY:
+        access: read-write
+
+  "LSCH*_DUTY_R":
+    _add:
+      DUTY_R:
+        description: "This register represents the current duty cycle of the output signal for low-speed channel %s"
+        bitOffset: 0
+        bitWidth: 25
+        access: read-only
+
+  "HSTIMER*_CONF":
+    _strip: "HSTIMER0_"
+    _strip_end: "_HSTIMER0"
+
+  "HSTIMER*_VALUE":
+    _strip: "HSTIMER0_"
+
+  "LSTIMER*_CONF":
+    _strip: "LSTIMER0_"
+    _strip_end: "_LSTIMER0"
+
+  "LSTIMER*_VALUE":
+    _strip: "LSTIMER0_"

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -12,32 +12,59 @@ INTERRUPT_CORE0:
       SW_INTR_3:
         value: 53
       WIFI_MAC:
-       value: 0
+        value: 0
       WIFI_MAC_NMI:
-       value: 1
+        value: 1
       WIFI_PWR:
-       value: 2
+        value: 2
       WIFI_BB:
-       value: 3
+        value: 3
       BT_MAC:
-       value: 4
+        value: 4
       BT_BB:
-       value: 5
+        value: 5
       BT_BB_NMI:
-       value: 6
+        value: 6
       RWBT:
-       value: 7
+        value: 7
       RWBLE:
-       value: 8
+        value: 8
       RWBT_NMI:
-       value: 9
+        value: 9
       RWBLE_NMI:
-       value: 10
+        value: 10
+
+LEDC:
+  _strip: "LS"
+
+  _array:
+    "CH*_CONF0": {}
+    "CH*_HPOINT": {}
+    "CH*_DUTY": {}
+    "CH*_CONF1": {}
+    "CH*_DUTY_R": {}
+    "TIMER*_CONF": {}
+    "TIMER*_VALUE": {}
+
+  "*":
+    _strip_end: "_LSCH0"
+
+  "CH0_DUTY_R":
+    _modify:
+      "DUTY_LSCH0_R":
+        name: "DUTY_R"
+
+  "TIMER0_CONF":
+    _strip: "LSTIMER0_"
+    _strip_end: "_LSTIMER0"
+
+  "TIMER0_VALUE":
+    _strip: "LSTIMER0_"
 
 TIMG0:
   "T0*":
     _strip:
-      - "T0_"    
+      - "T0_"
 
 TIMG1:
   "T0*":

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -29,6 +29,17 @@ INTERRUPT:
       RWBLE_NMI:
         value: 10
 
+LEDC:
+  "*":
+    _strip_end: "_CH0"
+
+  "TIMER%s_CONF":
+    _strip: "TIMER0_"
+    _strip_end: "_TIMER0"
+
+  "TIMER%s_VALUE":
+    _strip: "TIMER0_"
+
 TWAI:
   _modify:
     _interrupts:
@@ -53,7 +64,7 @@ RTCIO:
 TIMG0:
   "T%s*":
     _strip:
-      - "T0_"    
+      - "T0_"
   WDTCONFIG1:
     _modify:
       WDT_CLK_PRESCALER:
@@ -62,7 +73,7 @@ TIMG0:
 TIMG1:
   "T%s*":
     _strip:
-      - "T0_"    
+      - "T0_"
   WDTCONFIG1:
     _modify:
       WDT_CLK_PRESCALER:

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -1,29 +1,39 @@
 _svd: ../esp32s3.base.svd
 
-
 INTERRUPT_CORE0:
   _add:
     _interrupts:
       WIFI_MAC:
-       value: 0
+        value: 0
       WIFI_NMI:
-       value: 1
+        value: 1
       WIFI_BB:
-       value: 2
+        value: 2
       BT_MAC:
-       value: 3
+        value: 3
       BT_BB:
-       value: 4
+        value: 4
       BT_BB_NMI:
-       value: 5
+        value: 5
       RWBT:
-       value: 6
+        value: 6
       RWBLE:
-       value: 7
+        value: 7
       RWBT_NMI:
-       value: 8
+        value: 8
       RWBLE_NMI:
-       value: 9
+        value: 9
+
+LEDC:
+  "*":
+    _strip_end: "_CH0"
+
+  "TIMER%s_CONF":
+    _strip: "TIMER0_"
+    _strip_end: "_TIMER0"
+
+  "TIMER%s_VALUE":
+    _strip: "TIMER0_"
 
 _modify:
   RTC_IO:
@@ -48,9 +58,9 @@ RTCIO:
 TIMG0:
   "T%s*":
     _strip:
-      - "T0_"    
+      - "T0_"
 
 TIMG1:
   "T%s*":
     _strip:
-      - "T0_"    
+      - "T0_"


### PR DESCRIPTION
This should make the naming of registers and fields for the `LEDC` peripheral as similar as possible. The ESP32 will always differ from the rest due to its low/high speed channels, but the register structure otherwise matches the other chips.

This does rename a number of registers and fields obviously, so updates will be required in the PR for the HAL. However, once those changes are made then we should be able to support the S2 and S3 fairly trivially. I have not modified any interrupt-related registers, as interrupt support for this peripheral is not implemented in the PR.

@bjoernQ @JurajSadel PTAL and let me know if you spot any issues. Probably easiest to run each SVD through [svd2html](https://github.com/bjoernQ/svd2html) for visual comparison (which is what I've done, comparing with the TRMs). Remember to patch the SVDs prior to generating the HTML representation if you do that.