### PR TITLE
Patch SHA registers for S2 chip to be consistent with others (C2/C3/S3)

### DIFF
--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -1,1 +1,15 @@
 _svd: ../esp32s2.base.svd
+
+"SHA":
+  _strip_end: "OP"
+  _modify:
+    "M_%s":
+      name: "M_MEM%s"
+    _registers:
+      M_0:
+        name: M_MEM 
+    "H_%s":
+      name: "H_MEM%s"
+    _registers:
+      H_0:
+        name: H_MEM 


### PR DESCRIPTION
Note that stripping `OP` now gives `continue_` which is the same as others, but we might want to patch all of the others to have the register be `continue` 