### PR TITLE
Strip prefixes from ESP32-S3 I2S1

### DIFF
--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -26,3 +26,8 @@ SENS:
     _strip: "SAR_"
   "SAR_ATTEN1":
     _strip: "SAR_"
+
+I2S1:
+  _strip: "I2S_"
+  "*":
+    _strip: "I2S_"


### PR DESCRIPTION
This is needed for the upcoming I2S implementation

This only includes the changed patch-file - not the updated sources.
Not sure what the policy should be - probably including updated sources in PRs would be annoying

Maybe we should have some hints in the README PRs should look like?
