### PR TITLE
rename esp32s2 PCNT register fields to be consistent with esp32s3

### DIFF
--- a/esp32s2/src/pcnt/u_cnt.rs
+++ b/esp32s2/src/pcnt/u_cnt.rs
@@ -13,13 +13,13 @@ impl From<crate::R<U_CNT_SPEC>> for R {
         R(reader)
     }
 }
-#[doc = "Field `PULSE_CNT_U0` reader - This register stores the current pulse count value for unit %s."]
-pub type PULSE_CNT_U0_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `PULSE_CNT_U` reader - This register stores the current pulse count value for unit %s."]
+pub type PULSE_CNT_U_R = crate::FieldReader<u16, u16>;
 impl R {
     #[doc = "Bits 0:15 - This register stores the current pulse count value for unit %s."]
     #[inline(always)]
-    pub fn pulse_cnt_u0(&self) -> PULSE_CNT_U0_R {
-        PULSE_CNT_U0_R::new((self.bits & 0xffff) as u16)
+    pub fn pulse_cnt_u(&self) -> PULSE_CNT_U_R {
+        PULSE_CNT_U_R::new((self.bits & 0xffff) as u16)
     }
 }
 #[doc = "Counter value for unit %s\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [u_cnt](index.html) module"]

--- a/esp32s2/src/pcnt/u_conf0.rs
+++ b/esp32s2/src/pcnt/u_conf0.rs
@@ -34,242 +34,242 @@ impl From<crate::W<U_CONF0_SPEC>> for W {
         W(writer)
     }
 }
-#[doc = "Field `FILTER_THRES_U0` reader - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
-pub type FILTER_THRES_U0_R = crate::FieldReader<u16, u16>;
-#[doc = "Field `FILTER_THRES_U0` writer - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
-pub type FILTER_THRES_U0_W<'a, const O: u8> =
+#[doc = "Field `FILTER_THRES_U` reader - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
+pub type FILTER_THRES_U_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `FILTER_THRES_U` writer - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
+pub type FILTER_THRES_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u16, u16, 10, O>;
-#[doc = "Field `FILTER_EN_U0` reader - This is the enable bit for unit %s's input filter."]
-pub type FILTER_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `FILTER_EN_U0` writer - This is the enable bit for unit %s's input filter."]
-pub type FILTER_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `THR_ZERO_EN_U0` reader - This is the enable bit for unit %s's zero comparator."]
-pub type THR_ZERO_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `THR_ZERO_EN_U0` writer - This is the enable bit for unit %s's zero comparator."]
-pub type THR_ZERO_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `THR_H_LIM_EN_U0` reader - This is the enable bit for unit %s's thr_h_lim comparator."]
-pub type THR_H_LIM_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `THR_H_LIM_EN_U0` writer - This is the enable bit for unit %s's thr_h_lim comparator."]
-pub type THR_H_LIM_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `THR_L_LIM_EN_U0` reader - This is the enable bit for unit %s's thr_l_lim comparator."]
-pub type THR_L_LIM_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `THR_L_LIM_EN_U0` writer - This is the enable bit for unit %s's thr_l_lim comparator."]
-pub type THR_L_LIM_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `THR_THRES0_EN_U0` reader - This is the enable bit for unit %s's thres0 comparator."]
-pub type THR_THRES0_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `THR_THRES0_EN_U0` writer - This is the enable bit for unit %s's thres0 comparator."]
-pub type THR_THRES0_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `THR_THRES1_EN_U0` reader - This is the enable bit for unit %s's thres1 comparator."]
-pub type THR_THRES1_EN_U0_R = crate::BitReader<bool>;
-#[doc = "Field `THR_THRES1_EN_U0` writer - This is the enable bit for unit %s's thres1 comparator."]
-pub type THR_THRES1_EN_U0_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
-#[doc = "Field `CH0_NEG_MODE_U0` reader - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
-pub type CH0_NEG_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH0_NEG_MODE_U0` writer - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
-pub type CH0_NEG_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `FILTER_EN_U` reader - This is the enable bit for unit %s's input filter."]
+pub type FILTER_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `FILTER_EN_U` writer - This is the enable bit for unit %s's input filter."]
+pub type FILTER_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `THR_ZERO_EN_U` reader - This is the enable bit for unit %s's zero comparator."]
+pub type THR_ZERO_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `THR_ZERO_EN_U` writer - This is the enable bit for unit %s's zero comparator."]
+pub type THR_ZERO_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `THR_H_LIM_EN_U` reader - This is the enable bit for unit %s's thr_h_lim comparator."]
+pub type THR_H_LIM_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `THR_H_LIM_EN_U` writer - This is the enable bit for unit %s's thr_h_lim comparator."]
+pub type THR_H_LIM_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `THR_L_LIM_EN_U` reader - This is the enable bit for unit %s's thr_l_lim comparator."]
+pub type THR_L_LIM_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `THR_L_LIM_EN_U` writer - This is the enable bit for unit %s's thr_l_lim comparator."]
+pub type THR_L_LIM_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `THR_THRES0_EN_U` reader - This is the enable bit for unit %s's thres0 comparator."]
+pub type THR_THRES0_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `THR_THRES0_EN_U` writer - This is the enable bit for unit %s's thres0 comparator."]
+pub type THR_THRES0_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `THR_THRES1_EN_U` reader - This is the enable bit for unit %s's thres1 comparator."]
+pub type THR_THRES1_EN_U_R = crate::BitReader<bool>;
+#[doc = "Field `THR_THRES1_EN_U` writer - This is the enable bit for unit %s's thres1 comparator."]
+pub type THR_THRES1_EN_U_W<'a, const O: u8> = crate::BitWriter<'a, u32, U_CONF0_SPEC, bool, O>;
+#[doc = "Field `CH0_NEG_MODE_U` reader - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
+pub type CH0_NEG_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH0_NEG_MODE_U` writer - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
+pub type CH0_NEG_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH0_POS_MODE_U0` reader - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
-pub type CH0_POS_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH0_POS_MODE_U0` writer - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
-pub type CH0_POS_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH0_POS_MODE_U` reader - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
+pub type CH0_POS_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH0_POS_MODE_U` writer - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
+pub type CH0_POS_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH0_HCTRL_MODE_U0` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH0_HCTRL_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH0_HCTRL_MODE_U0` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH0_HCTRL_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH0_HCTRL_MODE_U` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH0_HCTRL_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH0_HCTRL_MODE_U` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH0_HCTRL_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH0_LCTRL_MODE_U0` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH0_LCTRL_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH0_LCTRL_MODE_U0` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH0_LCTRL_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH0_LCTRL_MODE_U` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH0_LCTRL_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH0_LCTRL_MODE_U` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH0_LCTRL_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH1_NEG_MODE_U0` reader - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
-pub type CH1_NEG_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH1_NEG_MODE_U0` writer - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
-pub type CH1_NEG_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH1_NEG_MODE_U` reader - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
+pub type CH1_NEG_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH1_NEG_MODE_U` writer - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
+pub type CH1_NEG_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH1_POS_MODE_U0` reader - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
-pub type CH1_POS_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH1_POS_MODE_U0` writer - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
-pub type CH1_POS_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH1_POS_MODE_U` reader - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
+pub type CH1_POS_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH1_POS_MODE_U` writer - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
+pub type CH1_POS_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH1_HCTRL_MODE_U0` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH1_HCTRL_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH1_HCTRL_MODE_U0` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH1_HCTRL_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH1_HCTRL_MODE_U` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH1_HCTRL_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH1_HCTRL_MODE_U` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH1_HCTRL_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
-#[doc = "Field `CH1_LCTRL_MODE_U0` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH1_LCTRL_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CH1_LCTRL_MODE_U0` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
-pub type CH1_LCTRL_MODE_U0_W<'a, const O: u8> =
+#[doc = "Field `CH1_LCTRL_MODE_U` reader - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH1_LCTRL_MODE_U_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `CH1_LCTRL_MODE_U` writer - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
+pub type CH1_LCTRL_MODE_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF0_SPEC, u8, u8, 2, O>;
 impl R {
     #[doc = "Bits 0:9 - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
     #[inline(always)]
-    pub fn filter_thres_u0(&self) -> FILTER_THRES_U0_R {
-        FILTER_THRES_U0_R::new((self.bits & 0x03ff) as u16)
+    pub fn filter_thres_u(&self) -> FILTER_THRES_U_R {
+        FILTER_THRES_U_R::new((self.bits & 0x03ff) as u16)
     }
     #[doc = "Bit 10 - This is the enable bit for unit %s's input filter."]
     #[inline(always)]
-    pub fn filter_en_u0(&self) -> FILTER_EN_U0_R {
-        FILTER_EN_U0_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn filter_en_u(&self) -> FILTER_EN_U_R {
+        FILTER_EN_U_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - This is the enable bit for unit %s's zero comparator."]
     #[inline(always)]
-    pub fn thr_zero_en_u0(&self) -> THR_ZERO_EN_U0_R {
-        THR_ZERO_EN_U0_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn thr_zero_en_u(&self) -> THR_ZERO_EN_U_R {
+        THR_ZERO_EN_U_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - This is the enable bit for unit %s's thr_h_lim comparator."]
     #[inline(always)]
-    pub fn thr_h_lim_en_u0(&self) -> THR_H_LIM_EN_U0_R {
-        THR_H_LIM_EN_U0_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn thr_h_lim_en_u(&self) -> THR_H_LIM_EN_U_R {
+        THR_H_LIM_EN_U_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - This is the enable bit for unit %s's thr_l_lim comparator."]
     #[inline(always)]
-    pub fn thr_l_lim_en_u0(&self) -> THR_L_LIM_EN_U0_R {
-        THR_L_LIM_EN_U0_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn thr_l_lim_en_u(&self) -> THR_L_LIM_EN_U_R {
+        THR_L_LIM_EN_U_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - This is the enable bit for unit %s's thres0 comparator."]
     #[inline(always)]
-    pub fn thr_thres0_en_u0(&self) -> THR_THRES0_EN_U0_R {
-        THR_THRES0_EN_U0_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn thr_thres0_en_u(&self) -> THR_THRES0_EN_U_R {
+        THR_THRES0_EN_U_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - This is the enable bit for unit %s's thres1 comparator."]
     #[inline(always)]
-    pub fn thr_thres1_en_u0(&self) -> THR_THRES1_EN_U0_R {
-        THR_THRES1_EN_U0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn thr_thres1_en_u(&self) -> THR_THRES1_EN_U_R {
+        THR_THRES1_EN_U_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bits 16:17 - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
     #[inline(always)]
-    pub fn ch0_neg_mode_u0(&self) -> CH0_NEG_MODE_U0_R {
-        CH0_NEG_MODE_U0_R::new(((self.bits >> 16) & 3) as u8)
+    pub fn ch0_neg_mode_u(&self) -> CH0_NEG_MODE_U_R {
+        CH0_NEG_MODE_U_R::new(((self.bits >> 16) & 3) as u8)
     }
     #[doc = "Bits 18:19 - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
     #[inline(always)]
-    pub fn ch0_pos_mode_u0(&self) -> CH0_POS_MODE_U0_R {
-        CH0_POS_MODE_U0_R::new(((self.bits >> 18) & 3) as u8)
+    pub fn ch0_pos_mode_u(&self) -> CH0_POS_MODE_U_R {
+        CH0_POS_MODE_U_R::new(((self.bits >> 18) & 3) as u8)
     }
     #[doc = "Bits 20:21 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
-    pub fn ch0_hctrl_mode_u0(&self) -> CH0_HCTRL_MODE_U0_R {
-        CH0_HCTRL_MODE_U0_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn ch0_hctrl_mode_u(&self) -> CH0_HCTRL_MODE_U_R {
+        CH0_HCTRL_MODE_U_R::new(((self.bits >> 20) & 3) as u8)
     }
     #[doc = "Bits 22:23 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
-    pub fn ch0_lctrl_mode_u0(&self) -> CH0_LCTRL_MODE_U0_R {
-        CH0_LCTRL_MODE_U0_R::new(((self.bits >> 22) & 3) as u8)
+    pub fn ch0_lctrl_mode_u(&self) -> CH0_LCTRL_MODE_U_R {
+        CH0_LCTRL_MODE_U_R::new(((self.bits >> 22) & 3) as u8)
     }
     #[doc = "Bits 24:25 - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
     #[inline(always)]
-    pub fn ch1_neg_mode_u0(&self) -> CH1_NEG_MODE_U0_R {
-        CH1_NEG_MODE_U0_R::new(((self.bits >> 24) & 3) as u8)
+    pub fn ch1_neg_mode_u(&self) -> CH1_NEG_MODE_U_R {
+        CH1_NEG_MODE_U_R::new(((self.bits >> 24) & 3) as u8)
     }
     #[doc = "Bits 26:27 - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
     #[inline(always)]
-    pub fn ch1_pos_mode_u0(&self) -> CH1_POS_MODE_U0_R {
-        CH1_POS_MODE_U0_R::new(((self.bits >> 26) & 3) as u8)
+    pub fn ch1_pos_mode_u(&self) -> CH1_POS_MODE_U_R {
+        CH1_POS_MODE_U_R::new(((self.bits >> 26) & 3) as u8)
     }
     #[doc = "Bits 28:29 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
-    pub fn ch1_hctrl_mode_u0(&self) -> CH1_HCTRL_MODE_U0_R {
-        CH1_HCTRL_MODE_U0_R::new(((self.bits >> 28) & 3) as u8)
+    pub fn ch1_hctrl_mode_u(&self) -> CH1_HCTRL_MODE_U_R {
+        CH1_HCTRL_MODE_U_R::new(((self.bits >> 28) & 3) as u8)
     }
     #[doc = "Bits 30:31 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
-    pub fn ch1_lctrl_mode_u0(&self) -> CH1_LCTRL_MODE_U0_R {
-        CH1_LCTRL_MODE_U0_R::new(((self.bits >> 30) & 3) as u8)
+    pub fn ch1_lctrl_mode_u(&self) -> CH1_LCTRL_MODE_U_R {
+        CH1_LCTRL_MODE_U_R::new(((self.bits >> 30) & 3) as u8)
     }
 }
 impl W {
     #[doc = "Bits 0:9 - This sets the maximum threshold, in APB_CLK cycles, for the filter. Any pulses with width less than this will be ignored when the filter is enabled."]
     #[inline(always)]
     #[must_use]
-    pub fn filter_thres_u0(&mut self) -> FILTER_THRES_U0_W<0> {
-        FILTER_THRES_U0_W::new(self)
+    pub fn filter_thres_u(&mut self) -> FILTER_THRES_U_W<0> {
+        FILTER_THRES_U_W::new(self)
     }
     #[doc = "Bit 10 - This is the enable bit for unit %s's input filter."]
     #[inline(always)]
     #[must_use]
-    pub fn filter_en_u0(&mut self) -> FILTER_EN_U0_W<10> {
-        FILTER_EN_U0_W::new(self)
+    pub fn filter_en_u(&mut self) -> FILTER_EN_U_W<10> {
+        FILTER_EN_U_W::new(self)
     }
     #[doc = "Bit 11 - This is the enable bit for unit %s's zero comparator."]
     #[inline(always)]
     #[must_use]
-    pub fn thr_zero_en_u0(&mut self) -> THR_ZERO_EN_U0_W<11> {
-        THR_ZERO_EN_U0_W::new(self)
+    pub fn thr_zero_en_u(&mut self) -> THR_ZERO_EN_U_W<11> {
+        THR_ZERO_EN_U_W::new(self)
     }
     #[doc = "Bit 12 - This is the enable bit for unit %s's thr_h_lim comparator."]
     #[inline(always)]
     #[must_use]
-    pub fn thr_h_lim_en_u0(&mut self) -> THR_H_LIM_EN_U0_W<12> {
-        THR_H_LIM_EN_U0_W::new(self)
+    pub fn thr_h_lim_en_u(&mut self) -> THR_H_LIM_EN_U_W<12> {
+        THR_H_LIM_EN_U_W::new(self)
     }
     #[doc = "Bit 13 - This is the enable bit for unit %s's thr_l_lim comparator."]
     #[inline(always)]
     #[must_use]
-    pub fn thr_l_lim_en_u0(&mut self) -> THR_L_LIM_EN_U0_W<13> {
-        THR_L_LIM_EN_U0_W::new(self)
+    pub fn thr_l_lim_en_u(&mut self) -> THR_L_LIM_EN_U_W<13> {
+        THR_L_LIM_EN_U_W::new(self)
     }
     #[doc = "Bit 14 - This is the enable bit for unit %s's thres0 comparator."]
     #[inline(always)]
     #[must_use]
-    pub fn thr_thres0_en_u0(&mut self) -> THR_THRES0_EN_U0_W<14> {
-        THR_THRES0_EN_U0_W::new(self)
+    pub fn thr_thres0_en_u(&mut self) -> THR_THRES0_EN_U_W<14> {
+        THR_THRES0_EN_U_W::new(self)
     }
     #[doc = "Bit 15 - This is the enable bit for unit %s's thres1 comparator."]
     #[inline(always)]
     #[must_use]
-    pub fn thr_thres1_en_u0(&mut self) -> THR_THRES1_EN_U0_W<15> {
-        THR_THRES1_EN_U0_W::new(self)
+    pub fn thr_thres1_en_u(&mut self) -> THR_THRES1_EN_U_W<15> {
+        THR_THRES1_EN_U_W::new(self)
     }
     #[doc = "Bits 16:17 - This register sets the behavior when the signal input of channel 0 detects a negative edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
     #[inline(always)]
     #[must_use]
-    pub fn ch0_neg_mode_u0(&mut self) -> CH0_NEG_MODE_U0_W<16> {
-        CH0_NEG_MODE_U0_W::new(self)
+    pub fn ch0_neg_mode_u(&mut self) -> CH0_NEG_MODE_U_W<16> {
+        CH0_NEG_MODE_U_W::new(self)
     }
     #[doc = "Bits 18:19 - This register sets the behavior when the signal input of channel 0 detects a positive edge. 1: Increase the counter. 2: Decrease the counter. 0, 3: No effect on counter."]
     #[inline(always)]
     #[must_use]
-    pub fn ch0_pos_mode_u0(&mut self) -> CH0_POS_MODE_U0_W<18> {
-        CH0_POS_MODE_U0_W::new(self)
+    pub fn ch0_pos_mode_u(&mut self) -> CH0_POS_MODE_U_W<18> {
+        CH0_POS_MODE_U_W::new(self)
     }
     #[doc = "Bits 20:21 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
     #[must_use]
-    pub fn ch0_hctrl_mode_u0(&mut self) -> CH0_HCTRL_MODE_U0_W<20> {
-        CH0_HCTRL_MODE_U0_W::new(self)
+    pub fn ch0_hctrl_mode_u(&mut self) -> CH0_HCTRL_MODE_U_W<20> {
+        CH0_HCTRL_MODE_U_W::new(self)
     }
     #[doc = "Bits 22:23 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
     #[must_use]
-    pub fn ch0_lctrl_mode_u0(&mut self) -> CH0_LCTRL_MODE_U0_W<22> {
-        CH0_LCTRL_MODE_U0_W::new(self)
+    pub fn ch0_lctrl_mode_u(&mut self) -> CH0_LCTRL_MODE_U_W<22> {
+        CH0_LCTRL_MODE_U_W::new(self)
     }
     #[doc = "Bits 24:25 - This register sets the behavior when the signal input of channel 1 detects a negative edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
     #[inline(always)]
     #[must_use]
-    pub fn ch1_neg_mode_u0(&mut self) -> CH1_NEG_MODE_U0_W<24> {
-        CH1_NEG_MODE_U0_W::new(self)
+    pub fn ch1_neg_mode_u(&mut self) -> CH1_NEG_MODE_U_W<24> {
+        CH1_NEG_MODE_U_W::new(self)
     }
     #[doc = "Bits 26:27 - This register sets the behavior when the signal input of channel 1 detects a positive edge. 1: Increment the counter. 2: Decrement the counter. 0, 3: No effect on counter."]
     #[inline(always)]
     #[must_use]
-    pub fn ch1_pos_mode_u0(&mut self) -> CH1_POS_MODE_U0_W<26> {
-        CH1_POS_MODE_U0_W::new(self)
+    pub fn ch1_pos_mode_u(&mut self) -> CH1_POS_MODE_U_W<26> {
+        CH1_POS_MODE_U_W::new(self)
     }
     #[doc = "Bits 28:29 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is high. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
     #[must_use]
-    pub fn ch1_hctrl_mode_u0(&mut self) -> CH1_HCTRL_MODE_U0_W<28> {
-        CH1_HCTRL_MODE_U0_W::new(self)
+    pub fn ch1_hctrl_mode_u(&mut self) -> CH1_HCTRL_MODE_U_W<28> {
+        CH1_HCTRL_MODE_U_W::new(self)
     }
     #[doc = "Bits 30:31 - This register configures how the CH%s_POS_MODE/CH%s_NEG_MODE settings will be modified when the control signal is low. 0: No modification. 1: Invert behavior (increase -> decrease, decrease -> increase). 2, 3: Inhibit counter modification."]
     #[inline(always)]
     #[must_use]
-    pub fn ch1_lctrl_mode_u0(&mut self) -> CH1_LCTRL_MODE_U0_W<30> {
-        CH1_LCTRL_MODE_U0_W::new(self)
+    pub fn ch1_lctrl_mode_u(&mut self) -> CH1_LCTRL_MODE_U_W<30> {
+        CH1_LCTRL_MODE_U_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/esp32s2/src/pcnt/u_conf1.rs
+++ b/esp32s2/src/pcnt/u_conf1.rs
@@ -34,40 +34,40 @@ impl From<crate::W<U_CONF1_SPEC>> for W {
         W(writer)
     }
 }
-#[doc = "Field `CNT_THRES0_U0` reader - This register is used to configure the thres0 value for unit %s."]
-pub type CNT_THRES0_U0_R = crate::FieldReader<u16, u16>;
-#[doc = "Field `CNT_THRES0_U0` writer - This register is used to configure the thres0 value for unit %s."]
-pub type CNT_THRES0_U0_W<'a, const O: u8> =
+#[doc = "Field `CNT_THRES0_U` reader - This register is used to configure the thres0 value for unit %s."]
+pub type CNT_THRES0_U_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `CNT_THRES0_U` writer - This register is used to configure the thres0 value for unit %s."]
+pub type CNT_THRES0_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF1_SPEC, u16, u16, 16, O>;
-#[doc = "Field `CNT_THRES1_U0` reader - This register is used to configure the thres1 value for unit %s."]
-pub type CNT_THRES1_U0_R = crate::FieldReader<u16, u16>;
-#[doc = "Field `CNT_THRES1_U0` writer - This register is used to configure the thres1 value for unit %s."]
-pub type CNT_THRES1_U0_W<'a, const O: u8> =
+#[doc = "Field `CNT_THRES1_U` reader - This register is used to configure the thres1 value for unit %s."]
+pub type CNT_THRES1_U_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `CNT_THRES1_U` writer - This register is used to configure the thres1 value for unit %s."]
+pub type CNT_THRES1_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF1_SPEC, u16, u16, 16, O>;
 impl R {
     #[doc = "Bits 0:15 - This register is used to configure the thres0 value for unit %s."]
     #[inline(always)]
-    pub fn cnt_thres0_u0(&self) -> CNT_THRES0_U0_R {
-        CNT_THRES0_U0_R::new((self.bits & 0xffff) as u16)
+    pub fn cnt_thres0_u(&self) -> CNT_THRES0_U_R {
+        CNT_THRES0_U_R::new((self.bits & 0xffff) as u16)
     }
     #[doc = "Bits 16:31 - This register is used to configure the thres1 value for unit %s."]
     #[inline(always)]
-    pub fn cnt_thres1_u0(&self) -> CNT_THRES1_U0_R {
-        CNT_THRES1_U0_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn cnt_thres1_u(&self) -> CNT_THRES1_U_R {
+        CNT_THRES1_U_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
     #[doc = "Bits 0:15 - This register is used to configure the thres0 value for unit %s."]
     #[inline(always)]
     #[must_use]
-    pub fn cnt_thres0_u0(&mut self) -> CNT_THRES0_U0_W<0> {
-        CNT_THRES0_U0_W::new(self)
+    pub fn cnt_thres0_u(&mut self) -> CNT_THRES0_U_W<0> {
+        CNT_THRES0_U_W::new(self)
     }
     #[doc = "Bits 16:31 - This register is used to configure the thres1 value for unit %s."]
     #[inline(always)]
     #[must_use]
-    pub fn cnt_thres1_u0(&mut self) -> CNT_THRES1_U0_W<16> {
-        CNT_THRES1_U0_W::new(self)
+    pub fn cnt_thres1_u(&mut self) -> CNT_THRES1_U_W<16> {
+        CNT_THRES1_U_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/esp32s2/src/pcnt/u_conf2.rs
+++ b/esp32s2/src/pcnt/u_conf2.rs
@@ -34,40 +34,40 @@ impl From<crate::W<U_CONF2_SPEC>> for W {
         W(writer)
     }
 }
-#[doc = "Field `CNT_H_LIM_U0` reader - This register is used to configure the thr_h_lim value for unit %s."]
-pub type CNT_H_LIM_U0_R = crate::FieldReader<u16, u16>;
-#[doc = "Field `CNT_H_LIM_U0` writer - This register is used to configure the thr_h_lim value for unit %s."]
-pub type CNT_H_LIM_U0_W<'a, const O: u8> =
+#[doc = "Field `CNT_H_LIM_U` reader - This register is used to configure the thr_h_lim value for unit %s."]
+pub type CNT_H_LIM_U_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `CNT_H_LIM_U` writer - This register is used to configure the thr_h_lim value for unit %s."]
+pub type CNT_H_LIM_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF2_SPEC, u16, u16, 16, O>;
-#[doc = "Field `CNT_L_LIM_U0` reader - This register is used to configure the thr_l_lim value for unit %s."]
-pub type CNT_L_LIM_U0_R = crate::FieldReader<u16, u16>;
-#[doc = "Field `CNT_L_LIM_U0` writer - This register is used to configure the thr_l_lim value for unit %s."]
-pub type CNT_L_LIM_U0_W<'a, const O: u8> =
+#[doc = "Field `CNT_L_LIM_U` reader - This register is used to configure the thr_l_lim value for unit %s."]
+pub type CNT_L_LIM_U_R = crate::FieldReader<u16, u16>;
+#[doc = "Field `CNT_L_LIM_U` writer - This register is used to configure the thr_l_lim value for unit %s."]
+pub type CNT_L_LIM_U_W<'a, const O: u8> =
     crate::FieldWriter<'a, u32, U_CONF2_SPEC, u16, u16, 16, O>;
 impl R {
     #[doc = "Bits 0:15 - This register is used to configure the thr_h_lim value for unit %s."]
     #[inline(always)]
-    pub fn cnt_h_lim_u0(&self) -> CNT_H_LIM_U0_R {
-        CNT_H_LIM_U0_R::new((self.bits & 0xffff) as u16)
+    pub fn cnt_h_lim_u(&self) -> CNT_H_LIM_U_R {
+        CNT_H_LIM_U_R::new((self.bits & 0xffff) as u16)
     }
     #[doc = "Bits 16:31 - This register is used to configure the thr_l_lim value for unit %s."]
     #[inline(always)]
-    pub fn cnt_l_lim_u0(&self) -> CNT_L_LIM_U0_R {
-        CNT_L_LIM_U0_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn cnt_l_lim_u(&self) -> CNT_L_LIM_U_R {
+        CNT_L_LIM_U_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
     #[doc = "Bits 0:15 - This register is used to configure the thr_h_lim value for unit %s."]
     #[inline(always)]
     #[must_use]
-    pub fn cnt_h_lim_u0(&mut self) -> CNT_H_LIM_U0_W<0> {
-        CNT_H_LIM_U0_W::new(self)
+    pub fn cnt_h_lim_u(&mut self) -> CNT_H_LIM_U_W<0> {
+        CNT_H_LIM_U_W::new(self)
     }
     #[doc = "Bits 16:31 - This register is used to configure the thr_l_lim value for unit %s."]
     #[inline(always)]
     #[must_use]
-    pub fn cnt_l_lim_u0(&mut self) -> CNT_L_LIM_U0_W<16> {
-        CNT_L_LIM_U0_W::new(self)
+    pub fn cnt_l_lim_u(&mut self) -> CNT_L_LIM_U_W<16> {
+        CNT_L_LIM_U_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -13,3 +13,53 @@ _svd: ../esp32s2.base.svd
     _registers:
       H_0:
         name: H_MEM 
+
+"PCNT":
+  U%s_CONF0:
+    _modify:
+      FILTER_THRES_U0:
+        name: FILTER_THRES_U
+      FILTER_EN_U0:
+        name: FILTER_EN_U
+      THR_ZERO_EN_U0:
+        name: THR_ZERO_EN_U
+      THR_H_LIM_EN_U0:
+        name: THR_H_LIM_EN_U
+      THR_L_LIM_EN_U0:
+        name: THR_L_LIM_EN_U
+      THR_THRES0_EN_U0:
+        name: THR_THRES0_EN_U
+      THR_THRES1_EN_U0:
+        name: THR_THRES1_EN_U
+      CH0_NEG_MODE_U0:
+        name: CH0_NEG_MODE_U
+      CH0_POS_MODE_U0:
+        name: CH0_POS_MODE_U
+      CH0_HCTRL_MODE_U0:
+        name: CH0_HCTRL_MODE_U
+      CH0_LCTRL_MODE_U0:
+        name: CH0_LCTRL_MODE_U
+      CH1_NEG_MODE_U0:
+        name: CH1_NEG_MODE_U
+      CH1_POS_MODE_U0:
+        name: CH1_POS_MODE_U
+      CH1_HCTRL_MODE_U0:
+        name: CH1_HCTRL_MODE_U
+      CH1_LCTRL_MODE_U0:
+        name: CH1_LCTRL_MODE_U
+  U%s_CONF1:
+    _modify:
+      CNT_THRES0_U0:
+        name: CNT_THRES0_U
+      CNT_THRES1_U0:
+        name: CNT_THRES1_U
+  U%s_CONF2:
+    _modify:
+      CNT_H_LIM_U0:
+        name: CNT_H_LIM_U
+      CNT_L_LIM_U0:
+        name: CNT_L_LIM_U
+  U%s_CNT:
+    _modify:
+      PULSE_CNT_U0:
+        name: PULSE_CNT_U


### PR DESCRIPTION
rename some PCNT register fields to remove the unit number
where the register is unit specific.