### PR TITLE
PCNT status register field names for esp32/esp32s2/esp32s3

### DIFF
--- a/esp32/src/pcnt/u_status.rs
+++ b/esp32/src/pcnt/u_status.rs
@@ -36,10 +36,10 @@ impl From<crate::W<U_STATUS_SPEC>> for W {
 }
 #[doc = "Field `CORE_STATUS_U0` reader - "]
 pub type CORE_STATUS_U0_R = crate::FieldReader<u32, u32>;
-#[doc = "Field `CNT_MODE` reader - "]
-pub type CNT_MODE_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CNT_MODE` writer - "]
-pub type CNT_MODE_W<'a, const O: u8> = crate::FieldWriter<'a, u32, U_STATUS_SPEC, u8, u8, 2, O>;
+#[doc = "Field `ZERO_MODE` reader - "]
+pub type ZERO_MODE_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `ZERO_MODE` writer - "]
+pub type ZERO_MODE_W<'a, const O: u8> = crate::FieldWriter<'a, u32, U_STATUS_SPEC, u8, u8, 2, O>;
 #[doc = "Field `THRES1` reader - "]
 pub type THRES1_R = crate::BitReader<bool>;
 #[doc = "Field `THRES1` writer - "]
@@ -68,8 +68,8 @@ impl R {
     }
     #[doc = "Bits 0:1"]
     #[inline(always)]
-    pub fn cnt_mode(&self) -> CNT_MODE_R {
-        CNT_MODE_R::new((self.bits & 3) as u8)
+    pub fn zero_mode(&self) -> ZERO_MODE_R {
+        ZERO_MODE_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bit 2"]
     #[inline(always)]
@@ -101,8 +101,8 @@ impl W {
     #[doc = "Bits 0:1"]
     #[inline(always)]
     #[must_use]
-    pub fn cnt_mode(&mut self) -> CNT_MODE_W<0> {
-        CNT_MODE_W::new(self)
+    pub fn zero_mode(&mut self) -> ZERO_MODE_W<0> {
+        ZERO_MODE_W::new(self)
     }
     #[doc = "Bit 2"]
     #[inline(always)]

--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -44,6 +44,9 @@ PCNT:
     "U?_STATUS":
       name: "U%s_STATUS"
       _strip: "STATUS_"
+      _modify:
+        CNT_MODE:
+          name: ZERO_MODE
 
   CTRL:
     _strip: "PLUS_"

--- a/esp32s2/src/pcnt/u_status.rs
+++ b/esp32s2/src/pcnt/u_status.rs
@@ -13,48 +13,48 @@ impl From<crate::R<U_STATUS_SPEC>> for R {
         R(reader)
     }
 }
-#[doc = "Field `CNT_THR_ZERO_MODE_U0` reader - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
-pub type CNT_THR_ZERO_MODE_U0_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CNT_THR_THRES1_LAT_U0` reader - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others."]
-pub type CNT_THR_THRES1_LAT_U0_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_THRES0_LAT_U0` reader - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others."]
-pub type CNT_THR_THRES0_LAT_U0_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_L_LIM_LAT_U0` reader - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others."]
-pub type CNT_THR_L_LIM_LAT_U0_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_H_LIM_LAT_U0` reader - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others."]
-pub type CNT_THR_H_LIM_LAT_U0_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_ZERO_LAT_U0` reader - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others."]
-pub type CNT_THR_ZERO_LAT_U0_R = crate::BitReader<bool>;
+#[doc = "Field `ZERO_MODE` reader - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
+pub type ZERO_MODE_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `THRES1` reader - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others."]
+pub type THRES1_R = crate::BitReader<bool>;
+#[doc = "Field `THRES0` reader - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others."]
+pub type THRES0_R = crate::BitReader<bool>;
+#[doc = "Field `L_LIM` reader - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others."]
+pub type L_LIM_R = crate::BitReader<bool>;
+#[doc = "Field `H_LIM` reader - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others."]
+pub type H_LIM_R = crate::BitReader<bool>;
+#[doc = "Field `ZERO` reader - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others."]
+pub type ZERO_R = crate::BitReader<bool>;
 impl R {
     #[doc = "Bits 0:1 - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
     #[inline(always)]
-    pub fn cnt_thr_zero_mode_u0(&self) -> CNT_THR_ZERO_MODE_U0_R {
-        CNT_THR_ZERO_MODE_U0_R::new((self.bits & 3) as u8)
+    pub fn zero_mode(&self) -> ZERO_MODE_R {
+        ZERO_MODE_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bit 2 - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others."]
     #[inline(always)]
-    pub fn cnt_thr_thres1_lat_u0(&self) -> CNT_THR_THRES1_LAT_U0_R {
-        CNT_THR_THRES1_LAT_U0_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn thres1(&self) -> THRES1_R {
+        THRES1_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others."]
     #[inline(always)]
-    pub fn cnt_thr_thres0_lat_u0(&self) -> CNT_THR_THRES0_LAT_U0_R {
-        CNT_THR_THRES0_LAT_U0_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn thres0(&self) -> THRES0_R {
+        THRES0_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others."]
     #[inline(always)]
-    pub fn cnt_thr_l_lim_lat_u0(&self) -> CNT_THR_L_LIM_LAT_U0_R {
-        CNT_THR_L_LIM_LAT_U0_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn l_lim(&self) -> L_LIM_R {
+        L_LIM_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others."]
     #[inline(always)]
-    pub fn cnt_thr_h_lim_lat_u0(&self) -> CNT_THR_H_LIM_LAT_U0_R {
-        CNT_THR_H_LIM_LAT_U0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn h_lim(&self) -> H_LIM_R {
+        H_LIM_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others."]
     #[inline(always)]
-    pub fn cnt_thr_zero_lat_u0(&self) -> CNT_THR_ZERO_LAT_U0_R {
-        CNT_THR_ZERO_LAT_U0_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn zero(&self) -> ZERO_R {
+        ZERO_R::new(((self.bits >> 6) & 1) != 0)
     }
 }
 #[doc = "PNCT UNIT%s status register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [u_status](index.html) module"]

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -28,6 +28,12 @@ _svd: ../esp32s2.base.svd
         name: CNT
   CTRL:
     _strip: "PULSE_"
+  "U%s_STATUS":
+    _strip: "CNT_THR_"
+    _strip_end: "_LAT_U0"
+    _modify:
+      ZERO_MODE_U0:
+        name: ZERO_MODE
   INT_RAW:
     _strip_end: "_INT_RAW"
   INT_ST:

--- a/esp32s3/src/pcnt/u_status.rs
+++ b/esp32s3/src/pcnt/u_status.rs
@@ -13,48 +13,48 @@ impl From<crate::R<U_STATUS_SPEC>> for R {
         R(reader)
     }
 }
-#[doc = "Field `CNT_THR_ZERO_MODE_U` reader - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
-pub type CNT_THR_ZERO_MODE_U_R = crate::FieldReader<u8, u8>;
-#[doc = "Field `CNT_THR_THRES1_LAT_U` reader - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others"]
-pub type CNT_THR_THRES1_LAT_U_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_THRES0_LAT_U` reader - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others"]
-pub type CNT_THR_THRES0_LAT_U_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_L_LIM_LAT_U` reader - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others"]
-pub type CNT_THR_L_LIM_LAT_U_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_H_LIM_LAT_U` reader - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others"]
-pub type CNT_THR_H_LIM_LAT_U_R = crate::BitReader<bool>;
-#[doc = "Field `CNT_THR_ZERO_LAT_U` reader - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others"]
-pub type CNT_THR_ZERO_LAT_U_R = crate::BitReader<bool>;
+#[doc = "Field `ZERO_MODE` reader - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
+pub type ZERO_MODE_R = crate::FieldReader<u8, u8>;
+#[doc = "Field `THRES1` reader - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others"]
+pub type THRES1_R = crate::BitReader<bool>;
+#[doc = "Field `THRES0` reader - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others"]
+pub type THRES0_R = crate::BitReader<bool>;
+#[doc = "Field `L_LIM` reader - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others"]
+pub type L_LIM_R = crate::BitReader<bool>;
+#[doc = "Field `H_LIM` reader - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others"]
+pub type H_LIM_R = crate::BitReader<bool>;
+#[doc = "Field `ZERO` reader - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others"]
+pub type ZERO_R = crate::BitReader<bool>;
 impl R {
     #[doc = "Bits 0:1 - The pulse counter status of PCNT_U%s corresponding to 0. 0: pulse counter decreases from positive to 0. 1: pulse counter increases from negative to 0. 2: pulse counter is negative. 3: pulse counter is positive."]
     #[inline(always)]
-    pub fn cnt_thr_zero_mode_u(&self) -> CNT_THR_ZERO_MODE_U_R {
-        CNT_THR_ZERO_MODE_U_R::new((self.bits & 3) as u8)
+    pub fn zero_mode(&self) -> ZERO_MODE_R {
+        ZERO_MODE_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bit 2 - The latched value of thres1 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres1 and thres1 event is valid. 0: others"]
     #[inline(always)]
-    pub fn cnt_thr_thres1_lat_u(&self) -> CNT_THR_THRES1_LAT_U_R {
-        CNT_THR_THRES1_LAT_U_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn thres1(&self) -> THRES1_R {
+        THRES1_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - The latched value of thres0 event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thres0 and thres0 event is valid. 0: others"]
     #[inline(always)]
-    pub fn cnt_thr_thres0_lat_u(&self) -> CNT_THR_THRES0_LAT_U_R {
-        CNT_THR_THRES0_LAT_U_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn thres0(&self) -> THRES0_R {
+        THRES0_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - The latched value of low limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_l_lim and low limit event is valid. 0: others"]
     #[inline(always)]
-    pub fn cnt_thr_l_lim_lat_u(&self) -> CNT_THR_L_LIM_LAT_U_R {
-        CNT_THR_L_LIM_LAT_U_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn l_lim(&self) -> L_LIM_R {
+        L_LIM_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - The latched value of high limit event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to thr_h_lim and high limit event is valid. 0: others"]
     #[inline(always)]
-    pub fn cnt_thr_h_lim_lat_u(&self) -> CNT_THR_H_LIM_LAT_U_R {
-        CNT_THR_H_LIM_LAT_U_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn h_lim(&self) -> H_LIM_R {
+        H_LIM_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - The latched value of zero threshold event of PCNT_U%s when threshold event interrupt is valid. 1: the current pulse counter equals to 0 and zero threshold event is valid. 0: others"]
     #[inline(always)]
-    pub fn cnt_thr_zero_lat_u(&self) -> CNT_THR_ZERO_LAT_U_R {
-        CNT_THR_ZERO_LAT_U_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn zero(&self) -> ZERO_R {
+        ZERO_R::new(((self.bits >> 6) & 1) != 0)
     }
 }
 #[doc = "PNCT UNIT%s status register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [u_status](index.html) module"]

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -99,6 +99,12 @@ TWAI:
         name: CNT
   CTRL:
     _strip: "PULSE_"
+  "U%s_STATUS":
+    _strip: "CNT_THR_"
+    _strip_end: "_LAT_U"
+    _modify:
+      ZERO_MODE_U:
+        name: ZERO_MODE
   INT_RAW:
     _strip_end: "_INT_RAW"
   INT_ST:


### PR DESCRIPTION
made status register field names consistent across esp32/esp32s2/esp32s3