### PR TITLE
Bump dependencies for RISC-V chips

### DIFF
--- a/esp32c2/Cargo.toml
+++ b/esp32c2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32c2"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 edition = "2021"
 description = "Peripheral access crate for the ESP32-C2"

--- a/esp32c2/Cargo.toml
+++ b/esp32c2/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/esp-rs/esp-pacs"
 license = "MIT OR Apache-2.0"
 keywords = [
     "no-std",
-    "esp32-c2",
+    "esp32c2",
     "wifi",
     "embedded",
 ]
@@ -27,8 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-riscv = "0.10.0"
-riscv-rt = { version = "0.10.0", optional = true }
+riscv = "0.10.1"
+riscv-rt = { version = "0.11.0", optional = true }
 vcell = "0.1.3"
 
 [features]

--- a/esp32c3/Cargo.toml
+++ b/esp32c3/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/esp-rs/esp-pacs"
 license = "MIT OR Apache-2.0"
 keywords = [
     "no-std",
-    "esp32-c3",
+    "esp32c3",
     "wifi",
     "embedded",
 ]
@@ -30,8 +30,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-riscv = "0.10.0"
-riscv-rt = { version = "0.10.0", optional = true }
+riscv = "0.10.1"
+riscv-rt = { version = "0.11.0", optional = true }
 vcell = "0.1.3"
 
 [features]

--- a/esp32c3/Cargo.toml
+++ b/esp32c3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32c3"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "Samir Shetty <samirshetty23@gmail.com>",
     "Jesse Braham <jesse@beta7.io>",

--- a/esp32c6/Cargo.toml
+++ b/esp32c6/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/esp-rs/esp-pacs"
 license = "MIT OR Apache-2.0"
 keywords = [
     "no-std",
-    "esp32-c6",
+    "esp32c6",
     "wifi",
     "embedded",
 ]
@@ -27,8 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-riscv = "0.10.0"
-riscv-rt = { version = "0.10.0", optional = true }
+riscv = "0.10.1"
+riscv-rt = { version = "0.11.0", optional = true }
 vcell = "0.1.3"
 
 [features]

--- a/esp32h2/Cargo.toml
+++ b/esp32h2/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/esp-rs/esp-pacs"
 license = "MIT OR Apache-2.0"
 keywords = [
     "no-std",
-    "esp32-h2",
+    "esp32h2",
     "wifi",
     "embedded",
 ]
@@ -27,8 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-riscv = "0.10.0"
-riscv-rt = { version = "0.10.0", optional = true }
+riscv = "0.10.1"
+riscv-rt = { version = "0.11.0", optional = true }
 vcell = "0.1.3"
 
 [features]


### PR DESCRIPTION
New releases of `riscv` and `riscv-rt` are now available.