### PR TITLE
Remove dependency to rt-crates

### DIFF
--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -31,8 +31,7 @@ license = "MIT OR Apache-2.0"
 critical-section = { version = "1.1.1", optional = true }
 vcell = "0.1.3"
 xtensa-lx = "0.7.0"
-xtensa-lx-rt = { version = "0.14.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32"]
-rt = ["xtensa-lx-rt/esp32"]
+rt = []

--- a/esp32c2/Cargo.toml
+++ b/esp32c2/Cargo.toml
@@ -27,9 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-esp-riscv-rt = { version = "0.1.0", optional = true }
 vcell = "0.1.3"
 
 [features]
 default = []
-rt = ["esp-riscv-rt"]
+rt = []

--- a/esp32c3/Cargo.toml
+++ b/esp32c3/Cargo.toml
@@ -30,9 +30,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-esp-riscv-rt = { version = "0.1.0", optional = true }
 vcell = "0.1.3"
 
 [features]
 default = []
-rt = ["esp-riscv-rt"]
+rt = []

--- a/esp32c6/Cargo.toml
+++ b/esp32c6/Cargo.toml
@@ -27,9 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-esp-riscv-rt = { version = "0.1.0", optional = true }
 vcell = "0.1.3"
 
 [features]
 default = []
-rt = ["esp-riscv-rt"]
+rt = []

--- a/esp32h2/Cargo.toml
+++ b/esp32h2/Cargo.toml
@@ -27,9 +27,8 @@ include = [
 
 [dependencies]
 critical-section = { version = "1.1.1", optional = true }
-esp-riscv-rt = { version = "0.1.0", optional = true }
 vcell = "0.1.3"
 
 [features]
 default = []
-rt = ["esp-riscv-rt"]
+rt = []

--- a/esp32s2/Cargo.toml
+++ b/esp32s2/Cargo.toml
@@ -29,8 +29,7 @@ license = "MIT OR Apache-2.0"
 critical-section = { version = "1.1.1", optional = true }
 vcell = "0.1.3"
 xtensa-lx = "0.7.0"
-xtensa-lx-rt = { version = "0.14.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32s2"]
-rt = ["xtensa-lx-rt/esp32s2"]
+rt = []

--- a/esp32s3/Cargo.toml
+++ b/esp32s3/Cargo.toml
@@ -29,8 +29,7 @@ license = "MIT OR Apache-2.0"
 critical-section = { version = "1.1.1", optional = true }
 vcell = "0.1.3"
 xtensa-lx = "0.7.0"
-xtensa-lx-rt = { version = "0.14.0", optional = true }
 
 [features]
 default = ["xtensa-lx/esp32s3"]
-rt = ["xtensa-lx-rt/esp32s3"]
+rt = []


### PR DESCRIPTION
First change for what was discussed in https://github.com/esp-rs/esp-hal/issues/382

For Xtensa it still needs `xtensa-lx` but that is less of a problem since it changes not that frequently. Would be better to not need it but that's how svd2rust generates the code currently. (I don't think we need that in our HALs but not a big deal IMHO)
