### PR TITLE
Rewrite the CI workflow

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -13,10 +13,6 @@ inputs:
     description: Target to use when checking the specified package
     type: string
     required: true
-  toolchain:
-    description: Toolchain to use when checking the specified package
-    default: nightly
-    required: false
 
 runs:
   using: composite
@@ -26,19 +22,19 @@ runs:
     # prior to invoking the 'xtensa-toolchain' action:
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: inputs.toolchain == 'esp'
+      if: startsWith(inputs.target, 'xtensa')
 
     # Install the newest available version of the specified toolchain,
     # required for building the PAC:
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: inputs.toolchain != 'esp'
+      if: startsWith(inputs.target, 'riscv')
       with:
         target: ${{ inputs.target }}
         components: rust-src
 
     - uses: esp-rs/xtensa-toolchain@v1.5
-      if: inputs.toolchain == 'esp'
+      if: startsWith(inputs.target, 'xtensa')
       with:
         ldproxy: false
         buildtargets: ${{ inputs.package }}
@@ -54,15 +50,16 @@ runs:
     # Install the MSRV of the specified toolchain:
 
     - uses: dtolnay/rust-toolchain@master
-      if: inputs.toolchain != 'esp'
+      if: startsWith(inputs.target, 'riscv')
       with:
         toolchain: ${{ inputs.msrv }}
         target: ${{ inputs.target }}
         components: rust-src
 
     - uses: esp-rs/xtensa-toolchain@v1.5
-      if: inputs.toolchain == 'esp'
+      if: startsWith(inputs.target, 'xtensa')
       with:
+        default: true
         ldproxy: false
         buildtargets: ${{ inputs.package }}
         override: false
@@ -71,5 +68,11 @@ runs:
     # Verify that the PAC builds using the MSRV of the specified toolchain:
 
     - name: Check MSRV
+      if: startsWith(inputs.target, 'riscv')
+      shell: bash
+      run: cd ${{ inputs.package }} && cargo +${{ inputs.msrv }} check --all-targets
+
+    - name: Check MSRV
+      if: startsWith(inputs.target, 'xtensa')
       shell: bash
       run: cd ${{ inputs.package }} && cargo check --all-targets

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -1,0 +1,75 @@
+name: Check Package
+
+inputs:
+  msrv:
+    description: Minimum Supported Rust Version
+    type: string
+    required: true
+  package:
+    description: Name of the package to check
+    type: string
+    required: true
+  target:
+    description: Target to use when checking the specified package
+    type: string
+    required: true
+  toolchain:
+    description: Toolchain to use when checking the specified package
+    default: nightly
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    # If using the 'esp' toolchain, we also need to have 'nightly' installed
+    # prior to invoking the 'xtensa-toolchain' action:
+
+    - uses: dtolnay/rust-toolchain@nightly
+      if: inputs.toolchain == 'esp'
+
+    # Install the newest available version of the specified toolchain,
+    # required for building the PAC:
+
+    - uses: dtolnay/rust-toolchain@nightly
+      if: inputs.toolchain != 'esp'
+      with:
+        target: ${{ inputs.target }}
+        components: rust-src
+
+    - uses: esp-rs/xtensa-toolchain@v1.5
+      if: inputs.toolchain == 'esp'
+      with:
+        ldproxy: false
+        buildtargets: ${{ inputs.package }}
+        override: false
+
+    # Build the PAC using the newest available version of the specified
+    # toolchain:
+
+    - name: Build PAC
+      shell: bash
+      run: cd ${{ inputs.package }} && cargo check --all-targets
+
+    # Install the MSRV of the specified toolchain:
+
+    - uses: dtolnay/rust-toolchain@master
+      if: inputs.toolchain != 'esp'
+      with:
+        toolchain: ${{ inputs.msrv }}
+        target: ${{ inputs.target }}
+        components: rust-src
+
+    - uses: esp-rs/xtensa-toolchain@v1.5
+      if: inputs.toolchain == 'esp'
+      with:
+        ldproxy: false
+        buildtargets: ${{ inputs.package }}
+        override: false
+        version: ${{ inputs.msrv }}
+
+    # Verify that the PAC builds using the MSRV of the specified toolchain:
+
+    - name: Check MSRV
+      shell: bash
+      run: cd ${{ inputs.package }} && cargo check --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,125 +22,35 @@ concurrency:
 
 jobs:
   # --------------------------------------------------------------------------
-  # ESP32
 
-  esp32:
+  check:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [
+            # Xtensa:
+            { package: "esp32", target: "xtensa-esp32-none-elf" },
+            { package: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { package: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+  
+            # RISC-V:
+            { package: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { package: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+            { package: "esp32c6", target: "riscv32imac-unknown-none-elf" },
+            { package: "esp32h2", target: "riscv32imac-unknown-none-elf" },
+
+            # RISC-V (Ultra) Low-Power:
+            { package: "esp32c6-lp", target: "riscv32imac-unknown-none-elf" },
+            { package: "esp32s2-ulp", target: "riscv32imc-unknown-none-elf" },
+            { package: "esp32s3-ulp", target: "riscv32imc-unknown-none-elf" },
+          ]
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/check
         with:
           msrv: ${{ env.MSRV }}
-          package: "esp32"
-          target: "xtensa-esp32-none-elf"
-          toolchain: "esp"
-
-  # --------------------------------------------------------------------------
-  # ESP32-C2 / ESP8684
-
-  esp32c2:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32c2"
-          target: "riscv32imc-unknown-none-elf"
-
-  # --------------------------------------------------------------------------
-  # ESP32-C3 / ESP8685
-
-  esp32c3:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32c3"
-          target: "riscv32imc-unknown-none-elf"
-
-  # --------------------------------------------------------------------------
-  # ESP32-C6
-
-  esp32c6:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32c6"
-          target: "riscv32imac-unknown-none-elf"
-
-  esp32c6-lp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32c6-lp"
-          target: "riscv32imac-unknown-none-elf"
-
-  # --------------------------------------------------------------------------
-  # ESP32-H2
-
-  esp32h2:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32h2"
-          target: "riscv32imac-unknown-none-elf"
-
-  # --------------------------------------------------------------------------
-  # ESP32-S2
-
-  esp32s2:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32s2"
-          target: "xtensa-esp32s2-none-elf"
-          toolchain: "esp"
-
-  esp32s2-ulp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32s2-ulp"
-          target: "riscv32imc-unknown-none-elf"
-
-  # --------------------------------------------------------------------------
-  # ESP32-S3
-
-  esp32s3:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32s3"
-          target: "xtensa-esp32s3-none-elf"
-          toolchain: "esp"
-
-  esp32s3-ulp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/check
-        with:
-          msrv: ${{ env.MSRV }}
-          package: "esp32s3-ulp"
-          target: "riscv32imc-unknown-none-elf"
+          package: ${{ matrix.build.package }}
+          target: ${{ matrix.build.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MSRV: "1.65.0"
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
@@ -21,116 +22,125 @@ concurrency:
 
 jobs:
   # --------------------------------------------------------------------------
-  # Check
+  # ESP32
 
-  check-riscv:
+  esp32:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        chip:
-          [
-            esp32c2,
-            esp32c3,
-            esp32c6,
-            esp32h2,
-            esp32c6-lp,
-            esp32s2-ulp,
-            esp32s3-ulp,
-          ]
-
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/check
         with:
-          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
-
-      - name: generate pac
-        run: cargo run --manifest-path=xtask/Cargo.toml -- generate ${{ matrix.chip }}
-      - name: build pac
-        run: cd ${{ matrix.chip }} && cargo check --all-targets
-
-  check-xtensa:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        chip: [esp32, esp32s2, esp32s3]
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          ldproxy: false
-          buildtargets: ${{ matrix.chip }}
-          override: false
-      - uses: Swatinem/rust-cache@v2
-
-      - name: generate pac
-        run: cargo run --manifest-path=xtask/Cargo.toml -- generate ${{ matrix.chip }}
-      - name: build pac
-        run: cd ${{ matrix.chip }} && cargo check --all-targets
+          msrv: ${{ env.MSRV }}
+          package: "esp32"
+          target: "xtensa-esp32-none-elf"
+          toolchain: "esp"
 
   # --------------------------------------------------------------------------
-  # MSRV
+  # ESP32-C2 / ESP8684
 
-  msrv-riscv:
+  esp32c2:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        chip:
-          [
-            esp32c2,
-            esp32c3,
-            esp32c6,
-            esp32h2,
-            esp32c6-lp,
-            esp32s2-ulp,
-            esp32s3-ulp,
-          ]
-
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/check
         with:
-          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          components: rust-src
-      - uses: dtolnay/rust-toolchain@1.65.0
-        with:
-          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
+          msrv: ${{ env.MSRV }}
+          package: "esp32c2"
+          target: "riscv32imc-unknown-none-elf"
 
-      - name: generate pac
-        run: cargo +nightly run --manifest-path=xtask/Cargo.toml -- generate ${{ matrix.chip }}
-      - name: build pac
-        run: cd ${{ matrix.chip }} && cargo +1.65.0 check --all-targets
+  # --------------------------------------------------------------------------
+  # ESP32-C3 / ESP8685
 
-  msrv-xtensa:
+  esp32c3:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        chip: [esp32, esp32s2, esp32s3]
-
     steps:
       - uses: actions/checkout@v3
-      - uses: esp-rs/xtensa-toolchain@v1.5
+      - uses: ./.github/actions/check
         with:
-          ldproxy: false
-          buildtargets: ${{ matrix.chip }}
-          version: "1.65.0"
-          override: false
-      - uses: Swatinem/rust-cache@v2
+          msrv: ${{ env.MSRV }}
+          package: "esp32c3"
+          target: "riscv32imc-unknown-none-elf"
 
-      - name: generate pac
-        run: cargo run --manifest-path=xtask/Cargo.toml -- generate ${{ matrix.chip }}
-      - name: build pac
-        run: cd ${{ matrix.chip }} && cargo check --all-targets
+  # --------------------------------------------------------------------------
+  # ESP32-C6
+
+  esp32c6:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32c6"
+          target: "riscv32imac-unknown-none-elf"
+
+  esp32c6-lp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32c6-lp"
+          target: "riscv32imac-unknown-none-elf"
+
+  # --------------------------------------------------------------------------
+  # ESP32-H2
+
+  esp32h2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32h2"
+          target: "riscv32imac-unknown-none-elf"
+
+  # --------------------------------------------------------------------------
+  # ESP32-S2
+
+  esp32s2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32s2"
+          target: "xtensa-esp32s2-none-elf"
+          toolchain: "esp"
+
+  esp32s2-ulp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32s2-ulp"
+          target: "riscv32imc-unknown-none-elf"
+
+  # --------------------------------------------------------------------------
+  # ESP32-S3
+
+  esp32s3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32s3"
+          target: "xtensa-esp32s3-none-elf"
+          toolchain: "esp"
+
+  esp32s3-ulp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/check
+        with:
+          msrv: ${{ env.MSRV }}
+          package: "esp32s3-ulp"
+          target: "riscv32imc-unknown-none-elf"


### PR DESCRIPTION
We had maxed out on our concurrency with the addition of the PACs for the coprocessors, and given that we have more chips coming in the future I figured it was time to address this.

I've created an action which will check a package using both the latest version as well as the MSRV, using the correct toolchain and all that. This action is now invoked for each package, giving us plenty of room to expand for the foreseeable future.