### PR TITLE
ESP32H2: Add Qx, Qy and Qz memory block to ECC peripheral

### DIFF
--- a/esp32h2/src/ecc.rs
+++ b/esp32h2/src/ecc.rs
@@ -22,6 +22,12 @@ pub struct RegisterBlock {
     pub px_mem: [PX_MEM; 32],
     #[doc = "0x140..0x160 - The memory that stores Py."]
     pub py_mem: [PY_MEM; 32],
+    #[doc = "0x160..0x180 - The memory that stores Qx"]
+    pub qx_mem: [QX_MEM; 32],
+    #[doc = "0x180..0x1a0 - The memory that stores Qy"]
+    pub qy_mem: [QY_MEM; 32],
+    #[doc = "0x1a0..0x1c0 - The memory that stores Qz"]
+    pub qz_mem: [QZ_MEM; 32],
 }
 #[doc = "MULT_INT_RAW (r) register accessor: ECC interrupt raw register, valid in level.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`mult_int_raw::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mult_int_raw`] module"]
 pub type MULT_INT_RAW = crate::Reg<mult_int_raw::MULT_INT_RAW_SPEC>;
@@ -59,3 +65,15 @@ pub mod px_mem;
 pub type PY_MEM = crate::Reg<py_mem::PY_MEM_SPEC>;
 #[doc = "The memory that stores Py."]
 pub mod py_mem;
+#[doc = "QX_MEM (rw) register accessor: The memory that stores Qx\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qx_mem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qx_mem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`qx_mem`] module"]
+pub type QX_MEM = crate::Reg<qx_mem::QX_MEM_SPEC>;
+#[doc = "The memory that stores Qx"]
+pub mod qx_mem;
+#[doc = "QY_MEM (rw) register accessor: The memory that stores Qy\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qy_mem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qy_mem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`qy_mem`] module"]
+pub type QY_MEM = crate::Reg<qy_mem::QY_MEM_SPEC>;
+#[doc = "The memory that stores Qy"]
+pub mod qy_mem;
+#[doc = "QZ_MEM (rw) register accessor: The memory that stores Qz\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qz_mem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qz_mem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`qz_mem`] module"]
+pub type QZ_MEM = crate::Reg<qz_mem::QZ_MEM_SPEC>;
+#[doc = "The memory that stores Qz"]
+pub mod qz_mem;

--- a/esp32h2/src/ecc/qx_mem.rs
+++ b/esp32h2/src/ecc/qx_mem.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `QX_MEM%s` reader"]
+pub type R = crate::R<QX_MEM_SPEC>;
+#[doc = "Register `QX_MEM%s` writer"]
+pub type W = crate::W<QX_MEM_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<QX_MEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.read().fmt(f)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u8) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The memory that stores Qx\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qx_mem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qx_mem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct QX_MEM_SPEC;
+impl crate::RegisterSpec for QX_MEM_SPEC {
+    type Ux = u8;
+}
+#[doc = "`read()` method returns [`qx_mem::R`](R) reader structure"]
+impl crate::Readable for QX_MEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`qx_mem::W`](W) writer structure"]
+impl crate::Writable for QX_MEM_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets QX_MEM%s to value 0"]
+impl crate::Resettable for QX_MEM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/esp32h2/src/ecc/qy_mem.rs
+++ b/esp32h2/src/ecc/qy_mem.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `QY_MEM%s` reader"]
+pub type R = crate::R<QY_MEM_SPEC>;
+#[doc = "Register `QY_MEM%s` writer"]
+pub type W = crate::W<QY_MEM_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<QY_MEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.read().fmt(f)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u8) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The memory that stores Qy\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qy_mem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qy_mem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct QY_MEM_SPEC;
+impl crate::RegisterSpec for QY_MEM_SPEC {
+    type Ux = u8;
+}
+#[doc = "`read()` method returns [`qy_mem::R`](R) reader structure"]
+impl crate::Readable for QY_MEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`qy_mem::W`](W) writer structure"]
+impl crate::Writable for QY_MEM_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets QY_MEM%s to value 0"]
+impl crate::Resettable for QY_MEM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/esp32h2/src/ecc/qz_mem.rs
+++ b/esp32h2/src/ecc/qz_mem.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `QZ_MEM%s` reader"]
+pub type R = crate::R<QZ_MEM_SPEC>;
+#[doc = "Register `QZ_MEM%s` writer"]
+pub type W = crate::W<QZ_MEM_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<QZ_MEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.read().fmt(f)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u8) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The memory that stores Qz\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`qz_mem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`qz_mem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct QZ_MEM_SPEC;
+impl crate::RegisterSpec for QZ_MEM_SPEC {
+    type Ux = u8;
+}
+#[doc = "`read()` method returns [`qz_mem::R`](R) reader structure"]
+impl crate::Readable for QZ_MEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`qz_mem::W`](W) writer structure"]
+impl crate::Writable for QZ_MEM_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets QZ_MEM%s to value 0"]
+impl crate::Resettable for QZ_MEM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -5,3 +5,28 @@ USB_DEVICE:
     _interrupts:
       USB:
         name: USB_DEVICE
+
+ECC:
+  _add:
+        _registers:
+          QX_MEM%s:
+            dim: 32
+            dimIncrement: 0x1
+            description: The memory that stores Qx
+            addressOffset: 0x160
+            size: 0x8
+            access: read-write
+          QY_MEM%s:
+            dim: 32
+            dimIncrement: 0x1
+            description: The memory that stores Qy
+            addressOffset: 0x180
+            size: 0x8
+            access: read-write
+          QZ_MEM%s:
+            dim: 32
+            dimIncrement: 0x1
+            description: The memory that stores Qz
+            addressOffset: 0x1A0
+            size: 0x8
+            access: read-write


### PR DESCRIPTION
Leaving this as a draft for now, maybe I missed something else, will verify and update it tomorrow.