### PR TITLE
Fix `MULT_MODE` and `MODEXP_MODE` fields for `ESP32`

### DIFF
--- a/esp32/src/rsa/modexp_mode.rs
+++ b/esp32/src/rsa/modexp_mode.rs
@@ -5,12 +5,12 @@ pub type W = crate::W<MODEXP_MODE_SPEC>;
 #[doc = "Field `MODEXP_MODE` reader - This register contains the mode of modular exponentiation."]
 pub type MODEXP_MODE_R = crate::FieldReader;
 #[doc = "Field `MODEXP_MODE` writer - This register contains the mode of modular exponentiation."]
-pub type MODEXP_MODE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+pub type MODEXP_MODE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 3, O>;
 impl R {
-    #[doc = "Bits 0:1 - This register contains the mode of modular exponentiation."]
+    #[doc = "Bits 0:2 - This register contains the mode of modular exponentiation."]
     #[inline(always)]
     pub fn modexp_mode(&self) -> MODEXP_MODE_R {
-        MODEXP_MODE_R::new((self.bits & 3) as u8)
+        MODEXP_MODE_R::new((self.bits & 7) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
@@ -31,7 +31,7 @@ impl core::fmt::Debug for crate::generic::Reg<MODEXP_MODE_SPEC> {
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - This register contains the mode of modular exponentiation."]
+    #[doc = "Bits 0:2 - This register contains the mode of modular exponentiation."]
     #[inline(always)]
     #[must_use]
     pub fn modexp_mode(&mut self) -> MODEXP_MODE_W<MODEXP_MODE_SPEC, 0> {

--- a/esp32/src/rsa/mult_mode.rs
+++ b/esp32/src/rsa/mult_mode.rs
@@ -3,21 +3,21 @@ pub type R = crate::R<MULT_MODE_SPEC>;
 #[doc = "Register `MULT_MODE` writer"]
 pub type W = crate::W<MULT_MODE_SPEC>;
 #[doc = "Field `MULT_MODE` reader - This register contains the mode of modular multiplication and multiplication."]
-pub type MULT_MODE_R = crate::BitReader;
+pub type MULT_MODE_R = crate::FieldReader;
 #[doc = "Field `MULT_MODE` writer - This register contains the mode of modular multiplication and multiplication."]
-pub type MULT_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+pub type MULT_MODE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
 impl R {
-    #[doc = "Bit 0 - This register contains the mode of modular multiplication and multiplication."]
+    #[doc = "Bits 0:3 - This register contains the mode of modular multiplication and multiplication."]
     #[inline(always)]
     pub fn mult_mode(&self) -> MULT_MODE_R {
-        MULT_MODE_R::new((self.bits & 1) != 0)
+        MULT_MODE_R::new((self.bits & 0x0f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("MULT_MODE")
-            .field("mult_mode", &format_args!("{}", self.mult_mode().bit()))
+            .field("mult_mode", &format_args!("{}", self.mult_mode().bits()))
             .finish()
     }
 }
@@ -28,7 +28,7 @@ impl core::fmt::Debug for crate::generic::Reg<MULT_MODE_SPEC> {
     }
 }
 impl W {
-    #[doc = "Bit 0 - This register contains the mode of modular multiplication and multiplication."]
+    #[doc = "Bits 0:3 - This register contains the mode of modular multiplication and multiplication."]
     #[inline(always)]
     #[must_use]
     pub fn mult_mode(&mut self) -> MULT_MODE_W<MULT_MODE_SPEC, 0> {

--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -3,3 +3,14 @@ _svd: ../esp32.base.svd
 _modify:
   SDMMC:
     name: SDHOST
+
+RSA:
+  MODEXP_MODE:
+    _modify:
+      MODEXP_MODE:
+        bitWidth: 3
+  
+  MULT_MODE:
+    _modify:
+      MULT_MODE:
+        bitWidth: 4


### PR DESCRIPTION
After checking with the `TRM` for the ESP32 chip, I found out that the bit widths of these two registers do not match the documentation.