### PR TITLE
Correct name of `LP_IO::GPIO%s` field for ESP32-C6 LP, fix typos in ESP32 UART descriptions

### DIFF
--- a/esp32/src/uart0/mem_cnt_status.rs
+++ b/esp32/src/uart0/mem_cnt_status.rs
@@ -1,16 +1,16 @@
 #[doc = "Register `MEM_CNT_STATUS` reader"]
 pub type R = crate::R<MEM_CNT_STATUS_SPEC>;
-#[doc = "Field `RX_MEM_CNT` reader - refer to the rxfifo_cnt's describtion."]
+#[doc = "Field `RX_MEM_CNT` reader - Refer to the rxfifo_cnt's description."]
 pub type RX_MEM_CNT_R = crate::FieldReader;
-#[doc = "Field `TX_MEM_CNT` reader - refer to the txfifo_cnt's describtion."]
+#[doc = "Field `TX_MEM_CNT` reader - Refer to the txfifo_cnt's description."]
 pub type TX_MEM_CNT_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:2 - refer to the rxfifo_cnt's describtion."]
+    #[doc = "Bits 0:2 - Refer to the rxfifo_cnt's description."]
     #[inline(always)]
     pub fn rx_mem_cnt(&self) -> RX_MEM_CNT_R {
         RX_MEM_CNT_R::new((self.bits & 7) as u8)
     }
-    #[doc = "Bits 3:5 - refer to the txfifo_cnt's describtion."]
+    #[doc = "Bits 3:5 - Refer to the txfifo_cnt's description."]
     #[inline(always)]
     pub fn tx_mem_cnt(&self) -> TX_MEM_CNT_R {
         TX_MEM_CNT_R::new(((self.bits >> 3) & 7) as u8)

--- a/esp32/src/uart0/mem_conf.rs
+++ b/esp32/src/uart0/mem_conf.rs
@@ -14,29 +14,29 @@ pub type RX_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 pub type TX_SIZE_R = crate::FieldReader;
 #[doc = "Field `TX_SIZE` writer - This register is used to configure the amount of mem allocated to transmitter's fifo.the default byte num is 128."]
 pub type TX_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `RX_FLOW_THRHD_H3` reader - refer to the rx_flow_thrhd's describtion."]
+#[doc = "Field `RX_FLOW_THRHD_H3` reader - Refer to the rx_flow_thrhd's description."]
 pub type RX_FLOW_THRHD_H3_R = crate::FieldReader;
-#[doc = "Field `RX_FLOW_THRHD_H3` writer - refer to the rx_flow_thrhd's describtion."]
+#[doc = "Field `RX_FLOW_THRHD_H3` writer - Refer to the rx_flow_thrhd's description."]
 pub type RX_FLOW_THRHD_H3_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `RX_TOUT_THRHD_H3` reader - refer to the rx_tout_thrhd's describtion."]
+#[doc = "Field `RX_TOUT_THRHD_H3` reader - Refer to the rx_tout_thrhd's description."]
 pub type RX_TOUT_THRHD_H3_R = crate::FieldReader;
-#[doc = "Field `RX_TOUT_THRHD_H3` writer - refer to the rx_tout_thrhd's describtion."]
+#[doc = "Field `RX_TOUT_THRHD_H3` writer - Refer to the rx_tout_thrhd's description."]
 pub type RX_TOUT_THRHD_H3_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `XON_THRESHOLD_H2` reader - refer to the uart_xon_threshold's describtion."]
+#[doc = "Field `XON_THRESHOLD_H2` reader - Refer to the uart_xon_threshold's description."]
 pub type XON_THRESHOLD_H2_R = crate::FieldReader;
-#[doc = "Field `XON_THRESHOLD_H2` writer - refer to the uart_xon_threshold's describtion."]
+#[doc = "Field `XON_THRESHOLD_H2` writer - Refer to the uart_xon_threshold's description."]
 pub type XON_THRESHOLD_H2_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `XOFF_THRESHOLD_H2` reader - refer to the uart_xoff_threshold's describtion."]
+#[doc = "Field `XOFF_THRESHOLD_H2` reader - Refer to the uart_xoff_threshold's description."]
 pub type XOFF_THRESHOLD_H2_R = crate::FieldReader;
-#[doc = "Field `XOFF_THRESHOLD_H2` writer - refer to the uart_xoff_threshold's describtion."]
+#[doc = "Field `XOFF_THRESHOLD_H2` writer - Refer to the uart_xoff_threshold's description."]
 pub type XOFF_THRESHOLD_H2_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `RX_MEM_FULL_THRHD` reader - refer to the rxfifo_full_thrhd's describtion."]
+#[doc = "Field `RX_MEM_FULL_THRHD` reader - Refer to the rxfifo_full_thrhd's description."]
 pub type RX_MEM_FULL_THRHD_R = crate::FieldReader;
-#[doc = "Field `RX_MEM_FULL_THRHD` writer - refer to the rxfifo_full_thrhd's describtion."]
+#[doc = "Field `RX_MEM_FULL_THRHD` writer - Refer to the rxfifo_full_thrhd's description."]
 pub type RX_MEM_FULL_THRHD_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `TX_MEM_EMPTY_THRHD` reader - refer to txfifo_empty_thrhd 's describtion."]
+#[doc = "Field `TX_MEM_EMPTY_THRHD` reader - Refer to txfifo_empty_thrhd's description."]
 pub type TX_MEM_EMPTY_THRHD_R = crate::FieldReader;
-#[doc = "Field `TX_MEM_EMPTY_THRHD` writer - refer to txfifo_empty_thrhd 's describtion."]
+#[doc = "Field `TX_MEM_EMPTY_THRHD` writer - Refer to txfifo_empty_thrhd's description."]
 pub type TX_MEM_EMPTY_THRHD_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
 impl R {
     #[doc = "Bit 0 - Set this bit to power down mem.when reg_mem_pd registers in the 3 uarts are all set to 1 mem will enter low power mode."]
@@ -54,32 +54,32 @@ impl R {
     pub fn tx_size(&self) -> TX_SIZE_R {
         TX_SIZE_R::new(((self.bits >> 7) & 0x0f) as u8)
     }
-    #[doc = "Bits 15:17 - refer to the rx_flow_thrhd's describtion."]
+    #[doc = "Bits 15:17 - Refer to the rx_flow_thrhd's description."]
     #[inline(always)]
     pub fn rx_flow_thrhd_h3(&self) -> RX_FLOW_THRHD_H3_R {
         RX_FLOW_THRHD_H3_R::new(((self.bits >> 15) & 7) as u8)
     }
-    #[doc = "Bits 18:20 - refer to the rx_tout_thrhd's describtion."]
+    #[doc = "Bits 18:20 - Refer to the rx_tout_thrhd's description."]
     #[inline(always)]
     pub fn rx_tout_thrhd_h3(&self) -> RX_TOUT_THRHD_H3_R {
         RX_TOUT_THRHD_H3_R::new(((self.bits >> 18) & 7) as u8)
     }
-    #[doc = "Bits 21:22 - refer to the uart_xon_threshold's describtion."]
+    #[doc = "Bits 21:22 - Refer to the uart_xon_threshold's description."]
     #[inline(always)]
     pub fn xon_threshold_h2(&self) -> XON_THRESHOLD_H2_R {
         XON_THRESHOLD_H2_R::new(((self.bits >> 21) & 3) as u8)
     }
-    #[doc = "Bits 23:24 - refer to the uart_xoff_threshold's describtion."]
+    #[doc = "Bits 23:24 - Refer to the uart_xoff_threshold's description."]
     #[inline(always)]
     pub fn xoff_threshold_h2(&self) -> XOFF_THRESHOLD_H2_R {
         XOFF_THRESHOLD_H2_R::new(((self.bits >> 23) & 3) as u8)
     }
-    #[doc = "Bits 25:27 - refer to the rxfifo_full_thrhd's describtion."]
+    #[doc = "Bits 25:27 - Refer to the rxfifo_full_thrhd's description."]
     #[inline(always)]
     pub fn rx_mem_full_thrhd(&self) -> RX_MEM_FULL_THRHD_R {
         RX_MEM_FULL_THRHD_R::new(((self.bits >> 25) & 7) as u8)
     }
-    #[doc = "Bits 28:30 - refer to txfifo_empty_thrhd 's describtion."]
+    #[doc = "Bits 28:30 - Refer to txfifo_empty_thrhd's description."]
     #[inline(always)]
     pub fn tx_mem_empty_thrhd(&self) -> TX_MEM_EMPTY_THRHD_R {
         TX_MEM_EMPTY_THRHD_R::new(((self.bits >> 28) & 7) as u8)
@@ -144,37 +144,37 @@ impl W {
     pub fn tx_size(&mut self) -> TX_SIZE_W<MEM_CONF_SPEC> {
         TX_SIZE_W::new(self, 7)
     }
-    #[doc = "Bits 15:17 - refer to the rx_flow_thrhd's describtion."]
+    #[doc = "Bits 15:17 - Refer to the rx_flow_thrhd's description."]
     #[inline(always)]
     #[must_use]
     pub fn rx_flow_thrhd_h3(&mut self) -> RX_FLOW_THRHD_H3_W<MEM_CONF_SPEC> {
         RX_FLOW_THRHD_H3_W::new(self, 15)
     }
-    #[doc = "Bits 18:20 - refer to the rx_tout_thrhd's describtion."]
+    #[doc = "Bits 18:20 - Refer to the rx_tout_thrhd's description."]
     #[inline(always)]
     #[must_use]
     pub fn rx_tout_thrhd_h3(&mut self) -> RX_TOUT_THRHD_H3_W<MEM_CONF_SPEC> {
         RX_TOUT_THRHD_H3_W::new(self, 18)
     }
-    #[doc = "Bits 21:22 - refer to the uart_xon_threshold's describtion."]
+    #[doc = "Bits 21:22 - Refer to the uart_xon_threshold's description."]
     #[inline(always)]
     #[must_use]
     pub fn xon_threshold_h2(&mut self) -> XON_THRESHOLD_H2_W<MEM_CONF_SPEC> {
         XON_THRESHOLD_H2_W::new(self, 21)
     }
-    #[doc = "Bits 23:24 - refer to the uart_xoff_threshold's describtion."]
+    #[doc = "Bits 23:24 - Refer to the uart_xoff_threshold's description."]
     #[inline(always)]
     #[must_use]
     pub fn xoff_threshold_h2(&mut self) -> XOFF_THRESHOLD_H2_W<MEM_CONF_SPEC> {
         XOFF_THRESHOLD_H2_W::new(self, 23)
     }
-    #[doc = "Bits 25:27 - refer to the rxfifo_full_thrhd's describtion."]
+    #[doc = "Bits 25:27 - Refer to the rxfifo_full_thrhd's description."]
     #[inline(always)]
     #[must_use]
     pub fn rx_mem_full_thrhd(&mut self) -> RX_MEM_FULL_THRHD_W<MEM_CONF_SPEC> {
         RX_MEM_FULL_THRHD_W::new(self, 25)
     }
-    #[doc = "Bits 28:30 - refer to txfifo_empty_thrhd 's describtion."]
+    #[doc = "Bits 28:30 - Refer to txfifo_empty_thrhd's description."]
     #[inline(always)]
     #[must_use]
     pub fn tx_mem_empty_thrhd(&mut self) -> TX_MEM_EMPTY_THRHD_W<MEM_CONF_SPEC> {

--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -25,3 +25,26 @@ RSA:
       dim: 32
       dimIncrement: 0x4
       size: 0x20
+
+"UART*":
+  MEM_CONF:
+    _modify:
+      RX_FLOW_THRHD_H3:
+        description: "Refer to the rx_flow_thrhd's description."
+      RX_TOUT_THRHD_H3:
+        description: "Refer to the rx_tout_thrhd's description."
+      XON_THRESHOLD_H2:
+        description: "Refer to the uart_xon_threshold's description."
+      XOFF_THRESHOLD_H2:
+        description: "Refer to the uart_xoff_threshold's description."
+      RX_MEM_FULL_THRHD:
+        description: "Refer to the rxfifo_full_thrhd's description."
+      TX_MEM_EMPTY_THRHD:
+        description: "Refer to txfifo_empty_thrhd's description."
+
+  MEM_CNT_STATUS:
+    _modify:
+      RX_MEM_CNT:
+        description: "Refer to the rxfifo_cnt's description."
+      TX_MEM_CNT:
+        description: "Refer to the txfifo_cnt's description."

--- a/esp32c6-lp/src/lp_io/gpio.rs
+++ b/esp32c6-lp/src/lp_io/gpio.rs
@@ -42,10 +42,10 @@ pub type FUN_IE_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type FUN_DRV_R = crate::FieldReader;
 #[doc = "Field `FUN_DRV` writer - need des"]
 pub type FUN_DRV_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `MCU_SEL` reader - need des"]
-pub type MCU_SEL_R = crate::FieldReader;
-#[doc = "Field `MCU_SEL` writer - need des"]
-pub type MCU_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `FUN_SEL` reader - need des"]
+pub type FUN_SEL_R = crate::FieldReader;
+#[doc = "Field `FUN_SEL` writer - need des"]
+pub type FUN_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
 impl R {
     #[doc = "Bit 0 - need des"]
     #[inline(always)]
@@ -99,8 +99,8 @@ impl R {
     }
     #[doc = "Bits 12:14 - need des"]
     #[inline(always)]
-    pub fn mcu_sel(&self) -> MCU_SEL_R {
-        MCU_SEL_R::new(((self.bits >> 12) & 7) as u8)
+    pub fn fun_sel(&self) -> FUN_SEL_R {
+        FUN_SEL_R::new(((self.bits >> 12) & 7) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
@@ -117,7 +117,7 @@ impl core::fmt::Debug for R {
             .field("fun_wpu", &format_args!("{}", self.fun_wpu().bit()))
             .field("fun_ie", &format_args!("{}", self.fun_ie().bit()))
             .field("fun_drv", &format_args!("{}", self.fun_drv().bits()))
-            .field("mcu_sel", &format_args!("{}", self.mcu_sel().bits()))
+            .field("fun_sel", &format_args!("{}", self.fun_sel().bits()))
             .finish()
     }
 }
@@ -191,8 +191,8 @@ impl W {
     #[doc = "Bits 12:14 - need des"]
     #[inline(always)]
     #[must_use]
-    pub fn mcu_sel(&mut self) -> MCU_SEL_W<GPIO_SPEC> {
-        MCU_SEL_W::new(self, 12)
+    pub fn fun_sel(&mut self) -> FUN_SEL_W<GPIO_SPEC> {
+        FUN_SEL_W::new(self, 12)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/esp32c6-lp/svd/patches/esp32c6-lp.yaml
+++ b/esp32c6-lp/svd/patches/esp32c6-lp.yaml
@@ -35,6 +35,9 @@ LP_IO:
 
   GPIO0:
     _strip: "LP_GPIO0_"
+    _modify:
+      MCU_SEL:
+        name: FUN_SEL
   PIN0:
     _strip: "LP_GPIO0_"
 


### PR DESCRIPTION
Closes #167