### PR TITLE
Use rwtext as link section

### DIFF
--- a/esp32/src/lib.rs
+++ b/esp32/src/lib.rs
@@ -88,6 +88,7 @@ pub union Vector {
     _reserved: u32,
 }
 #[cfg(feature = "rt")]
+#[link_section = ".rwtext"]
 #[doc(hidden)]
 pub static __INTERRUPTS: [Vector; 69] = [
     Vector { _handler: WIFI_MAC },

--- a/esp32c2/src/lib.rs
+++ b/esp32c2/src/lib.rs
@@ -64,7 +64,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 42] = [
     Vector { _handler: WIFI_MAC },

--- a/esp32c3/src/lib.rs
+++ b/esp32c3/src/lib.rs
@@ -84,7 +84,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 62] = [
     Vector { _handler: WIFI_MAC },

--- a/esp32c6-lp/src/lib.rs
+++ b/esp32c6-lp/src/lib.rs
@@ -29,7 +29,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 22] = [
     Vector { _reserved: 0 },

--- a/esp32c6/src/lib.rs
+++ b/esp32c6/src/lib.rs
@@ -99,7 +99,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 77] = [
     Vector { _handler: WIFI_MAC },

--- a/esp32h2/src/lib.rs
+++ b/esp32h2/src/lib.rs
@@ -87,7 +87,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 65] = [
     Vector { _handler: PMU },

--- a/esp32p4/src/lib.rs
+++ b/esp32p4/src/lib.rs
@@ -117,7 +117,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 128] = [
     Vector { _reserved: 0 },

--- a/esp32s2-ulp/src/lib.rs
+++ b/esp32s2-ulp/src/lib.rs
@@ -31,7 +31,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 9] = [
     Vector {

--- a/esp32s2/src/lib.rs
+++ b/esp32s2/src/lib.rs
@@ -109,6 +109,7 @@ pub union Vector {
     _reserved: u32,
 }
 #[cfg(feature = "rt")]
+#[link_section = ".rwtext"]
 #[doc(hidden)]
 pub static __INTERRUPTS: [Vector; 95] = [
     Vector { _handler: WIFI_MAC },

--- a/esp32s3-ulp/src/lib.rs
+++ b/esp32s3-ulp/src/lib.rs
@@ -34,7 +34,7 @@ pub union Vector {
 }
 #[cfg(feature = "rt")]
 #[doc(hidden)]
-#[link_section = ".trap.rodata"]
+#[link_section = ".rwtext"]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 12] = [
     Vector {

--- a/esp32s3/src/lib.rs
+++ b/esp32s3/src/lib.rs
@@ -115,6 +115,7 @@ pub union Vector {
     _reserved: u32,
 }
 #[cfg(feature = "rt")]
+#[link_section = ".rwtext"]
 #[doc(hidden)]
 pub static __INTERRUPTS: [Vector; 99] = [
     Vector { _handler: WIFI_MAC },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -206,14 +206,8 @@ fn generate_package(workspace: &Path, chip: &Chip) -> Result<()> {
         output_dir: Some(path.clone()),
         impl_debug: true,
         impl_debug_feature: Some("impl-register-debug".to_owned()),
-
-        ..match target {
-            Target::RISCV => Config {
-                interrupt_link_section: Some(".trap.rodata".to_owned()),
-                ..Config::default()
-            },
-            _ => Config::default(),
-        }
+        interrupt_link_section: Some(".rwtext".to_owned()),
+        ..Config::default()
     };
 
     let input = fs::read_to_string(svd_file)?;


### PR DESCRIPTION
This is a first step to make https://github.com/esp-rs/esp-hal/issues/1063 happen

And probably it's a good idea to move the interrupt vectors to RAM in general. We had it before for Xtensa but for RISC-V it was on flash
