### PR TITLE
Patch for missing IV blocks in ESP32-C3 DS peripheral

### DIFF
--- a/esp32c3/src/ds.rs
+++ b/esp32c3/src/ds.rs
@@ -6,17 +6,18 @@ pub struct RegisterBlock {
     m_mem: [M_MEM; 128],
     rb_mem: [RB_MEM; 128],
     box_mem: [BOX_MEM; 12],
-    _reserved4: [u8; 0x01d0],
+    iv_mem: [IV_MEM; 4],
+    _reserved5: [u8; 0x01c0],
     x_mem: [X_MEM; 128],
     z_mem: [Z_MEM; 128],
-    _reserved6: [u8; 0x0200],
+    _reserved7: [u8; 0x0200],
     set_start: SET_START,
     set_continue: SET_CONTINUE,
     set_finish: SET_FINISH,
     query_busy: QUERY_BUSY,
     query_key_wrong: QUERY_KEY_WRONG,
     query_check: QUERY_CHECK,
-    _reserved12: [u8; 0x08],
+    _reserved13: [u8; 0x08],
     date: DATE,
 }
 impl RegisterBlock {
@@ -63,6 +64,17 @@ impl RegisterBlock {
     #[inline(always)]
     pub fn box_mem_iter(&self) -> impl Iterator<Item = &BOX_MEM> {
         self.box_mem.iter()
+    }
+    #[doc = "0x630..0x640 - IV block data"]
+    #[inline(always)]
+    pub const fn iv_mem(&self, n: usize) -> &IV_MEM {
+        &self.iv_mem[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x630..0x640 - IV block data"]
+    #[inline(always)]
+    pub fn iv_mem_iter(&self) -> impl Iterator<Item = &IV_MEM> {
+        self.iv_mem.iter()
     }
     #[doc = "0x800..0xa00 - memory that stores X"]
     #[inline(always)]
@@ -174,3 +186,7 @@ pub mod query_check;
 pub type DATE = crate::Reg<date::DATE_SPEC>;
 #[doc = "DS version control register"]
 pub mod date;
+#[doc = "IV_MEM (rw) register accessor: IV block data\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`iv_mem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`iv_mem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@iv_mem`] module"]
+pub type IV_MEM = crate::Reg<iv_mem::IV_MEM_SPEC>;
+#[doc = "IV block data"]
+pub mod iv_mem;

--- a/esp32c3/src/ds/iv_mem.rs
+++ b/esp32c3/src/ds/iv_mem.rs
@@ -1,0 +1,34 @@
+#[doc = "Register `IV_MEM%s` reader"]
+pub type R = crate::R<IV_MEM_SPEC>;
+#[doc = "Register `IV_MEM%s` writer"]
+pub type W = crate::W<IV_MEM_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IV_MEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {}
+#[doc = "IV block data\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`iv_mem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`iv_mem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IV_MEM_SPEC;
+impl crate::RegisterSpec for IV_MEM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`iv_mem::R`](R) reader structure"]
+impl crate::Readable for IV_MEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`iv_mem::W`](W) writer structure"]
+impl crate::Writable for IV_MEM_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IV_MEM%s to value 0"]
+impl crate::Resettable for IV_MEM_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -1,1 +1,11 @@
 _svd: ../esp32c3.base.svd
+
+DS:
+  _add:
+      IV_MEM%s:
+        dim: 4
+        dimIncrement: 0x4
+        name: IV_MEM%s
+        description: IV block data
+        addressOffset: 0x630
+        size: 0x20


### PR DESCRIPTION
Other chips with DS have these registers, but missing in the C3 official SVD