### PR TITLE
snake case for peripheral sigletones

### DIFF
--- a/esp32/src/lib.rs
+++ b/esp32/src/lib.rs
@@ -2554,97 +2554,97 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_CTRL"]
-    pub APB_CTRL: APB_CTRL,
+    pub apb_ctrl: APB_CTRL,
     #[doc = "BB"]
-    pub BB: BB,
+    pub bb: BB,
     #[doc = "DPORT"]
-    pub DPORT: DPORT,
+    pub dport: DPORT,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EMAC_DMA"]
-    pub EMAC_DMA: EMAC_DMA,
+    pub emac_dma: EMAC_DMA,
     #[doc = "EMAC_EXT"]
-    pub EMAC_EXT: EMAC_EXT,
+    pub emac_ext: EMAC_EXT,
     #[doc = "EMAC_MAC"]
-    pub EMAC_MAC: EMAC_MAC,
+    pub emac_mac: EMAC_MAC,
     #[doc = "FLASH_ENCRYPTION"]
-    pub FLASH_ENCRYPTION: FLASH_ENCRYPTION,
+    pub flash_encryption: FLASH_ENCRYPTION,
     #[doc = "FRC_TIMER"]
-    pub FRC_TIMER: FRC_TIMER,
+    pub frc_timer: FRC_TIMER,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HINF"]
-    pub HINF: HINF,
+    pub hinf: HINF,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2C1"]
-    pub I2C1: I2C1,
+    pub i2c1: I2C1,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "I2S1"]
-    pub I2S1: I2S1,
+    pub i2s1: I2S1,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "MCPWM0"]
-    pub MCPWM0: MCPWM0,
+    pub mcpwm0: MCPWM0,
     #[doc = "MCPWM1"]
-    pub MCPWM1: MCPWM1,
+    pub mcpwm1: MCPWM1,
     #[doc = "NRX"]
-    pub NRX: NRX,
+    pub nrx: NRX,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "RTC_IO"]
-    pub RTC_IO: RTC_IO,
+    pub rtc_io: RTC_IO,
     #[doc = "RTC_I2C"]
-    pub RTC_I2C: RTC_I2C,
+    pub rtc_i2c: RTC_I2C,
     #[doc = "SDHOST"]
-    pub SDHOST: SDHOST,
+    pub sdhost: SDHOST,
     #[doc = "SENS"]
-    pub SENS: SENS,
+    pub sens: SENS,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SLC"]
-    pub SLC: SLC,
+    pub slc: SLC,
     #[doc = "SLCHOST"]
-    pub SLCHOST: SLCHOST,
+    pub slchost: SLCHOST,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SPI3"]
-    pub SPI3: SPI3,
+    pub spi3: SPI3,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UART2"]
-    pub UART2: UART2,
+    pub uart2: UART2,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "UHCI1"]
-    pub UHCI1: UHCI1,
+    pub uhci1: UHCI1,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -2667,142 +2667,142 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_CTRL: APB_CTRL {
+            apb_ctrl: APB_CTRL {
                 _marker: PhantomData,
             },
-            BB: BB {
+            bb: BB {
                 _marker: PhantomData,
             },
-            DPORT: DPORT {
+            dport: DPORT {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EMAC_DMA: EMAC_DMA {
+            emac_dma: EMAC_DMA {
                 _marker: PhantomData,
             },
-            EMAC_EXT: EMAC_EXT {
+            emac_ext: EMAC_EXT {
                 _marker: PhantomData,
             },
-            EMAC_MAC: EMAC_MAC {
+            emac_mac: EMAC_MAC {
                 _marker: PhantomData,
             },
-            FLASH_ENCRYPTION: FLASH_ENCRYPTION {
+            flash_encryption: FLASH_ENCRYPTION {
                 _marker: PhantomData,
             },
-            FRC_TIMER: FRC_TIMER {
+            frc_timer: FRC_TIMER {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HINF: HINF {
+            hinf: HINF {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2C1: I2C1 {
+            i2c1: I2C1 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            I2S1: I2S1 {
+            i2s1: I2S1 {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            MCPWM0: MCPWM0 {
+            mcpwm0: MCPWM0 {
                 _marker: PhantomData,
             },
-            MCPWM1: MCPWM1 {
+            mcpwm1: MCPWM1 {
                 _marker: PhantomData,
             },
-            NRX: NRX {
+            nrx: NRX {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            RTC_IO: RTC_IO {
+            rtc_io: RTC_IO {
                 _marker: PhantomData,
             },
-            RTC_I2C: RTC_I2C {
+            rtc_i2c: RTC_I2C {
                 _marker: PhantomData,
             },
-            SDHOST: SDHOST {
+            sdhost: SDHOST {
                 _marker: PhantomData,
             },
-            SENS: SENS {
+            sens: SENS {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SLC: SLC {
+            slc: SLC {
                 _marker: PhantomData,
             },
-            SLCHOST: SLCHOST {
+            slchost: SLCHOST {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SPI3: SPI3 {
+            spi3: SPI3 {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UART2: UART2 {
+            uart2: UART2 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            UHCI1: UHCI1 {
+            uhci1: UHCI1 {
                 _marker: PhantomData,
             },
         }

--- a/esp32c2/src/lib.rs
+++ b/esp32c2/src/lib.rs
@@ -1395,59 +1395,59 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "APB_CTRL"]
-    pub APB_CTRL: APB_CTRL,
+    pub apb_ctrl: APB_CTRL,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "BB"]
-    pub BB: BB,
+    pub bb: BB,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "ECC"]
-    pub ECC: ECC,
+    pub ecc: ECC,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EXTMEM"]
-    pub EXTMEM: EXTMEM,
+    pub extmem: EXTMEM,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "MODEM_CLKRST"]
-    pub MODEM_CLKRST: MODEM_CLKRST,
+    pub modem_clkrst: MODEM_CLKRST,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "SENSITIVE"]
-    pub SENSITIVE: SENSITIVE,
+    pub sensitive: SENSITIVE,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SYSTEM"]
-    pub SYSTEM: SYSTEM,
+    pub system: SYSTEM,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "XTS_AES"]
-    pub XTS_AES: XTS_AES,
+    pub xts_aes: XTS_AES,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -1470,85 +1470,85 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            APB_CTRL: APB_CTRL {
+            apb_ctrl: APB_CTRL {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            BB: BB {
+            bb: BB {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            ECC: ECC {
+            ecc: ECC {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EXTMEM: EXTMEM {
+            extmem: EXTMEM {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            MODEM_CLKRST: MODEM_CLKRST {
+            modem_clkrst: MODEM_CLKRST {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            SENSITIVE: SENSITIVE {
+            sensitive: SENSITIVE {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SYSTEM: SYSTEM {
+            system: SYSTEM {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            XTS_AES: XTS_AES {
+            xts_aes: XTS_AES {
                 _marker: PhantomData,
             },
         }

--- a/esp32c3/src/lib.rs
+++ b/esp32c3/src/lib.rs
@@ -1915,79 +1915,79 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_CTRL"]
-    pub APB_CTRL: APB_CTRL,
+    pub apb_ctrl: APB_CTRL,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "BB"]
-    pub BB: BB,
+    pub bb: BB,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EXTMEM"]
-    pub EXTMEM: EXTMEM,
+    pub extmem: EXTMEM,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "SENSITIVE"]
-    pub SENSITIVE: SENSITIVE,
+    pub sensitive: SENSITIVE,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SYSTEM"]
-    pub SYSTEM: SYSTEM,
+    pub system: SYSTEM,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "UHCI1"]
-    pub UHCI1: UHCI1,
+    pub uhci1: UHCI1,
     #[doc = "USB_DEVICE"]
-    pub USB_DEVICE: USB_DEVICE,
+    pub usb_device: USB_DEVICE,
     #[doc = "XTS_AES"]
-    pub XTS_AES: XTS_AES,
+    pub xts_aes: XTS_AES,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -2010,115 +2010,115 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_CTRL: APB_CTRL {
+            apb_ctrl: APB_CTRL {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            BB: BB {
+            bb: BB {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EXTMEM: EXTMEM {
+            extmem: EXTMEM {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            SENSITIVE: SENSITIVE {
+            sensitive: SENSITIVE {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SYSTEM: SYSTEM {
+            system: SYSTEM {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            UHCI1: UHCI1 {
+            uhci1: UHCI1 {
                 _marker: PhantomData,
             },
-            USB_DEVICE: USB_DEVICE {
+            usb_device: USB_DEVICE {
                 _marker: PhantomData,
             },
-            XTS_AES: XTS_AES {
+            xts_aes: XTS_AES {
                 _marker: PhantomData,
             },
         }

--- a/esp32c6-lp/src/lib.rs
+++ b/esp32c6-lp/src/lib.rs
@@ -622,29 +622,29 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "LP_I2C0"]
-    pub LP_I2C0: LP_I2C0,
+    pub lp_i2c0: LP_I2C0,
     #[doc = "LP_PERI"]
-    pub LP_PERI: LP_PERI,
+    pub lp_peri: LP_PERI,
     #[doc = "LP_ANA"]
-    pub LP_ANA: LP_ANA,
+    pub lp_ana: LP_ANA,
     #[doc = "LP_AON"]
-    pub LP_AON: LP_AON,
+    pub lp_aon: LP_AON,
     #[doc = "LP_APM"]
-    pub LP_APM: LP_APM,
+    pub lp_apm: LP_APM,
     #[doc = "LP_CLKRST"]
-    pub LP_CLKRST: LP_CLKRST,
+    pub lp_clkrst: LP_CLKRST,
     #[doc = "LP_I2C_ANA_MST"]
-    pub LP_I2C_ANA_MST: LP_I2C_ANA_MST,
+    pub lp_i2c_ana_mst: LP_I2C_ANA_MST,
     #[doc = "LP_IO"]
-    pub LP_IO: LP_IO,
+    pub lp_io: LP_IO,
     #[doc = "LP_TEE"]
-    pub LP_TEE: LP_TEE,
+    pub lp_tee: LP_TEE,
     #[doc = "LP_TIMER"]
-    pub LP_TIMER: LP_TIMER,
+    pub lp_timer: LP_TIMER,
     #[doc = "LP_UART"]
-    pub LP_UART: LP_UART,
+    pub lp_uart: LP_UART,
     #[doc = "LP_WDT"]
-    pub LP_WDT: LP_WDT,
+    pub lp_wdt: LP_WDT,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -667,40 +667,40 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            LP_I2C0: LP_I2C0 {
+            lp_i2c0: LP_I2C0 {
                 _marker: PhantomData,
             },
-            LP_PERI: LP_PERI {
+            lp_peri: LP_PERI {
                 _marker: PhantomData,
             },
-            LP_ANA: LP_ANA {
+            lp_ana: LP_ANA {
                 _marker: PhantomData,
             },
-            LP_AON: LP_AON {
+            lp_aon: LP_AON {
                 _marker: PhantomData,
             },
-            LP_APM: LP_APM {
+            lp_apm: LP_APM {
                 _marker: PhantomData,
             },
-            LP_CLKRST: LP_CLKRST {
+            lp_clkrst: LP_CLKRST {
                 _marker: PhantomData,
             },
-            LP_I2C_ANA_MST: LP_I2C_ANA_MST {
+            lp_i2c_ana_mst: LP_I2C_ANA_MST {
                 _marker: PhantomData,
             },
-            LP_IO: LP_IO {
+            lp_io: LP_IO {
                 _marker: PhantomData,
             },
-            LP_TEE: LP_TEE {
+            lp_tee: LP_TEE {
                 _marker: PhantomData,
             },
-            LP_TIMER: LP_TIMER {
+            lp_timer: LP_TIMER {
                 _marker: PhantomData,
             },
-            LP_UART: LP_UART {
+            lp_uart: LP_UART {
                 _marker: PhantomData,
             },
-            LP_WDT: LP_WDT {
+            lp_wdt: LP_WDT {
                 _marker: PhantomData,
             },
         }

--- a/esp32c6/src/lib.rs
+++ b/esp32c6/src/lib.rs
@@ -3207,133 +3207,133 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "ATOMIC"]
-    pub ATOMIC: ATOMIC,
+    pub atomic: ATOMIC,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "ECC"]
-    pub ECC: ECC,
+    pub ecc: ECC,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EXTMEM"]
-    pub EXTMEM: EXTMEM,
+    pub extmem: EXTMEM,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HINF"]
-    pub HINF: HINF,
+    pub hinf: HINF,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "HP_APM"]
-    pub HP_APM: HP_APM,
+    pub hp_apm: HP_APM,
     #[doc = "HP_SYS"]
-    pub HP_SYS: HP_SYS,
+    pub hp_sys: HP_SYS,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "INTPRI"]
-    pub INTPRI: INTPRI,
+    pub intpri: INTPRI,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "LP_PERI"]
-    pub LP_PERI: LP_PERI,
+    pub lp_peri: LP_PERI,
     #[doc = "LP_ANA"]
-    pub LP_ANA: LP_ANA,
+    pub lp_ana: LP_ANA,
     #[doc = "LP_AON"]
-    pub LP_AON: LP_AON,
+    pub lp_aon: LP_AON,
     #[doc = "LP_APM"]
-    pub LP_APM: LP_APM,
+    pub lp_apm: LP_APM,
     #[doc = "LP_APM0"]
-    pub LP_APM0: LP_APM0,
+    pub lp_apm0: LP_APM0,
     #[doc = "LP_CLKRST"]
-    pub LP_CLKRST: LP_CLKRST,
+    pub lp_clkrst: LP_CLKRST,
     #[doc = "LP_I2C0"]
-    pub LP_I2C0: LP_I2C0,
+    pub lp_i2c0: LP_I2C0,
     #[doc = "LP_I2C_ANA_MST"]
-    pub LP_I2C_ANA_MST: LP_I2C_ANA_MST,
+    pub lp_i2c_ana_mst: LP_I2C_ANA_MST,
     #[doc = "LP_IO"]
-    pub LP_IO: LP_IO,
+    pub lp_io: LP_IO,
     #[doc = "LP_TEE"]
-    pub LP_TEE: LP_TEE,
+    pub lp_tee: LP_TEE,
     #[doc = "LP_TIMER"]
-    pub LP_TIMER: LP_TIMER,
+    pub lp_timer: LP_TIMER,
     #[doc = "LP_UART"]
-    pub LP_UART: LP_UART,
+    pub lp_uart: LP_UART,
     #[doc = "LP_WDT"]
-    pub LP_WDT: LP_WDT,
+    pub lp_wdt: LP_WDT,
     #[doc = "MCPWM0"]
-    pub MCPWM0: MCPWM0,
+    pub mcpwm0: MCPWM0,
     #[doc = "MEM_MONITOR"]
-    pub MEM_MONITOR: MEM_MONITOR,
+    pub mem_monitor: MEM_MONITOR,
     #[doc = "MODEM_LPCON"]
-    pub MODEM_LPCON: MODEM_LPCON,
+    pub modem_lpcon: MODEM_LPCON,
     #[doc = "MODEM_SYSCON"]
-    pub MODEM_SYSCON: MODEM_SYSCON,
+    pub modem_syscon: MODEM_SYSCON,
     #[doc = "OTP_DEBUG"]
-    pub OTP_DEBUG: OTP_DEBUG,
+    pub otp_debug: OTP_DEBUG,
     #[doc = "PARL_IO"]
-    pub PARL_IO: PARL_IO,
+    pub parl_io: PARL_IO,
     #[doc = "PAU"]
-    pub PAU: PAU,
+    pub pau: PAU,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "PCR"]
-    pub PCR: PCR,
+    pub pcr: PCR,
     #[doc = "PMU"]
-    pub PMU: PMU,
+    pub pmu: PMU,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SLCHOST"]
-    pub SLCHOST: SLCHOST,
+    pub slchost: SLCHOST,
     #[doc = "SOC_ETM"]
-    pub SOC_ETM: SOC_ETM,
+    pub soc_etm: SOC_ETM,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TEE"]
-    pub TEE: TEE,
+    pub tee: TEE,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TRACE"]
-    pub TRACE: TRACE,
+    pub trace: TRACE,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "TWAI1"]
-    pub TWAI1: TWAI1,
+    pub twai1: TWAI1,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "USB_DEVICE"]
-    pub USB_DEVICE: USB_DEVICE,
+    pub usb_device: USB_DEVICE,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -3356,196 +3356,196 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            ATOMIC: ATOMIC {
+            atomic: ATOMIC {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            ECC: ECC {
+            ecc: ECC {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EXTMEM: EXTMEM {
+            extmem: EXTMEM {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HINF: HINF {
+            hinf: HINF {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            HP_APM: HP_APM {
+            hp_apm: HP_APM {
                 _marker: PhantomData,
             },
-            HP_SYS: HP_SYS {
+            hp_sys: HP_SYS {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            INTPRI: INTPRI {
+            intpri: INTPRI {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            LP_PERI: LP_PERI {
+            lp_peri: LP_PERI {
                 _marker: PhantomData,
             },
-            LP_ANA: LP_ANA {
+            lp_ana: LP_ANA {
                 _marker: PhantomData,
             },
-            LP_AON: LP_AON {
+            lp_aon: LP_AON {
                 _marker: PhantomData,
             },
-            LP_APM: LP_APM {
+            lp_apm: LP_APM {
                 _marker: PhantomData,
             },
-            LP_APM0: LP_APM0 {
+            lp_apm0: LP_APM0 {
                 _marker: PhantomData,
             },
-            LP_CLKRST: LP_CLKRST {
+            lp_clkrst: LP_CLKRST {
                 _marker: PhantomData,
             },
-            LP_I2C0: LP_I2C0 {
+            lp_i2c0: LP_I2C0 {
                 _marker: PhantomData,
             },
-            LP_I2C_ANA_MST: LP_I2C_ANA_MST {
+            lp_i2c_ana_mst: LP_I2C_ANA_MST {
                 _marker: PhantomData,
             },
-            LP_IO: LP_IO {
+            lp_io: LP_IO {
                 _marker: PhantomData,
             },
-            LP_TEE: LP_TEE {
+            lp_tee: LP_TEE {
                 _marker: PhantomData,
             },
-            LP_TIMER: LP_TIMER {
+            lp_timer: LP_TIMER {
                 _marker: PhantomData,
             },
-            LP_UART: LP_UART {
+            lp_uart: LP_UART {
                 _marker: PhantomData,
             },
-            LP_WDT: LP_WDT {
+            lp_wdt: LP_WDT {
                 _marker: PhantomData,
             },
-            MCPWM0: MCPWM0 {
+            mcpwm0: MCPWM0 {
                 _marker: PhantomData,
             },
-            MEM_MONITOR: MEM_MONITOR {
+            mem_monitor: MEM_MONITOR {
                 _marker: PhantomData,
             },
-            MODEM_LPCON: MODEM_LPCON {
+            modem_lpcon: MODEM_LPCON {
                 _marker: PhantomData,
             },
-            MODEM_SYSCON: MODEM_SYSCON {
+            modem_syscon: MODEM_SYSCON {
                 _marker: PhantomData,
             },
-            OTP_DEBUG: OTP_DEBUG {
+            otp_debug: OTP_DEBUG {
                 _marker: PhantomData,
             },
-            PARL_IO: PARL_IO {
+            parl_io: PARL_IO {
                 _marker: PhantomData,
             },
-            PAU: PAU {
+            pau: PAU {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            PCR: PCR {
+            pcr: PCR {
                 _marker: PhantomData,
             },
-            PMU: PMU {
+            pmu: PMU {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SLCHOST: SLCHOST {
+            slchost: SLCHOST {
                 _marker: PhantomData,
             },
-            SOC_ETM: SOC_ETM {
+            soc_etm: SOC_ETM {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TEE: TEE {
+            tee: TEE {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TRACE: TRACE {
+            trace: TRACE {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            TWAI1: TWAI1 {
+            twai1: TWAI1 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            USB_DEVICE: USB_DEVICE {
+            usb_device: USB_DEVICE {
                 _marker: PhantomData,
             },
         }

--- a/esp32h2/src/lib.rs
+++ b/esp32h2/src/lib.rs
@@ -2715,113 +2715,113 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "ECC"]
-    pub ECC: ECC,
+    pub ecc: ECC,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "HP_APM"]
-    pub HP_APM: HP_APM,
+    pub hp_apm: HP_APM,
     #[doc = "HP_SYS"]
-    pub HP_SYS: HP_SYS,
+    pub hp_sys: HP_SYS,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2C1"]
-    pub I2C1: I2C1,
+    pub i2c1: I2C1,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "INTPRI"]
-    pub INTPRI: INTPRI,
+    pub intpri: INTPRI,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "LP_PERI"]
-    pub LP_PERI: LP_PERI,
+    pub lp_peri: LP_PERI,
     #[doc = "LP_ANA"]
-    pub LP_ANA: LP_ANA,
+    pub lp_ana: LP_ANA,
     #[doc = "LP_AON"]
-    pub LP_AON: LP_AON,
+    pub lp_aon: LP_AON,
     #[doc = "LP_APM"]
-    pub LP_APM: LP_APM,
+    pub lp_apm: LP_APM,
     #[doc = "LP_CLKRST"]
-    pub LP_CLKRST: LP_CLKRST,
+    pub lp_clkrst: LP_CLKRST,
     #[doc = "LP_TIMER"]
-    pub LP_TIMER: LP_TIMER,
+    pub lp_timer: LP_TIMER,
     #[doc = "LP_WDT"]
-    pub LP_WDT: LP_WDT,
+    pub lp_wdt: LP_WDT,
     #[doc = "MCPWM0"]
-    pub MCPWM0: MCPWM0,
+    pub mcpwm0: MCPWM0,
     #[doc = "MEM_MONITOR"]
-    pub MEM_MONITOR: MEM_MONITOR,
+    pub mem_monitor: MEM_MONITOR,
     #[doc = "MODEM_LPCON"]
-    pub MODEM_LPCON: MODEM_LPCON,
+    pub modem_lpcon: MODEM_LPCON,
     #[doc = "MODEM_SYSCON"]
-    pub MODEM_SYSCON: MODEM_SYSCON,
+    pub modem_syscon: MODEM_SYSCON,
     #[doc = "OTP_DEBUG"]
-    pub OTP_DEBUG: OTP_DEBUG,
+    pub otp_debug: OTP_DEBUG,
     #[doc = "PARL_IO"]
-    pub PARL_IO: PARL_IO,
+    pub parl_io: PARL_IO,
     #[doc = "PAU"]
-    pub PAU: PAU,
+    pub pau: PAU,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "PCR"]
-    pub PCR: PCR,
+    pub pcr: PCR,
     #[doc = "PMU"]
-    pub PMU: PMU,
+    pub pmu: PMU,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SOC_ETM"]
-    pub SOC_ETM: SOC_ETM,
+    pub soc_etm: SOC_ETM,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TEE"]
-    pub TEE: TEE,
+    pub tee: TEE,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TRACE"]
-    pub TRACE: TRACE,
+    pub trace: TRACE,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "USB_DEVICE"]
-    pub USB_DEVICE: USB_DEVICE,
+    pub usb_device: USB_DEVICE,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -2844,166 +2844,166 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            ECC: ECC {
+            ecc: ECC {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            HP_APM: HP_APM {
+            hp_apm: HP_APM {
                 _marker: PhantomData,
             },
-            HP_SYS: HP_SYS {
+            hp_sys: HP_SYS {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2C1: I2C1 {
+            i2c1: I2C1 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            INTPRI: INTPRI {
+            intpri: INTPRI {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            LP_PERI: LP_PERI {
+            lp_peri: LP_PERI {
                 _marker: PhantomData,
             },
-            LP_ANA: LP_ANA {
+            lp_ana: LP_ANA {
                 _marker: PhantomData,
             },
-            LP_AON: LP_AON {
+            lp_aon: LP_AON {
                 _marker: PhantomData,
             },
-            LP_APM: LP_APM {
+            lp_apm: LP_APM {
                 _marker: PhantomData,
             },
-            LP_CLKRST: LP_CLKRST {
+            lp_clkrst: LP_CLKRST {
                 _marker: PhantomData,
             },
-            LP_TIMER: LP_TIMER {
+            lp_timer: LP_TIMER {
                 _marker: PhantomData,
             },
-            LP_WDT: LP_WDT {
+            lp_wdt: LP_WDT {
                 _marker: PhantomData,
             },
-            MCPWM0: MCPWM0 {
+            mcpwm0: MCPWM0 {
                 _marker: PhantomData,
             },
-            MEM_MONITOR: MEM_MONITOR {
+            mem_monitor: MEM_MONITOR {
                 _marker: PhantomData,
             },
-            MODEM_LPCON: MODEM_LPCON {
+            modem_lpcon: MODEM_LPCON {
                 _marker: PhantomData,
             },
-            MODEM_SYSCON: MODEM_SYSCON {
+            modem_syscon: MODEM_SYSCON {
                 _marker: PhantomData,
             },
-            OTP_DEBUG: OTP_DEBUG {
+            otp_debug: OTP_DEBUG {
                 _marker: PhantomData,
             },
-            PARL_IO: PARL_IO {
+            parl_io: PARL_IO {
                 _marker: PhantomData,
             },
-            PAU: PAU {
+            pau: PAU {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            PCR: PCR {
+            pcr: PCR {
                 _marker: PhantomData,
             },
-            PMU: PMU {
+            pmu: PMU {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SOC_ETM: SOC_ETM {
+            soc_etm: SOC_ETM {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TEE: TEE {
+            tee: TEE {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TRACE: TRACE {
+            trace: TRACE {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            USB_DEVICE: USB_DEVICE {
+            usb_device: USB_DEVICE {
                 _marker: PhantomData,
             },
         }

--- a/esp32p4/src/lib.rs
+++ b/esp32p4/src/lib.rs
@@ -4428,183 +4428,183 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "ADC"]
-    pub ADC: ADC,
+    pub adc: ADC,
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "AHB_DMA"]
-    pub AHB_DMA: AHB_DMA,
+    pub ahb_dma: AHB_DMA,
     #[doc = "LP_I2C_ANA_MST"]
-    pub LP_I2C_ANA_MST: LP_I2C_ANA_MST,
+    pub lp_i2c_ana_mst: LP_I2C_ANA_MST,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "AXI_DMA"]
-    pub AXI_DMA: AXI_DMA,
+    pub axi_dma: AXI_DMA,
     #[doc = "BITSCRAMBLER"]
-    pub BITSCRAMBLER: BITSCRAMBLER,
+    pub bitscrambler: BITSCRAMBLER,
     #[doc = "CACHE"]
-    pub CACHE: CACHE,
+    pub cache: CACHE,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "INTERRUPT_CORE1"]
-    pub INTERRUPT_CORE1: INTERRUPT_CORE1,
+    pub interrupt_core1: INTERRUPT_CORE1,
     #[doc = "MIPI_CSI_BRIDGE"]
-    pub MIPI_CSI_BRIDGE: MIPI_CSI_BRIDGE,
+    pub mipi_csi_bridge: MIPI_CSI_BRIDGE,
     #[doc = "MIPI_CSI_HOST"]
-    pub MIPI_CSI_HOST: MIPI_CSI_HOST,
+    pub mipi_csi_host: MIPI_CSI_HOST,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "MIPI_DSI_BRIDGE"]
-    pub MIPI_DSI_BRIDGE: MIPI_DSI_BRIDGE,
+    pub mipi_dsi_bridge: MIPI_DSI_BRIDGE,
     #[doc = "MIPI_DSI_HOST"]
-    pub MIPI_DSI_HOST: MIPI_DSI_HOST,
+    pub mipi_dsi_host: MIPI_DSI_HOST,
     #[doc = "ECC"]
-    pub ECC: ECC,
+    pub ecc: ECC,
     #[doc = "ECDSA"]
-    pub ECDSA: ECDSA,
+    pub ecdsa: ECDSA,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "H264"]
-    pub H264: H264,
+    pub h264: H264,
     #[doc = "H264_DMA"]
-    pub H264_DMA: H264_DMA,
+    pub h264_dma: H264_DMA,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "HP_SYS"]
-    pub HP_SYS: HP_SYS,
+    pub hp_sys: HP_SYS,
     #[doc = "HP_SYS_CLKRST"]
-    pub HP_SYS_CLKRST: HP_SYS_CLKRST,
+    pub hp_sys_clkrst: HP_SYS_CLKRST,
     #[doc = "LP_HUK"]
-    pub LP_HUK: LP_HUK,
+    pub lp_huk: LP_HUK,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2C1"]
-    pub I2C1: I2C1,
+    pub i2c1: I2C1,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "I2S1"]
-    pub I2S1: I2S1,
+    pub i2s1: I2S1,
     #[doc = "I2S2"]
-    pub I2S2: I2S2,
+    pub i2s2: I2S2,
     #[doc = "I3C_MST"]
-    pub I3C_MST: I3C_MST,
+    pub i3c_mst: I3C_MST,
     #[doc = "I3C_MST_MEM"]
-    pub I3C_MST_MEM: I3C_MST_MEM,
+    pub i3c_mst_mem: I3C_MST_MEM,
     #[doc = "I3C_SLV"]
-    pub I3C_SLV: I3C_SLV,
+    pub i3c_slv: I3C_SLV,
     #[doc = "AXI_ICM"]
-    pub AXI_ICM: AXI_ICM,
+    pub axi_icm: AXI_ICM,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "ISP"]
-    pub ISP: ISP,
+    pub isp: ISP,
     #[doc = "JPEG"]
-    pub JPEG: JPEG,
+    pub jpeg: JPEG,
     #[doc = "LCD_CAM"]
-    pub LCD_CAM: LCD_CAM,
+    pub lcd_cam: LCD_CAM,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "LP_INTR"]
-    pub LP_INTR: LP_INTR,
+    pub lp_intr: LP_INTR,
     #[doc = "LP_PERI"]
-    pub LP_PERI: LP_PERI,
+    pub lp_peri: LP_PERI,
     #[doc = "LP_SYS"]
-    pub LP_SYS: LP_SYS,
+    pub lp_sys: LP_SYS,
     #[doc = "LP_ANA"]
-    pub LP_ANA: LP_ANA,
+    pub lp_ana: LP_ANA,
     #[doc = "LP_AON_CLKRST"]
-    pub LP_AON_CLKRST: LP_AON_CLKRST,
+    pub lp_aon_clkrst: LP_AON_CLKRST,
     #[doc = "LP_GPIO"]
-    pub LP_GPIO: LP_GPIO,
+    pub lp_gpio: LP_GPIO,
     #[doc = "LP_I2C0"]
-    pub LP_I2C0: LP_I2C0,
+    pub lp_i2c0: LP_I2C0,
     #[doc = "LP_I2S0"]
-    pub LP_I2S0: LP_I2S0,
+    pub lp_i2s0: LP_I2S0,
     #[doc = "LP_IO_MUX"]
-    pub LP_IO_MUX: LP_IO_MUX,
+    pub lp_io_mux: LP_IO_MUX,
     #[doc = "LP_UART"]
-    pub LP_UART: LP_UART,
+    pub lp_uart: LP_UART,
     #[doc = "MCPWM0"]
-    pub MCPWM0: MCPWM0,
+    pub mcpwm0: MCPWM0,
     #[doc = "MCPWM1"]
-    pub MCPWM1: MCPWM1,
+    pub mcpwm1: MCPWM1,
     #[doc = "PARL_IO"]
-    pub PARL_IO: PARL_IO,
+    pub parl_io: PARL_IO,
     #[doc = "PAU"]
-    pub PAU: PAU,
+    pub pau: PAU,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "PMU"]
-    pub PMU: PMU,
+    pub pmu: PMU,
     #[doc = "PPA"]
-    pub PPA: PPA,
+    pub ppa: PPA,
     #[doc = "PVT"]
-    pub PVT: PVT,
+    pub pvt: PVT,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "LP_ADC"]
-    pub LP_ADC: LP_ADC,
+    pub lp_adc: LP_ADC,
     #[doc = "LP_TIMER"]
-    pub LP_TIMER: LP_TIMER,
+    pub lp_timer: LP_TIMER,
     #[doc = "LP_TOUCH"]
-    pub LP_TOUCH: LP_TOUCH,
+    pub lp_touch: LP_TOUCH,
     #[doc = "LP_WDT"]
-    pub LP_WDT: LP_WDT,
+    pub lp_wdt: LP_WDT,
     #[doc = "SDHOST"]
-    pub SDHOST: SDHOST,
+    pub sdhost: SDHOST,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SOC_ETM"]
-    pub SOC_ETM: SOC_ETM,
+    pub soc_etm: SOC_ETM,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SPI3"]
-    pub SPI3: SPI3,
+    pub spi3: SPI3,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TRACE0"]
-    pub TRACE0: TRACE0,
+    pub trace0: TRACE0,
     #[doc = "TRACE1"]
-    pub TRACE1: TRACE1,
+    pub trace1: TRACE1,
     #[doc = "LP_TSENS"]
-    pub LP_TSENS: LP_TSENS,
+    pub lp_tsens: LP_TSENS,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "TWAI1"]
-    pub TWAI1: TWAI1,
+    pub twai1: TWAI1,
     #[doc = "TWAI2"]
-    pub TWAI2: TWAI2,
+    pub twai2: TWAI2,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UART2"]
-    pub UART2: UART2,
+    pub uart2: UART2,
     #[doc = "UART3"]
-    pub UART3: UART3,
+    pub uart3: UART3,
     #[doc = "UART4"]
-    pub UART4: UART4,
+    pub uart4: UART4,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "USB_DEVICE"]
-    pub USB_DEVICE: USB_DEVICE,
+    pub usb_device: USB_DEVICE,
     #[doc = "USB_WRAP"]
-    pub USB_WRAP: USB_WRAP,
+    pub usb_wrap: USB_WRAP,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -4627,271 +4627,271 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            ADC: ADC {
+            adc: ADC {
                 _marker: PhantomData,
             },
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            AHB_DMA: AHB_DMA {
+            ahb_dma: AHB_DMA {
                 _marker: PhantomData,
             },
-            LP_I2C_ANA_MST: LP_I2C_ANA_MST {
+            lp_i2c_ana_mst: LP_I2C_ANA_MST {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            AXI_DMA: AXI_DMA {
+            axi_dma: AXI_DMA {
                 _marker: PhantomData,
             },
-            BITSCRAMBLER: BITSCRAMBLER {
+            bitscrambler: BITSCRAMBLER {
                 _marker: PhantomData,
             },
-            CACHE: CACHE {
+            cache: CACHE {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE1: INTERRUPT_CORE1 {
+            interrupt_core1: INTERRUPT_CORE1 {
                 _marker: PhantomData,
             },
-            MIPI_CSI_BRIDGE: MIPI_CSI_BRIDGE {
+            mipi_csi_bridge: MIPI_CSI_BRIDGE {
                 _marker: PhantomData,
             },
-            MIPI_CSI_HOST: MIPI_CSI_HOST {
+            mipi_csi_host: MIPI_CSI_HOST {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            MIPI_DSI_BRIDGE: MIPI_DSI_BRIDGE {
+            mipi_dsi_bridge: MIPI_DSI_BRIDGE {
                 _marker: PhantomData,
             },
-            MIPI_DSI_HOST: MIPI_DSI_HOST {
+            mipi_dsi_host: MIPI_DSI_HOST {
                 _marker: PhantomData,
             },
-            ECC: ECC {
+            ecc: ECC {
                 _marker: PhantomData,
             },
-            ECDSA: ECDSA {
+            ecdsa: ECDSA {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            H264: H264 {
+            h264: H264 {
                 _marker: PhantomData,
             },
-            H264_DMA: H264_DMA {
+            h264_dma: H264_DMA {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            HP_SYS: HP_SYS {
+            hp_sys: HP_SYS {
                 _marker: PhantomData,
             },
-            HP_SYS_CLKRST: HP_SYS_CLKRST {
+            hp_sys_clkrst: HP_SYS_CLKRST {
                 _marker: PhantomData,
             },
-            LP_HUK: LP_HUK {
+            lp_huk: LP_HUK {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2C1: I2C1 {
+            i2c1: I2C1 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            I2S1: I2S1 {
+            i2s1: I2S1 {
                 _marker: PhantomData,
             },
-            I2S2: I2S2 {
+            i2s2: I2S2 {
                 _marker: PhantomData,
             },
-            I3C_MST: I3C_MST {
+            i3c_mst: I3C_MST {
                 _marker: PhantomData,
             },
-            I3C_MST_MEM: I3C_MST_MEM {
+            i3c_mst_mem: I3C_MST_MEM {
                 _marker: PhantomData,
             },
-            I3C_SLV: I3C_SLV {
+            i3c_slv: I3C_SLV {
                 _marker: PhantomData,
             },
-            AXI_ICM: AXI_ICM {
+            axi_icm: AXI_ICM {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            ISP: ISP {
+            isp: ISP {
                 _marker: PhantomData,
             },
-            JPEG: JPEG {
+            jpeg: JPEG {
                 _marker: PhantomData,
             },
-            LCD_CAM: LCD_CAM {
+            lcd_cam: LCD_CAM {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            LP_INTR: LP_INTR {
+            lp_intr: LP_INTR {
                 _marker: PhantomData,
             },
-            LP_PERI: LP_PERI {
+            lp_peri: LP_PERI {
                 _marker: PhantomData,
             },
-            LP_SYS: LP_SYS {
+            lp_sys: LP_SYS {
                 _marker: PhantomData,
             },
-            LP_ANA: LP_ANA {
+            lp_ana: LP_ANA {
                 _marker: PhantomData,
             },
-            LP_AON_CLKRST: LP_AON_CLKRST {
+            lp_aon_clkrst: LP_AON_CLKRST {
                 _marker: PhantomData,
             },
-            LP_GPIO: LP_GPIO {
+            lp_gpio: LP_GPIO {
                 _marker: PhantomData,
             },
-            LP_I2C0: LP_I2C0 {
+            lp_i2c0: LP_I2C0 {
                 _marker: PhantomData,
             },
-            LP_I2S0: LP_I2S0 {
+            lp_i2s0: LP_I2S0 {
                 _marker: PhantomData,
             },
-            LP_IO_MUX: LP_IO_MUX {
+            lp_io_mux: LP_IO_MUX {
                 _marker: PhantomData,
             },
-            LP_UART: LP_UART {
+            lp_uart: LP_UART {
                 _marker: PhantomData,
             },
-            MCPWM0: MCPWM0 {
+            mcpwm0: MCPWM0 {
                 _marker: PhantomData,
             },
-            MCPWM1: MCPWM1 {
+            mcpwm1: MCPWM1 {
                 _marker: PhantomData,
             },
-            PARL_IO: PARL_IO {
+            parl_io: PARL_IO {
                 _marker: PhantomData,
             },
-            PAU: PAU {
+            pau: PAU {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            PMU: PMU {
+            pmu: PMU {
                 _marker: PhantomData,
             },
-            PPA: PPA {
+            ppa: PPA {
                 _marker: PhantomData,
             },
-            PVT: PVT {
+            pvt: PVT {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            LP_ADC: LP_ADC {
+            lp_adc: LP_ADC {
                 _marker: PhantomData,
             },
-            LP_TIMER: LP_TIMER {
+            lp_timer: LP_TIMER {
                 _marker: PhantomData,
             },
-            LP_TOUCH: LP_TOUCH {
+            lp_touch: LP_TOUCH {
                 _marker: PhantomData,
             },
-            LP_WDT: LP_WDT {
+            lp_wdt: LP_WDT {
                 _marker: PhantomData,
             },
-            SDHOST: SDHOST {
+            sdhost: SDHOST {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SOC_ETM: SOC_ETM {
+            soc_etm: SOC_ETM {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SPI3: SPI3 {
+            spi3: SPI3 {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TRACE0: TRACE0 {
+            trace0: TRACE0 {
                 _marker: PhantomData,
             },
-            TRACE1: TRACE1 {
+            trace1: TRACE1 {
                 _marker: PhantomData,
             },
-            LP_TSENS: LP_TSENS {
+            lp_tsens: LP_TSENS {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            TWAI1: TWAI1 {
+            twai1: TWAI1 {
                 _marker: PhantomData,
             },
-            TWAI2: TWAI2 {
+            twai2: TWAI2 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UART2: UART2 {
+            uart2: UART2 {
                 _marker: PhantomData,
             },
-            UART3: UART3 {
+            uart3: UART3 {
                 _marker: PhantomData,
             },
-            UART4: UART4 {
+            uart4: UART4 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            USB_DEVICE: USB_DEVICE {
+            usb_device: USB_DEVICE {
                 _marker: PhantomData,
             },
-            USB_WRAP: USB_WRAP {
+            usb_wrap: USB_WRAP {
                 _marker: PhantomData,
             },
         }

--- a/esp32s2-ulp/src/lib.rs
+++ b/esp32s2-ulp/src/lib.rs
@@ -251,13 +251,13 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "RTC_IO"]
-    pub RTC_IO: RTC_IO,
+    pub rtc_io: RTC_IO,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "RTC_I2C"]
-    pub RTC_I2C: RTC_I2C,
+    pub rtc_i2c: RTC_I2C,
     #[doc = "SENS"]
-    pub SENS: SENS,
+    pub sens: SENS,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -280,16 +280,16 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            RTC_IO: RTC_IO {
+            rtc_io: RTC_IO {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            RTC_I2C: RTC_I2C {
+            rtc_i2c: RTC_I2C {
                 _marker: PhantomData,
             },
-            SENS: SENS {
+            sens: SENS {
                 _marker: PhantomData,
             },
         }

--- a/esp32s2/src/lib.rs
+++ b/esp32s2/src/lib.rs
@@ -2568,91 +2568,91 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "BB"]
-    pub BB: BB,
+    pub bb: BB,
     #[doc = "DEDICATED_GPIO"]
-    pub DEDICATED_GPIO: DEDICATED_GPIO,
+    pub dedicated_gpio: DEDICATED_GPIO,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EXTMEM"]
-    pub EXTMEM: EXTMEM,
+    pub extmem: EXTMEM,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2C1"]
-    pub I2C1: I2C1,
+    pub i2c1: I2C1,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "PMS"]
-    pub PMS: PMS,
+    pub pms: PMS,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "RTC_IO"]
-    pub RTC_IO: RTC_IO,
+    pub rtc_io: RTC_IO,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "RTC_I2C"]
-    pub RTC_I2C: RTC_I2C,
+    pub rtc_i2c: RTC_I2C,
     #[doc = "SENS"]
-    pub SENS: SENS,
+    pub sens: SENS,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SPI3"]
-    pub SPI3: SPI3,
+    pub spi3: SPI3,
     #[doc = "SPI4"]
-    pub SPI4: SPI4,
+    pub spi4: SPI4,
     #[doc = "SYSCON"]
-    pub SYSCON: SYSCON,
+    pub syscon: SYSCON,
     #[doc = "SYSTEM"]
-    pub SYSTEM: SYSTEM,
+    pub system: SYSTEM,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "USB0"]
-    pub USB0: USB0,
+    pub usb0: USB0,
     #[doc = "USB_WRAP"]
-    pub USB_WRAP: USB_WRAP,
+    pub usb_wrap: USB_WRAP,
     #[doc = "XTS_AES"]
-    pub XTS_AES: XTS_AES,
+    pub xts_aes: XTS_AES,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -2675,133 +2675,133 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            BB: BB {
+            bb: BB {
                 _marker: PhantomData,
             },
-            DEDICATED_GPIO: DEDICATED_GPIO {
+            dedicated_gpio: DEDICATED_GPIO {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EXTMEM: EXTMEM {
+            extmem: EXTMEM {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2C1: I2C1 {
+            i2c1: I2C1 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            PMS: PMS {
+            pms: PMS {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            RTC_IO: RTC_IO {
+            rtc_io: RTC_IO {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            RTC_I2C: RTC_I2C {
+            rtc_i2c: RTC_I2C {
                 _marker: PhantomData,
             },
-            SENS: SENS {
+            sens: SENS {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SPI3: SPI3 {
+            spi3: SPI3 {
                 _marker: PhantomData,
             },
-            SPI4: SPI4 {
+            spi4: SPI4 {
                 _marker: PhantomData,
             },
-            SYSCON: SYSCON {
+            syscon: SYSCON {
                 _marker: PhantomData,
             },
-            SYSTEM: SYSTEM {
+            system: SYSTEM {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            USB0: USB0 {
+            usb0: USB0 {
                 _marker: PhantomData,
             },
-            USB_WRAP: USB_WRAP {
+            usb_wrap: USB_WRAP {
                 _marker: PhantomData,
             },
-            XTS_AES: XTS_AES {
+            xts_aes: XTS_AES {
                 _marker: PhantomData,
             },
         }

--- a/esp32s3-ulp/src/lib.rs
+++ b/esp32s3-ulp/src/lib.rs
@@ -263,13 +263,13 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "RTC_I2C"]
-    pub RTC_I2C: RTC_I2C,
+    pub rtc_i2c: RTC_I2C,
     #[doc = "RTC_IO"]
-    pub RTC_IO: RTC_IO,
+    pub rtc_io: RTC_IO,
     #[doc = "SENS"]
-    pub SENS: SENS,
+    pub sens: SENS,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -292,16 +292,16 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            RTC_I2C: RTC_I2C {
+            rtc_i2c: RTC_I2C {
                 _marker: PhantomData,
             },
-            RTC_IO: RTC_IO {
+            rtc_io: RTC_IO {
                 _marker: PhantomData,
             },
-            SENS: SENS {
+            sens: SENS {
                 _marker: PhantomData,
             },
         }

--- a/esp32s3/src/lib.rs
+++ b/esp32s3/src/lib.rs
@@ -3114,113 +3114,113 @@ static mut DEVICE_PERIPHERALS: bool = false;
 #[allow(non_snake_case)]
 pub struct Peripherals {
     #[doc = "AES"]
-    pub AES: AES,
+    pub aes: AES,
     #[doc = "APB_CTRL"]
-    pub APB_CTRL: APB_CTRL,
+    pub apb_ctrl: APB_CTRL,
     #[doc = "APB_SARADC"]
-    pub APB_SARADC: APB_SARADC,
+    pub apb_saradc: APB_SARADC,
     #[doc = "BB"]
-    pub BB: BB,
+    pub bb: BB,
     #[doc = "ASSIST_DEBUG"]
-    pub ASSIST_DEBUG: ASSIST_DEBUG,
+    pub assist_debug: ASSIST_DEBUG,
     #[doc = "DMA"]
-    pub DMA: DMA,
+    pub dma: DMA,
     #[doc = "DS"]
-    pub DS: DS,
+    pub ds: DS,
     #[doc = "EFUSE"]
-    pub EFUSE: EFUSE,
+    pub efuse: EFUSE,
     #[doc = "EXTMEM"]
-    pub EXTMEM: EXTMEM,
+    pub extmem: EXTMEM,
     #[doc = "GPIO"]
-    pub GPIO: GPIO,
+    pub gpio: GPIO,
     #[doc = "GPIO_SD"]
-    pub GPIO_SD: GPIO_SD,
+    pub gpio_sd: GPIO_SD,
     #[doc = "HMAC"]
-    pub HMAC: HMAC,
+    pub hmac: HMAC,
     #[doc = "I2C0"]
-    pub I2C0: I2C0,
+    pub i2c0: I2C0,
     #[doc = "I2C1"]
-    pub I2C1: I2C1,
+    pub i2c1: I2C1,
     #[doc = "I2S0"]
-    pub I2S0: I2S0,
+    pub i2s0: I2S0,
     #[doc = "I2S1"]
-    pub I2S1: I2S1,
+    pub i2s1: I2S1,
     #[doc = "INTERRUPT_CORE0"]
-    pub INTERRUPT_CORE0: INTERRUPT_CORE0,
+    pub interrupt_core0: INTERRUPT_CORE0,
     #[doc = "INTERRUPT_CORE1"]
-    pub INTERRUPT_CORE1: INTERRUPT_CORE1,
+    pub interrupt_core1: INTERRUPT_CORE1,
     #[doc = "IO_MUX"]
-    pub IO_MUX: IO_MUX,
+    pub io_mux: IO_MUX,
     #[doc = "LCD_CAM"]
-    pub LCD_CAM: LCD_CAM,
+    pub lcd_cam: LCD_CAM,
     #[doc = "LEDC"]
-    pub LEDC: LEDC,
+    pub ledc: LEDC,
     #[doc = "PCNT"]
-    pub PCNT: PCNT,
+    pub pcnt: PCNT,
     #[doc = "PERI_BACKUP"]
-    pub PERI_BACKUP: PERI_BACKUP,
+    pub peri_backup: PERI_BACKUP,
     #[doc = "MCPWM0"]
-    pub MCPWM0: MCPWM0,
+    pub mcpwm0: MCPWM0,
     #[doc = "MCPWM1"]
-    pub MCPWM1: MCPWM1,
+    pub mcpwm1: MCPWM1,
     #[doc = "RMT"]
-    pub RMT: RMT,
+    pub rmt: RMT,
     #[doc = "RNG"]
-    pub RNG: RNG,
+    pub rng: RNG,
     #[doc = "RSA"]
-    pub RSA: RSA,
+    pub rsa: RSA,
     #[doc = "RTC_CNTL"]
-    pub RTC_CNTL: RTC_CNTL,
+    pub rtc_cntl: RTC_CNTL,
     #[doc = "RTC_I2C"]
-    pub RTC_I2C: RTC_I2C,
+    pub rtc_i2c: RTC_I2C,
     #[doc = "RTC_IO"]
-    pub RTC_IO: RTC_IO,
+    pub rtc_io: RTC_IO,
     #[doc = "SDHOST"]
-    pub SDHOST: SDHOST,
+    pub sdhost: SDHOST,
     #[doc = "SENS"]
-    pub SENS: SENS,
+    pub sens: SENS,
     #[doc = "SENSITIVE"]
-    pub SENSITIVE: SENSITIVE,
+    pub sensitive: SENSITIVE,
     #[doc = "SHA"]
-    pub SHA: SHA,
+    pub sha: SHA,
     #[doc = "SPI0"]
-    pub SPI0: SPI0,
+    pub spi0: SPI0,
     #[doc = "SPI1"]
-    pub SPI1: SPI1,
+    pub spi1: SPI1,
     #[doc = "SPI2"]
-    pub SPI2: SPI2,
+    pub spi2: SPI2,
     #[doc = "SPI3"]
-    pub SPI3: SPI3,
+    pub spi3: SPI3,
     #[doc = "SYSTEM"]
-    pub SYSTEM: SYSTEM,
+    pub system: SYSTEM,
     #[doc = "SYSTIMER"]
-    pub SYSTIMER: SYSTIMER,
+    pub systimer: SYSTIMER,
     #[doc = "TIMG0"]
-    pub TIMG0: TIMG0,
+    pub timg0: TIMG0,
     #[doc = "TIMG1"]
-    pub TIMG1: TIMG1,
+    pub timg1: TIMG1,
     #[doc = "TWAI0"]
-    pub TWAI0: TWAI0,
+    pub twai0: TWAI0,
     #[doc = "UART0"]
-    pub UART0: UART0,
+    pub uart0: UART0,
     #[doc = "UART1"]
-    pub UART1: UART1,
+    pub uart1: UART1,
     #[doc = "UART2"]
-    pub UART2: UART2,
+    pub uart2: UART2,
     #[doc = "UHCI0"]
-    pub UHCI0: UHCI0,
+    pub uhci0: UHCI0,
     #[doc = "UHCI1"]
-    pub UHCI1: UHCI1,
+    pub uhci1: UHCI1,
     #[doc = "USB0"]
-    pub USB0: USB0,
+    pub usb0: USB0,
     #[doc = "USB_DEVICE"]
-    pub USB_DEVICE: USB_DEVICE,
+    pub usb_device: USB_DEVICE,
     #[doc = "USB_WRAP"]
-    pub USB_WRAP: USB_WRAP,
+    pub usb_wrap: USB_WRAP,
     #[doc = "WCL"]
-    pub WCL: WCL,
+    pub wcl: WCL,
     #[doc = "XTS_AES"]
-    pub XTS_AES: XTS_AES,
+    pub xts_aes: XTS_AES,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -3243,166 +3243,166 @@ impl Peripherals {
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {
-            AES: AES {
+            aes: AES {
                 _marker: PhantomData,
             },
-            APB_CTRL: APB_CTRL {
+            apb_ctrl: APB_CTRL {
                 _marker: PhantomData,
             },
-            APB_SARADC: APB_SARADC {
+            apb_saradc: APB_SARADC {
                 _marker: PhantomData,
             },
-            BB: BB {
+            bb: BB {
                 _marker: PhantomData,
             },
-            ASSIST_DEBUG: ASSIST_DEBUG {
+            assist_debug: ASSIST_DEBUG {
                 _marker: PhantomData,
             },
-            DMA: DMA {
+            dma: DMA {
                 _marker: PhantomData,
             },
-            DS: DS {
+            ds: DS {
                 _marker: PhantomData,
             },
-            EFUSE: EFUSE {
+            efuse: EFUSE {
                 _marker: PhantomData,
             },
-            EXTMEM: EXTMEM {
+            extmem: EXTMEM {
                 _marker: PhantomData,
             },
-            GPIO: GPIO {
+            gpio: GPIO {
                 _marker: PhantomData,
             },
-            GPIO_SD: GPIO_SD {
+            gpio_sd: GPIO_SD {
                 _marker: PhantomData,
             },
-            HMAC: HMAC {
+            hmac: HMAC {
                 _marker: PhantomData,
             },
-            I2C0: I2C0 {
+            i2c0: I2C0 {
                 _marker: PhantomData,
             },
-            I2C1: I2C1 {
+            i2c1: I2C1 {
                 _marker: PhantomData,
             },
-            I2S0: I2S0 {
+            i2s0: I2S0 {
                 _marker: PhantomData,
             },
-            I2S1: I2S1 {
+            i2s1: I2S1 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE0: INTERRUPT_CORE0 {
+            interrupt_core0: INTERRUPT_CORE0 {
                 _marker: PhantomData,
             },
-            INTERRUPT_CORE1: INTERRUPT_CORE1 {
+            interrupt_core1: INTERRUPT_CORE1 {
                 _marker: PhantomData,
             },
-            IO_MUX: IO_MUX {
+            io_mux: IO_MUX {
                 _marker: PhantomData,
             },
-            LCD_CAM: LCD_CAM {
+            lcd_cam: LCD_CAM {
                 _marker: PhantomData,
             },
-            LEDC: LEDC {
+            ledc: LEDC {
                 _marker: PhantomData,
             },
-            PCNT: PCNT {
+            pcnt: PCNT {
                 _marker: PhantomData,
             },
-            PERI_BACKUP: PERI_BACKUP {
+            peri_backup: PERI_BACKUP {
                 _marker: PhantomData,
             },
-            MCPWM0: MCPWM0 {
+            mcpwm0: MCPWM0 {
                 _marker: PhantomData,
             },
-            MCPWM1: MCPWM1 {
+            mcpwm1: MCPWM1 {
                 _marker: PhantomData,
             },
-            RMT: RMT {
+            rmt: RMT {
                 _marker: PhantomData,
             },
-            RNG: RNG {
+            rng: RNG {
                 _marker: PhantomData,
             },
-            RSA: RSA {
+            rsa: RSA {
                 _marker: PhantomData,
             },
-            RTC_CNTL: RTC_CNTL {
+            rtc_cntl: RTC_CNTL {
                 _marker: PhantomData,
             },
-            RTC_I2C: RTC_I2C {
+            rtc_i2c: RTC_I2C {
                 _marker: PhantomData,
             },
-            RTC_IO: RTC_IO {
+            rtc_io: RTC_IO {
                 _marker: PhantomData,
             },
-            SDHOST: SDHOST {
+            sdhost: SDHOST {
                 _marker: PhantomData,
             },
-            SENS: SENS {
+            sens: SENS {
                 _marker: PhantomData,
             },
-            SENSITIVE: SENSITIVE {
+            sensitive: SENSITIVE {
                 _marker: PhantomData,
             },
-            SHA: SHA {
+            sha: SHA {
                 _marker: PhantomData,
             },
-            SPI0: SPI0 {
+            spi0: SPI0 {
                 _marker: PhantomData,
             },
-            SPI1: SPI1 {
+            spi1: SPI1 {
                 _marker: PhantomData,
             },
-            SPI2: SPI2 {
+            spi2: SPI2 {
                 _marker: PhantomData,
             },
-            SPI3: SPI3 {
+            spi3: SPI3 {
                 _marker: PhantomData,
             },
-            SYSTEM: SYSTEM {
+            system: SYSTEM {
                 _marker: PhantomData,
             },
-            SYSTIMER: SYSTIMER {
+            systimer: SYSTIMER {
                 _marker: PhantomData,
             },
-            TIMG0: TIMG0 {
+            timg0: TIMG0 {
                 _marker: PhantomData,
             },
-            TIMG1: TIMG1 {
+            timg1: TIMG1 {
                 _marker: PhantomData,
             },
-            TWAI0: TWAI0 {
+            twai0: TWAI0 {
                 _marker: PhantomData,
             },
-            UART0: UART0 {
+            uart0: UART0 {
                 _marker: PhantomData,
             },
-            UART1: UART1 {
+            uart1: UART1 {
                 _marker: PhantomData,
             },
-            UART2: UART2 {
+            uart2: UART2 {
                 _marker: PhantomData,
             },
-            UHCI0: UHCI0 {
+            uhci0: UHCI0 {
                 _marker: PhantomData,
             },
-            UHCI1: UHCI1 {
+            uhci1: UHCI1 {
                 _marker: PhantomData,
             },
-            USB0: USB0 {
+            usb0: USB0 {
                 _marker: PhantomData,
             },
-            USB_DEVICE: USB_DEVICE {
+            usb_device: USB_DEVICE {
                 _marker: PhantomData,
             },
-            USB_WRAP: USB_WRAP {
+            usb_wrap: USB_WRAP {
                 _marker: PhantomData,
             },
-            WCL: WCL {
+            wcl: WCL {
                 _marker: PhantomData,
             },
-            XTS_AES: XTS_AES {
+            xts_aes: XTS_AES {
                 _marker: PhantomData,
             },
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -174,7 +174,8 @@ fn patch_svd(workspace: &Path, chip: &Chip) -> Result<()> {
 
     let svd_path = workspace.join(chip.to_string()).join("svd");
     let yaml_file = svd_path.join("patches").join(format!("{chip}.yaml"));
-    let config = PatchConfig::default();
+    let mut config = PatchConfig::default();
+    config.enum_derive = svdtools::patch::EnumAutoDerive::Field;
     svdtools::patch::process_file(&yaml_file, None, None, &config)?;
 
     let from = svd_path.join(format!("{chip}.base.svd.patched"));
@@ -223,11 +224,9 @@ fn generate_package(workspace: &Path, chip: &Chip) -> Result<()> {
         Some(IdentFormatsTheme::Legacy) => IdentFormats::legacy_theme(),
         _ => IdentFormats::default_theme(),
     };
-    ident_formats.insert("enum_name".into(), IdentFormat::default().constant_case());
-    ident_formats.insert(
-        "enum_read_name".into(),
-        IdentFormat::default().constant_case(),
-    );
+    ident_formats.insert("peripheral_singleton".into(), IdentFormat::default().snake_case());
+    ident_formats.insert("enum_name".into(), IdentFormat::default());
+    ident_formats.insert("enum_read_name".into(), IdentFormat::default());
     ident_formats.insert("enum_value".into(), IdentFormat::default().pascal_case());
     ident_formats.extend(config.ident_formats.drain());
     config.ident_formats = ident_formats;


### PR DESCRIPTION
Do not change case of enum names and values, autoderive fields instead of enums (on common enum rule).