### PR TITLE
ESP32-H2: Fix 802.15.4 base-address

### DIFF
--- a/esp32h2/src/lib.rs
+++ b/esp32h2/src/lib.rs
@@ -922,7 +922,7 @@ pub struct IEEE802154 {
 unsafe impl Send for IEEE802154 {}
 impl IEEE802154 {
     #[doc = r"Pointer to the register block"]
-    pub const PTR: *const ieee802154::RegisterBlock = 0x6004_7000 as *const _;
+    pub const PTR: *const ieee802154::RegisterBlock = 0x600a_3000 as *const _;
     #[doc = r"Return the pointer to the register block"]
     #[inline(always)]
     pub const fn ptr() -> *const ieee802154::RegisterBlock {

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -295,3 +295,7 @@ TWAI0:
         name: TX_BYTE_11
       DATA_12:
         name: TX_BYTE_12
+
+_modify:
+  IEEE802154:
+    baseAddress: 0x600A3000


### PR DESCRIPTION
The base-address for 802.15.4 was wrong for ESP32-H2 - fixed via patch
