### PR TITLE
Add PMU for ESP32C6-LP

### DIFF
--- a/esp32c6-lp/device.x
+++ b/esp32c6-lp/device.x
@@ -1,4 +1,5 @@
 PROVIDE(LP_TIMER = DefaultHandler);
+PROVIDE(PMU = DefaultHandler);
 PROVIDE(LP_UART = DefaultHandler);
 PROVIDE(LP_I2C = DefaultHandler);
 PROVIDE(LP_WDT = DefaultHandler);

--- a/esp32c6-lp/src/interrupt.rs
+++ b/esp32c6-lp/src/interrupt.rs
@@ -5,6 +5,8 @@
 pub enum Interrupt {
     #[doc = "7 - LP_TIMER"]
     LP_TIMER = 7,
+    #[doc = "13 - PMU"]
+    PMU = 13,
     #[doc = "16 - LP_UART"]
     LP_UART = 16,
     #[doc = "17 - LP_I2C"]
@@ -27,6 +29,7 @@ impl Interrupt {
     pub fn try_from(value: u8) -> Result<Self, TryFromInterruptError> {
         match value {
             7 => Ok(Interrupt::LP_TIMER),
+            13 => Ok(Interrupt::PMU),
             16 => Ok(Interrupt::LP_UART),
             17 => Ok(Interrupt::LP_I2C),
             18 => Ok(Interrupt::LP_WDT),

--- a/esp32c6-lp/src/lib.rs
+++ b/esp32c6-lp/src/lib.rs
@@ -14,6 +14,7 @@ pub mod generic;
 #[cfg(feature = "rt")]
 extern "C" {
     fn LP_TIMER();
+    fn PMU();
     fn LP_UART();
     fn LP_I2C();
     fn LP_WDT();
@@ -45,7 +46,7 @@ pub static __EXTERNAL_INTERRUPTS: [Vector; 22] = [
     Vector { _reserved: 0 },
     Vector { _reserved: 0 },
     Vector { _reserved: 0 },
-    Vector { _reserved: 0 },
+    Vector { _handler: PMU },
     Vector { _reserved: 0 },
     Vector { _reserved: 0 },
     Vector { _handler: LP_UART },
@@ -616,6 +617,52 @@ impl core::fmt::Debug for LP_WDT {
 }
 #[doc = "Low-power Watchdog Timer"]
 pub mod lp_wdt;
+#[doc = "PMU Peripheral"]
+pub struct PMU {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PMU {}
+impl PMU {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const pmu::RegisterBlock = 0x600b_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const pmu::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for PMU {
+    type Target = pmu::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for PMU {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PMU").finish()
+    }
+}
+#[doc = "PMU Peripheral"]
+pub mod pmu;
 #[no_mangle]
 static mut DEVICE_PERIPHERALS: bool = false;
 #[doc = r" All the peripherals."]
@@ -645,6 +692,8 @@ pub struct Peripherals {
     pub LP_UART: LP_UART,
     #[doc = "LP_WDT"]
     pub LP_WDT: LP_WDT,
+    #[doc = "PMU"]
+    pub PMU: PMU,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -701,6 +750,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             LP_WDT: LP_WDT {
+                _marker: PhantomData,
+            },
+            PMU: PMU {
                 _marker: PhantomData,
             },
         }

--- a/esp32c6-lp/src/pmu.rs
+++ b/esp32c6-lp/src/pmu.rs
@@ -1,0 +1,1073 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    hp_active_dig_power: HP_ACTIVE_DIG_POWER,
+    hp_active_icg_hp_func: HP_ACTIVE_ICG_HP_FUNC,
+    hp_active_icg_hp_apb: HP_ACTIVE_ICG_HP_APB,
+    hp_active_icg_modem: HP_ACTIVE_ICG_MODEM,
+    hp_active_hp_sys_cntl: HP_ACTIVE_HP_SYS_CNTL,
+    hp_active_hp_ck_power: HP_ACTIVE_HP_CK_POWER,
+    hp_active_bias: HP_ACTIVE_BIAS,
+    hp_active_backup: HP_ACTIVE_BACKUP,
+    hp_active_backup_clk: HP_ACTIVE_BACKUP_CLK,
+    hp_active_sysclk: HP_ACTIVE_SYSCLK,
+    hp_active_hp_regulator0: HP_ACTIVE_HP_REGULATOR0,
+    hp_active_hp_regulator1: HP_ACTIVE_HP_REGULATOR1,
+    hp_active_xtal: HP_ACTIVE_XTAL,
+    hp_modem_dig_power: HP_MODEM_DIG_POWER,
+    hp_modem_icg_hp_func: HP_MODEM_ICG_HP_FUNC,
+    hp_modem_icg_hp_apb: HP_MODEM_ICG_HP_APB,
+    hp_modem_icg_modem: HP_MODEM_ICG_MODEM,
+    hp_modem_hp_sys_cntl: HP_MODEM_HP_SYS_CNTL,
+    hp_modem_hp_ck_power: HP_MODEM_HP_CK_POWER,
+    hp_modem_bias: HP_MODEM_BIAS,
+    hp_modem_backup: HP_MODEM_BACKUP,
+    hp_modem_backup_clk: HP_MODEM_BACKUP_CLK,
+    hp_modem_sysclk: HP_MODEM_SYSCLK,
+    hp_modem_hp_regulator0: HP_MODEM_HP_REGULATOR0,
+    hp_modem_hp_regulator1: HP_MODEM_HP_REGULATOR1,
+    hp_modem_xtal: HP_MODEM_XTAL,
+    hp_sleep_dig_power: HP_SLEEP_DIG_POWER,
+    hp_sleep_icg_hp_func: HP_SLEEP_ICG_HP_FUNC,
+    hp_sleep_icg_hp_apb: HP_SLEEP_ICG_HP_APB,
+    hp_sleep_icg_modem: HP_SLEEP_ICG_MODEM,
+    hp_sleep_hp_sys_cntl: HP_SLEEP_HP_SYS_CNTL,
+    hp_sleep_hp_ck_power: HP_SLEEP_HP_CK_POWER,
+    hp_sleep_bias: HP_SLEEP_BIAS,
+    hp_sleep_backup: HP_SLEEP_BACKUP,
+    hp_sleep_backup_clk: HP_SLEEP_BACKUP_CLK,
+    hp_sleep_sysclk: HP_SLEEP_SYSCLK,
+    hp_sleep_hp_regulator0: HP_SLEEP_HP_REGULATOR0,
+    hp_sleep_hp_regulator1: HP_SLEEP_HP_REGULATOR1,
+    hp_sleep_xtal: HP_SLEEP_XTAL,
+    hp_sleep_lp_regulator0: HP_SLEEP_LP_REGULATOR0,
+    hp_sleep_lp_regulator1: HP_SLEEP_LP_REGULATOR1,
+    hp_sleep_lp_dcdc_reserve: HP_SLEEP_LP_DCDC_RESERVE,
+    hp_sleep_lp_dig_power: HP_SLEEP_LP_DIG_POWER,
+    hp_sleep_lp_ck_power: HP_SLEEP_LP_CK_POWER,
+    lp_sleep_lp_bias_reserve: LP_SLEEP_LP_BIAS_RESERVE,
+    lp_sleep_lp_regulator0: LP_SLEEP_LP_REGULATOR0,
+    lp_sleep_lp_regulator1: LP_SLEEP_LP_REGULATOR1,
+    lp_sleep_xtal: LP_SLEEP_XTAL,
+    lp_sleep_lp_dig_power: LP_SLEEP_LP_DIG_POWER,
+    lp_sleep_lp_ck_power: LP_SLEEP_LP_CK_POWER,
+    lp_sleep_bias: LP_SLEEP_BIAS,
+    imm_hp_ck_power: IMM_HP_CK_POWER,
+    imm_sleep_sysclk: IMM_SLEEP_SYSCLK,
+    imm_hp_func_icg: IMM_HP_FUNC_ICG,
+    imm_hp_apb_icg: IMM_HP_APB_ICG,
+    imm_modem_icg: IMM_MODEM_ICG,
+    imm_lp_icg: IMM_LP_ICG,
+    imm_pad_hold_all: IMM_PAD_HOLD_ALL,
+    imm_i2c_iso: IMM_I2C_ISO,
+    power_wait_timer0: POWER_WAIT_TIMER0,
+    power_wait_timer1: POWER_WAIT_TIMER1,
+    power_pd_top_cntl: POWER_PD_TOP_CNTL,
+    power_pd_hpaon_cntl: POWER_PD_HPAON_CNTL,
+    power_pd_hpcpu_cntl: POWER_PD_HPCPU_CNTL,
+    power_pd_hpperi_reserve: POWER_PD_HPPERI_RESERVE,
+    power_pd_hpwifi_cntl: POWER_PD_HPWIFI_CNTL,
+    power_pd_lpperi_cntl: POWER_PD_LPPERI_CNTL,
+    power_pd_mem_cntl: POWER_PD_MEM_CNTL,
+    power_pd_mem_mask: POWER_PD_MEM_MASK,
+    power_hp_pad: POWER_HP_PAD,
+    power_vdd_spi_cntl: POWER_VDD_SPI_CNTL,
+    power_ck_wait_cntl: POWER_CK_WAIT_CNTL,
+    slp_wakeup_cntl0: SLP_WAKEUP_CNTL0,
+    slp_wakeup_cntl1: SLP_WAKEUP_CNTL1,
+    slp_wakeup_cntl2: SLP_WAKEUP_CNTL2,
+    slp_wakeup_cntl3: SLP_WAKEUP_CNTL3,
+    slp_wakeup_cntl4: SLP_WAKEUP_CNTL4,
+    slp_wakeup_cntl5: SLP_WAKEUP_CNTL5,
+    slp_wakeup_cntl6: SLP_WAKEUP_CNTL6,
+    slp_wakeup_cntl7: SLP_WAKEUP_CNTL7,
+    slp_wakeup_status0: SLP_WAKEUP_STATUS0,
+    slp_wakeup_status1: SLP_WAKEUP_STATUS1,
+    hp_ck_poweron: HP_CK_POWERON,
+    hp_ck_cntl: HP_CK_CNTL,
+    por_status: POR_STATUS,
+    rf_pwc: RF_PWC,
+    backup_cfg: BACKUP_CFG,
+    int_raw: INT_RAW,
+    int_st: INT_ST,
+    int_ena: INT_ENA,
+    int_clr: INT_CLR,
+    lp_int_raw: LP_INT_RAW,
+    lp_int_st: LP_INT_ST,
+    lp_int_ena: LP_INT_ENA,
+    lp_int_clr: LP_INT_CLR,
+    lp_cpu_pwr0: LP_CPU_PWR0,
+    lp_cpu_pwr1: LP_CPU_PWR1,
+    hp_lp_cpu_comm: HP_LP_CPU_COMM,
+    hp_regulator_cfg: HP_REGULATOR_CFG,
+    main_state: MAIN_STATE,
+    pwr_state: PWR_STATE,
+    clk_state0: CLK_STATE0,
+    clk_state1: CLK_STATE1,
+    clk_state2: CLK_STATE2,
+    vdd_spi_status: VDD_SPI_STATUS,
+    _reserved105: [u8; 0x0258],
+    date: DATE,
+}
+impl RegisterBlock {
+    #[doc = "0x00 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_dig_power(&self) -> &HP_ACTIVE_DIG_POWER {
+        &self.hp_active_dig_power
+    }
+    #[doc = "0x04 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_icg_hp_func(&self) -> &HP_ACTIVE_ICG_HP_FUNC {
+        &self.hp_active_icg_hp_func
+    }
+    #[doc = "0x08 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_icg_hp_apb(&self) -> &HP_ACTIVE_ICG_HP_APB {
+        &self.hp_active_icg_hp_apb
+    }
+    #[doc = "0x0c - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_icg_modem(&self) -> &HP_ACTIVE_ICG_MODEM {
+        &self.hp_active_icg_modem
+    }
+    #[doc = "0x10 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_hp_sys_cntl(&self) -> &HP_ACTIVE_HP_SYS_CNTL {
+        &self.hp_active_hp_sys_cntl
+    }
+    #[doc = "0x14 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_hp_ck_power(&self) -> &HP_ACTIVE_HP_CK_POWER {
+        &self.hp_active_hp_ck_power
+    }
+    #[doc = "0x18 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_bias(&self) -> &HP_ACTIVE_BIAS {
+        &self.hp_active_bias
+    }
+    #[doc = "0x1c - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_backup(&self) -> &HP_ACTIVE_BACKUP {
+        &self.hp_active_backup
+    }
+    #[doc = "0x20 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_backup_clk(&self) -> &HP_ACTIVE_BACKUP_CLK {
+        &self.hp_active_backup_clk
+    }
+    #[doc = "0x24 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_sysclk(&self) -> &HP_ACTIVE_SYSCLK {
+        &self.hp_active_sysclk
+    }
+    #[doc = "0x28 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_hp_regulator0(&self) -> &HP_ACTIVE_HP_REGULATOR0 {
+        &self.hp_active_hp_regulator0
+    }
+    #[doc = "0x2c - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_hp_regulator1(&self) -> &HP_ACTIVE_HP_REGULATOR1 {
+        &self.hp_active_hp_regulator1
+    }
+    #[doc = "0x30 - need_des"]
+    #[inline(always)]
+    pub const fn hp_active_xtal(&self) -> &HP_ACTIVE_XTAL {
+        &self.hp_active_xtal
+    }
+    #[doc = "0x34 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_dig_power(&self) -> &HP_MODEM_DIG_POWER {
+        &self.hp_modem_dig_power
+    }
+    #[doc = "0x38 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_icg_hp_func(&self) -> &HP_MODEM_ICG_HP_FUNC {
+        &self.hp_modem_icg_hp_func
+    }
+    #[doc = "0x3c - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_icg_hp_apb(&self) -> &HP_MODEM_ICG_HP_APB {
+        &self.hp_modem_icg_hp_apb
+    }
+    #[doc = "0x40 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_icg_modem(&self) -> &HP_MODEM_ICG_MODEM {
+        &self.hp_modem_icg_modem
+    }
+    #[doc = "0x44 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_hp_sys_cntl(&self) -> &HP_MODEM_HP_SYS_CNTL {
+        &self.hp_modem_hp_sys_cntl
+    }
+    #[doc = "0x48 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_hp_ck_power(&self) -> &HP_MODEM_HP_CK_POWER {
+        &self.hp_modem_hp_ck_power
+    }
+    #[doc = "0x4c - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_bias(&self) -> &HP_MODEM_BIAS {
+        &self.hp_modem_bias
+    }
+    #[doc = "0x50 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_backup(&self) -> &HP_MODEM_BACKUP {
+        &self.hp_modem_backup
+    }
+    #[doc = "0x54 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_backup_clk(&self) -> &HP_MODEM_BACKUP_CLK {
+        &self.hp_modem_backup_clk
+    }
+    #[doc = "0x58 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_sysclk(&self) -> &HP_MODEM_SYSCLK {
+        &self.hp_modem_sysclk
+    }
+    #[doc = "0x5c - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_hp_regulator0(&self) -> &HP_MODEM_HP_REGULATOR0 {
+        &self.hp_modem_hp_regulator0
+    }
+    #[doc = "0x60 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_hp_regulator1(&self) -> &HP_MODEM_HP_REGULATOR1 {
+        &self.hp_modem_hp_regulator1
+    }
+    #[doc = "0x64 - need_des"]
+    #[inline(always)]
+    pub const fn hp_modem_xtal(&self) -> &HP_MODEM_XTAL {
+        &self.hp_modem_xtal
+    }
+    #[doc = "0x68 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_dig_power(&self) -> &HP_SLEEP_DIG_POWER {
+        &self.hp_sleep_dig_power
+    }
+    #[doc = "0x6c - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_icg_hp_func(&self) -> &HP_SLEEP_ICG_HP_FUNC {
+        &self.hp_sleep_icg_hp_func
+    }
+    #[doc = "0x70 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_icg_hp_apb(&self) -> &HP_SLEEP_ICG_HP_APB {
+        &self.hp_sleep_icg_hp_apb
+    }
+    #[doc = "0x74 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_icg_modem(&self) -> &HP_SLEEP_ICG_MODEM {
+        &self.hp_sleep_icg_modem
+    }
+    #[doc = "0x78 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_hp_sys_cntl(&self) -> &HP_SLEEP_HP_SYS_CNTL {
+        &self.hp_sleep_hp_sys_cntl
+    }
+    #[doc = "0x7c - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_hp_ck_power(&self) -> &HP_SLEEP_HP_CK_POWER {
+        &self.hp_sleep_hp_ck_power
+    }
+    #[doc = "0x80 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_bias(&self) -> &HP_SLEEP_BIAS {
+        &self.hp_sleep_bias
+    }
+    #[doc = "0x84 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_backup(&self) -> &HP_SLEEP_BACKUP {
+        &self.hp_sleep_backup
+    }
+    #[doc = "0x88 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_backup_clk(&self) -> &HP_SLEEP_BACKUP_CLK {
+        &self.hp_sleep_backup_clk
+    }
+    #[doc = "0x8c - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_sysclk(&self) -> &HP_SLEEP_SYSCLK {
+        &self.hp_sleep_sysclk
+    }
+    #[doc = "0x90 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_hp_regulator0(&self) -> &HP_SLEEP_HP_REGULATOR0 {
+        &self.hp_sleep_hp_regulator0
+    }
+    #[doc = "0x94 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_hp_regulator1(&self) -> &HP_SLEEP_HP_REGULATOR1 {
+        &self.hp_sleep_hp_regulator1
+    }
+    #[doc = "0x98 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_xtal(&self) -> &HP_SLEEP_XTAL {
+        &self.hp_sleep_xtal
+    }
+    #[doc = "0x9c - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_lp_regulator0(&self) -> &HP_SLEEP_LP_REGULATOR0 {
+        &self.hp_sleep_lp_regulator0
+    }
+    #[doc = "0xa0 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_lp_regulator1(&self) -> &HP_SLEEP_LP_REGULATOR1 {
+        &self.hp_sleep_lp_regulator1
+    }
+    #[doc = "0xa4 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_lp_dcdc_reserve(&self) -> &HP_SLEEP_LP_DCDC_RESERVE {
+        &self.hp_sleep_lp_dcdc_reserve
+    }
+    #[doc = "0xa8 - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_lp_dig_power(&self) -> &HP_SLEEP_LP_DIG_POWER {
+        &self.hp_sleep_lp_dig_power
+    }
+    #[doc = "0xac - need_des"]
+    #[inline(always)]
+    pub const fn hp_sleep_lp_ck_power(&self) -> &HP_SLEEP_LP_CK_POWER {
+        &self.hp_sleep_lp_ck_power
+    }
+    #[doc = "0xb0 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_lp_bias_reserve(&self) -> &LP_SLEEP_LP_BIAS_RESERVE {
+        &self.lp_sleep_lp_bias_reserve
+    }
+    #[doc = "0xb4 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_lp_regulator0(&self) -> &LP_SLEEP_LP_REGULATOR0 {
+        &self.lp_sleep_lp_regulator0
+    }
+    #[doc = "0xb8 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_lp_regulator1(&self) -> &LP_SLEEP_LP_REGULATOR1 {
+        &self.lp_sleep_lp_regulator1
+    }
+    #[doc = "0xbc - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_xtal(&self) -> &LP_SLEEP_XTAL {
+        &self.lp_sleep_xtal
+    }
+    #[doc = "0xc0 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_lp_dig_power(&self) -> &LP_SLEEP_LP_DIG_POWER {
+        &self.lp_sleep_lp_dig_power
+    }
+    #[doc = "0xc4 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_lp_ck_power(&self) -> &LP_SLEEP_LP_CK_POWER {
+        &self.lp_sleep_lp_ck_power
+    }
+    #[doc = "0xc8 - need_des"]
+    #[inline(always)]
+    pub const fn lp_sleep_bias(&self) -> &LP_SLEEP_BIAS {
+        &self.lp_sleep_bias
+    }
+    #[doc = "0xcc - need_des"]
+    #[inline(always)]
+    pub const fn imm_hp_ck_power(&self) -> &IMM_HP_CK_POWER {
+        &self.imm_hp_ck_power
+    }
+    #[doc = "0xd0 - need_des"]
+    #[inline(always)]
+    pub const fn imm_sleep_sysclk(&self) -> &IMM_SLEEP_SYSCLK {
+        &self.imm_sleep_sysclk
+    }
+    #[doc = "0xd4 - need_des"]
+    #[inline(always)]
+    pub const fn imm_hp_func_icg(&self) -> &IMM_HP_FUNC_ICG {
+        &self.imm_hp_func_icg
+    }
+    #[doc = "0xd8 - need_des"]
+    #[inline(always)]
+    pub const fn imm_hp_apb_icg(&self) -> &IMM_HP_APB_ICG {
+        &self.imm_hp_apb_icg
+    }
+    #[doc = "0xdc - need_des"]
+    #[inline(always)]
+    pub const fn imm_modem_icg(&self) -> &IMM_MODEM_ICG {
+        &self.imm_modem_icg
+    }
+    #[doc = "0xe0 - need_des"]
+    #[inline(always)]
+    pub const fn imm_lp_icg(&self) -> &IMM_LP_ICG {
+        &self.imm_lp_icg
+    }
+    #[doc = "0xe4 - need_des"]
+    #[inline(always)]
+    pub const fn imm_pad_hold_all(&self) -> &IMM_PAD_HOLD_ALL {
+        &self.imm_pad_hold_all
+    }
+    #[doc = "0xe8 - need_des"]
+    #[inline(always)]
+    pub const fn imm_i2c_iso(&self) -> &IMM_I2C_ISO {
+        &self.imm_i2c_iso
+    }
+    #[doc = "0xec - need_des"]
+    #[inline(always)]
+    pub const fn power_wait_timer0(&self) -> &POWER_WAIT_TIMER0 {
+        &self.power_wait_timer0
+    }
+    #[doc = "0xf0 - need_des"]
+    #[inline(always)]
+    pub const fn power_wait_timer1(&self) -> &POWER_WAIT_TIMER1 {
+        &self.power_wait_timer1
+    }
+    #[doc = "0xf4 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_top_cntl(&self) -> &POWER_PD_TOP_CNTL {
+        &self.power_pd_top_cntl
+    }
+    #[doc = "0xf8 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_hpaon_cntl(&self) -> &POWER_PD_HPAON_CNTL {
+        &self.power_pd_hpaon_cntl
+    }
+    #[doc = "0xfc - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_hpcpu_cntl(&self) -> &POWER_PD_HPCPU_CNTL {
+        &self.power_pd_hpcpu_cntl
+    }
+    #[doc = "0x100 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_hpperi_reserve(&self) -> &POWER_PD_HPPERI_RESERVE {
+        &self.power_pd_hpperi_reserve
+    }
+    #[doc = "0x104 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_hpwifi_cntl(&self) -> &POWER_PD_HPWIFI_CNTL {
+        &self.power_pd_hpwifi_cntl
+    }
+    #[doc = "0x108 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_lpperi_cntl(&self) -> &POWER_PD_LPPERI_CNTL {
+        &self.power_pd_lpperi_cntl
+    }
+    #[doc = "0x10c - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_mem_cntl(&self) -> &POWER_PD_MEM_CNTL {
+        &self.power_pd_mem_cntl
+    }
+    #[doc = "0x110 - need_des"]
+    #[inline(always)]
+    pub const fn power_pd_mem_mask(&self) -> &POWER_PD_MEM_MASK {
+        &self.power_pd_mem_mask
+    }
+    #[doc = "0x114 - need_des"]
+    #[inline(always)]
+    pub const fn power_hp_pad(&self) -> &POWER_HP_PAD {
+        &self.power_hp_pad
+    }
+    #[doc = "0x118 - need_des"]
+    #[inline(always)]
+    pub const fn power_vdd_spi_cntl(&self) -> &POWER_VDD_SPI_CNTL {
+        &self.power_vdd_spi_cntl
+    }
+    #[doc = "0x11c - need_des"]
+    #[inline(always)]
+    pub const fn power_ck_wait_cntl(&self) -> &POWER_CK_WAIT_CNTL {
+        &self.power_ck_wait_cntl
+    }
+    #[doc = "0x120 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl0(&self) -> &SLP_WAKEUP_CNTL0 {
+        &self.slp_wakeup_cntl0
+    }
+    #[doc = "0x124 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl1(&self) -> &SLP_WAKEUP_CNTL1 {
+        &self.slp_wakeup_cntl1
+    }
+    #[doc = "0x128 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl2(&self) -> &SLP_WAKEUP_CNTL2 {
+        &self.slp_wakeup_cntl2
+    }
+    #[doc = "0x12c - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl3(&self) -> &SLP_WAKEUP_CNTL3 {
+        &self.slp_wakeup_cntl3
+    }
+    #[doc = "0x130 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl4(&self) -> &SLP_WAKEUP_CNTL4 {
+        &self.slp_wakeup_cntl4
+    }
+    #[doc = "0x134 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl5(&self) -> &SLP_WAKEUP_CNTL5 {
+        &self.slp_wakeup_cntl5
+    }
+    #[doc = "0x138 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl6(&self) -> &SLP_WAKEUP_CNTL6 {
+        &self.slp_wakeup_cntl6
+    }
+    #[doc = "0x13c - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_cntl7(&self) -> &SLP_WAKEUP_CNTL7 {
+        &self.slp_wakeup_cntl7
+    }
+    #[doc = "0x140 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_status0(&self) -> &SLP_WAKEUP_STATUS0 {
+        &self.slp_wakeup_status0
+    }
+    #[doc = "0x144 - need_des"]
+    #[inline(always)]
+    pub const fn slp_wakeup_status1(&self) -> &SLP_WAKEUP_STATUS1 {
+        &self.slp_wakeup_status1
+    }
+    #[doc = "0x148 - need_des"]
+    #[inline(always)]
+    pub const fn hp_ck_poweron(&self) -> &HP_CK_POWERON {
+        &self.hp_ck_poweron
+    }
+    #[doc = "0x14c - need_des"]
+    #[inline(always)]
+    pub const fn hp_ck_cntl(&self) -> &HP_CK_CNTL {
+        &self.hp_ck_cntl
+    }
+    #[doc = "0x150 - need_des"]
+    #[inline(always)]
+    pub const fn por_status(&self) -> &POR_STATUS {
+        &self.por_status
+    }
+    #[doc = "0x154 - need_des"]
+    #[inline(always)]
+    pub const fn rf_pwc(&self) -> &RF_PWC {
+        &self.rf_pwc
+    }
+    #[doc = "0x158 - need_des"]
+    #[inline(always)]
+    pub const fn backup_cfg(&self) -> &BACKUP_CFG {
+        &self.backup_cfg
+    }
+    #[doc = "0x15c - need_des"]
+    #[inline(always)]
+    pub const fn int_raw(&self) -> &INT_RAW {
+        &self.int_raw
+    }
+    #[doc = "0x160 - need_des"]
+    #[inline(always)]
+    pub const fn int_st(&self) -> &INT_ST {
+        &self.int_st
+    }
+    #[doc = "0x164 - need_des"]
+    #[inline(always)]
+    pub const fn int_ena(&self) -> &INT_ENA {
+        &self.int_ena
+    }
+    #[doc = "0x168 - need_des"]
+    #[inline(always)]
+    pub const fn int_clr(&self) -> &INT_CLR {
+        &self.int_clr
+    }
+    #[doc = "0x16c - need_des"]
+    #[inline(always)]
+    pub const fn lp_int_raw(&self) -> &LP_INT_RAW {
+        &self.lp_int_raw
+    }
+    #[doc = "0x170 - need_des"]
+    #[inline(always)]
+    pub const fn lp_int_st(&self) -> &LP_INT_ST {
+        &self.lp_int_st
+    }
+    #[doc = "0x174 - need_des"]
+    #[inline(always)]
+    pub const fn lp_int_ena(&self) -> &LP_INT_ENA {
+        &self.lp_int_ena
+    }
+    #[doc = "0x178 - need_des"]
+    #[inline(always)]
+    pub const fn lp_int_clr(&self) -> &LP_INT_CLR {
+        &self.lp_int_clr
+    }
+    #[doc = "0x17c - need_des"]
+    #[inline(always)]
+    pub const fn lp_cpu_pwr0(&self) -> &LP_CPU_PWR0 {
+        &self.lp_cpu_pwr0
+    }
+    #[doc = "0x180 - need_des"]
+    #[inline(always)]
+    pub const fn lp_cpu_pwr1(&self) -> &LP_CPU_PWR1 {
+        &self.lp_cpu_pwr1
+    }
+    #[doc = "0x184 - need_des"]
+    #[inline(always)]
+    pub const fn hp_lp_cpu_comm(&self) -> &HP_LP_CPU_COMM {
+        &self.hp_lp_cpu_comm
+    }
+    #[doc = "0x188 - need_des"]
+    #[inline(always)]
+    pub const fn hp_regulator_cfg(&self) -> &HP_REGULATOR_CFG {
+        &self.hp_regulator_cfg
+    }
+    #[doc = "0x18c - need_des"]
+    #[inline(always)]
+    pub const fn main_state(&self) -> &MAIN_STATE {
+        &self.main_state
+    }
+    #[doc = "0x190 - need_des"]
+    #[inline(always)]
+    pub const fn pwr_state(&self) -> &PWR_STATE {
+        &self.pwr_state
+    }
+    #[doc = "0x194 - need_des"]
+    #[inline(always)]
+    pub const fn clk_state0(&self) -> &CLK_STATE0 {
+        &self.clk_state0
+    }
+    #[doc = "0x198 - need_des"]
+    #[inline(always)]
+    pub const fn clk_state1(&self) -> &CLK_STATE1 {
+        &self.clk_state1
+    }
+    #[doc = "0x19c - need_des"]
+    #[inline(always)]
+    pub const fn clk_state2(&self) -> &CLK_STATE2 {
+        &self.clk_state2
+    }
+    #[doc = "0x1a0 - need_des"]
+    #[inline(always)]
+    pub const fn vdd_spi_status(&self) -> &VDD_SPI_STATUS {
+        &self.vdd_spi_status
+    }
+    #[doc = "0x3fc - need_des"]
+    #[inline(always)]
+    pub const fn date(&self) -> &DATE {
+        &self.date
+    }
+}
+#[doc = "HP_ACTIVE_DIG_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_dig_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_dig_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_dig_power`] module"]
+pub type HP_ACTIVE_DIG_POWER = crate::Reg<hp_active_dig_power::HP_ACTIVE_DIG_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_dig_power;
+#[doc = "HP_ACTIVE_ICG_HP_FUNC (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_hp_func::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_hp_func::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_icg_hp_func`] module"]
+pub type HP_ACTIVE_ICG_HP_FUNC = crate::Reg<hp_active_icg_hp_func::HP_ACTIVE_ICG_HP_FUNC_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_icg_hp_func;
+#[doc = "HP_ACTIVE_ICG_HP_APB (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_hp_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_hp_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_icg_hp_apb`] module"]
+pub type HP_ACTIVE_ICG_HP_APB = crate::Reg<hp_active_icg_hp_apb::HP_ACTIVE_ICG_HP_APB_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_icg_hp_apb;
+#[doc = "HP_ACTIVE_ICG_MODEM (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_modem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_modem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_icg_modem`] module"]
+pub type HP_ACTIVE_ICG_MODEM = crate::Reg<hp_active_icg_modem::HP_ACTIVE_ICG_MODEM_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_icg_modem;
+#[doc = "HP_ACTIVE_HP_SYS_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_sys_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_sys_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_hp_sys_cntl`] module"]
+pub type HP_ACTIVE_HP_SYS_CNTL = crate::Reg<hp_active_hp_sys_cntl::HP_ACTIVE_HP_SYS_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_hp_sys_cntl;
+#[doc = "HP_ACTIVE_HP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_hp_ck_power`] module"]
+pub type HP_ACTIVE_HP_CK_POWER = crate::Reg<hp_active_hp_ck_power::HP_ACTIVE_HP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_hp_ck_power;
+#[doc = "HP_ACTIVE_BIAS (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_bias::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_bias::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_bias`] module"]
+pub type HP_ACTIVE_BIAS = crate::Reg<hp_active_bias::HP_ACTIVE_BIAS_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_bias;
+#[doc = "HP_ACTIVE_BACKUP (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_backup::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_backup::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_backup`] module"]
+pub type HP_ACTIVE_BACKUP = crate::Reg<hp_active_backup::HP_ACTIVE_BACKUP_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_backup;
+#[doc = "HP_ACTIVE_BACKUP_CLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_backup_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_backup_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_backup_clk`] module"]
+pub type HP_ACTIVE_BACKUP_CLK = crate::Reg<hp_active_backup_clk::HP_ACTIVE_BACKUP_CLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_backup_clk;
+#[doc = "HP_ACTIVE_SYSCLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_sysclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_sysclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_sysclk`] module"]
+pub type HP_ACTIVE_SYSCLK = crate::Reg<hp_active_sysclk::HP_ACTIVE_SYSCLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_sysclk;
+#[doc = "HP_ACTIVE_HP_REGULATOR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_regulator0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_regulator0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_hp_regulator0`] module"]
+pub type HP_ACTIVE_HP_REGULATOR0 =
+    crate::Reg<hp_active_hp_regulator0::HP_ACTIVE_HP_REGULATOR0_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_hp_regulator0;
+#[doc = "HP_ACTIVE_HP_REGULATOR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_regulator1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_regulator1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_hp_regulator1`] module"]
+pub type HP_ACTIVE_HP_REGULATOR1 =
+    crate::Reg<hp_active_hp_regulator1::HP_ACTIVE_HP_REGULATOR1_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_hp_regulator1;
+#[doc = "HP_ACTIVE_XTAL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_xtal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_xtal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_active_xtal`] module"]
+pub type HP_ACTIVE_XTAL = crate::Reg<hp_active_xtal::HP_ACTIVE_XTAL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_active_xtal;
+#[doc = "HP_MODEM_DIG_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_dig_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_dig_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_dig_power`] module"]
+pub type HP_MODEM_DIG_POWER = crate::Reg<hp_modem_dig_power::HP_MODEM_DIG_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_dig_power;
+#[doc = "HP_MODEM_ICG_HP_FUNC (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_hp_func::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_hp_func::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_icg_hp_func`] module"]
+pub type HP_MODEM_ICG_HP_FUNC = crate::Reg<hp_modem_icg_hp_func::HP_MODEM_ICG_HP_FUNC_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_icg_hp_func;
+#[doc = "HP_MODEM_ICG_HP_APB (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_hp_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_hp_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_icg_hp_apb`] module"]
+pub type HP_MODEM_ICG_HP_APB = crate::Reg<hp_modem_icg_hp_apb::HP_MODEM_ICG_HP_APB_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_icg_hp_apb;
+#[doc = "HP_MODEM_ICG_MODEM (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_modem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_modem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_icg_modem`] module"]
+pub type HP_MODEM_ICG_MODEM = crate::Reg<hp_modem_icg_modem::HP_MODEM_ICG_MODEM_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_icg_modem;
+#[doc = "HP_MODEM_HP_SYS_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_sys_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_sys_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_hp_sys_cntl`] module"]
+pub type HP_MODEM_HP_SYS_CNTL = crate::Reg<hp_modem_hp_sys_cntl::HP_MODEM_HP_SYS_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_hp_sys_cntl;
+#[doc = "HP_MODEM_HP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_hp_ck_power`] module"]
+pub type HP_MODEM_HP_CK_POWER = crate::Reg<hp_modem_hp_ck_power::HP_MODEM_HP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_hp_ck_power;
+#[doc = "HP_MODEM_BIAS (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_bias::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_bias::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_bias`] module"]
+pub type HP_MODEM_BIAS = crate::Reg<hp_modem_bias::HP_MODEM_BIAS_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_bias;
+#[doc = "HP_MODEM_BACKUP (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_backup::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_backup::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_backup`] module"]
+pub type HP_MODEM_BACKUP = crate::Reg<hp_modem_backup::HP_MODEM_BACKUP_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_backup;
+#[doc = "HP_MODEM_BACKUP_CLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_backup_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_backup_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_backup_clk`] module"]
+pub type HP_MODEM_BACKUP_CLK = crate::Reg<hp_modem_backup_clk::HP_MODEM_BACKUP_CLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_backup_clk;
+#[doc = "HP_MODEM_SYSCLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_sysclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_sysclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_sysclk`] module"]
+pub type HP_MODEM_SYSCLK = crate::Reg<hp_modem_sysclk::HP_MODEM_SYSCLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_sysclk;
+#[doc = "HP_MODEM_HP_REGULATOR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_regulator0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_regulator0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_hp_regulator0`] module"]
+pub type HP_MODEM_HP_REGULATOR0 = crate::Reg<hp_modem_hp_regulator0::HP_MODEM_HP_REGULATOR0_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_hp_regulator0;
+#[doc = "HP_MODEM_HP_REGULATOR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_regulator1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_regulator1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_hp_regulator1`] module"]
+pub type HP_MODEM_HP_REGULATOR1 = crate::Reg<hp_modem_hp_regulator1::HP_MODEM_HP_REGULATOR1_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_hp_regulator1;
+#[doc = "HP_MODEM_XTAL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_xtal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_xtal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_modem_xtal`] module"]
+pub type HP_MODEM_XTAL = crate::Reg<hp_modem_xtal::HP_MODEM_XTAL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_modem_xtal;
+#[doc = "HP_SLEEP_DIG_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_dig_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_dig_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_dig_power`] module"]
+pub type HP_SLEEP_DIG_POWER = crate::Reg<hp_sleep_dig_power::HP_SLEEP_DIG_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_dig_power;
+#[doc = "HP_SLEEP_ICG_HP_FUNC (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_hp_func::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_hp_func::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_icg_hp_func`] module"]
+pub type HP_SLEEP_ICG_HP_FUNC = crate::Reg<hp_sleep_icg_hp_func::HP_SLEEP_ICG_HP_FUNC_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_icg_hp_func;
+#[doc = "HP_SLEEP_ICG_HP_APB (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_hp_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_hp_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_icg_hp_apb`] module"]
+pub type HP_SLEEP_ICG_HP_APB = crate::Reg<hp_sleep_icg_hp_apb::HP_SLEEP_ICG_HP_APB_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_icg_hp_apb;
+#[doc = "HP_SLEEP_ICG_MODEM (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_modem::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_modem::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_icg_modem`] module"]
+pub type HP_SLEEP_ICG_MODEM = crate::Reg<hp_sleep_icg_modem::HP_SLEEP_ICG_MODEM_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_icg_modem;
+#[doc = "HP_SLEEP_HP_SYS_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_sys_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_sys_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_hp_sys_cntl`] module"]
+pub type HP_SLEEP_HP_SYS_CNTL = crate::Reg<hp_sleep_hp_sys_cntl::HP_SLEEP_HP_SYS_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_hp_sys_cntl;
+#[doc = "HP_SLEEP_HP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_hp_ck_power`] module"]
+pub type HP_SLEEP_HP_CK_POWER = crate::Reg<hp_sleep_hp_ck_power::HP_SLEEP_HP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_hp_ck_power;
+#[doc = "HP_SLEEP_BIAS (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_bias::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_bias::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_bias`] module"]
+pub type HP_SLEEP_BIAS = crate::Reg<hp_sleep_bias::HP_SLEEP_BIAS_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_bias;
+#[doc = "HP_SLEEP_BACKUP (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_backup::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_backup::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_backup`] module"]
+pub type HP_SLEEP_BACKUP = crate::Reg<hp_sleep_backup::HP_SLEEP_BACKUP_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_backup;
+#[doc = "HP_SLEEP_BACKUP_CLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_backup_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_backup_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_backup_clk`] module"]
+pub type HP_SLEEP_BACKUP_CLK = crate::Reg<hp_sleep_backup_clk::HP_SLEEP_BACKUP_CLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_backup_clk;
+#[doc = "HP_SLEEP_SYSCLK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_sysclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_sysclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_sysclk`] module"]
+pub type HP_SLEEP_SYSCLK = crate::Reg<hp_sleep_sysclk::HP_SLEEP_SYSCLK_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_sysclk;
+#[doc = "HP_SLEEP_HP_REGULATOR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_regulator0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_regulator0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_hp_regulator0`] module"]
+pub type HP_SLEEP_HP_REGULATOR0 = crate::Reg<hp_sleep_hp_regulator0::HP_SLEEP_HP_REGULATOR0_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_hp_regulator0;
+#[doc = "HP_SLEEP_HP_REGULATOR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_regulator1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_regulator1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_hp_regulator1`] module"]
+pub type HP_SLEEP_HP_REGULATOR1 = crate::Reg<hp_sleep_hp_regulator1::HP_SLEEP_HP_REGULATOR1_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_hp_regulator1;
+#[doc = "HP_SLEEP_XTAL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_xtal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_xtal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_xtal`] module"]
+pub type HP_SLEEP_XTAL = crate::Reg<hp_sleep_xtal::HP_SLEEP_XTAL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_xtal;
+#[doc = "HP_SLEEP_LP_REGULATOR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_regulator0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_regulator0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_lp_regulator0`] module"]
+pub type HP_SLEEP_LP_REGULATOR0 = crate::Reg<hp_sleep_lp_regulator0::HP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_lp_regulator0;
+#[doc = "HP_SLEEP_LP_REGULATOR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_regulator1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_regulator1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_lp_regulator1`] module"]
+pub type HP_SLEEP_LP_REGULATOR1 = crate::Reg<hp_sleep_lp_regulator1::HP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_lp_regulator1;
+#[doc = "HP_SLEEP_LP_DCDC_RESERVE (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_dcdc_reserve::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_lp_dcdc_reserve`] module"]
+pub type HP_SLEEP_LP_DCDC_RESERVE =
+    crate::Reg<hp_sleep_lp_dcdc_reserve::HP_SLEEP_LP_DCDC_RESERVE_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_lp_dcdc_reserve;
+#[doc = "HP_SLEEP_LP_DIG_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_dig_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_dig_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_lp_dig_power`] module"]
+pub type HP_SLEEP_LP_DIG_POWER = crate::Reg<hp_sleep_lp_dig_power::HP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_lp_dig_power;
+#[doc = "HP_SLEEP_LP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_sleep_lp_ck_power`] module"]
+pub type HP_SLEEP_LP_CK_POWER = crate::Reg<hp_sleep_lp_ck_power::HP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod hp_sleep_lp_ck_power;
+#[doc = "LP_SLEEP_LP_BIAS_RESERVE (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_bias_reserve::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_lp_bias_reserve`] module"]
+pub type LP_SLEEP_LP_BIAS_RESERVE =
+    crate::Reg<lp_sleep_lp_bias_reserve::LP_SLEEP_LP_BIAS_RESERVE_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_lp_bias_reserve;
+#[doc = "LP_SLEEP_LP_REGULATOR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_regulator0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_regulator0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_lp_regulator0`] module"]
+pub type LP_SLEEP_LP_REGULATOR0 = crate::Reg<lp_sleep_lp_regulator0::LP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_lp_regulator0;
+#[doc = "LP_SLEEP_LP_REGULATOR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_regulator1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_regulator1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_lp_regulator1`] module"]
+pub type LP_SLEEP_LP_REGULATOR1 = crate::Reg<lp_sleep_lp_regulator1::LP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_lp_regulator1;
+#[doc = "LP_SLEEP_XTAL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_xtal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_xtal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_xtal`] module"]
+pub type LP_SLEEP_XTAL = crate::Reg<lp_sleep_xtal::LP_SLEEP_XTAL_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_xtal;
+#[doc = "LP_SLEEP_LP_DIG_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_dig_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_dig_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_lp_dig_power`] module"]
+pub type LP_SLEEP_LP_DIG_POWER = crate::Reg<lp_sleep_lp_dig_power::LP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_lp_dig_power;
+#[doc = "LP_SLEEP_LP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_lp_ck_power`] module"]
+pub type LP_SLEEP_LP_CK_POWER = crate::Reg<lp_sleep_lp_ck_power::LP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_lp_ck_power;
+#[doc = "LP_SLEEP_BIAS (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_bias::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_bias::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_sleep_bias`] module"]
+pub type LP_SLEEP_BIAS = crate::Reg<lp_sleep_bias::LP_SLEEP_BIAS_SPEC>;
+#[doc = "need_des"]
+pub mod lp_sleep_bias;
+#[doc = "IMM_HP_CK_POWER (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`imm_hp_ck_power::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_ck_power::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_hp_ck_power`] module"]
+pub type IMM_HP_CK_POWER = crate::Reg<imm_hp_ck_power::IMM_HP_CK_POWER_SPEC>;
+#[doc = "need_des"]
+pub mod imm_hp_ck_power;
+#[doc = "IMM_SLEEP_SYSCLK (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_sleep_sysclk::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_sleep_sysclk`] module"]
+pub type IMM_SLEEP_SYSCLK = crate::Reg<imm_sleep_sysclk::IMM_SLEEP_SYSCLK_SPEC>;
+#[doc = "need_des"]
+pub mod imm_sleep_sysclk;
+#[doc = "IMM_HP_FUNC_ICG (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_func_icg::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_hp_func_icg`] module"]
+pub type IMM_HP_FUNC_ICG = crate::Reg<imm_hp_func_icg::IMM_HP_FUNC_ICG_SPEC>;
+#[doc = "need_des"]
+pub mod imm_hp_func_icg;
+#[doc = "IMM_HP_APB_ICG (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_apb_icg::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_hp_apb_icg`] module"]
+pub type IMM_HP_APB_ICG = crate::Reg<imm_hp_apb_icg::IMM_HP_APB_ICG_SPEC>;
+#[doc = "need_des"]
+pub mod imm_hp_apb_icg;
+#[doc = "IMM_MODEM_ICG (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_modem_icg::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_modem_icg`] module"]
+pub type IMM_MODEM_ICG = crate::Reg<imm_modem_icg::IMM_MODEM_ICG_SPEC>;
+#[doc = "need_des"]
+pub mod imm_modem_icg;
+#[doc = "IMM_LP_ICG (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_lp_icg::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_lp_icg`] module"]
+pub type IMM_LP_ICG = crate::Reg<imm_lp_icg::IMM_LP_ICG_SPEC>;
+#[doc = "need_des"]
+pub mod imm_lp_icg;
+#[doc = "IMM_PAD_HOLD_ALL (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_pad_hold_all::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_pad_hold_all`] module"]
+pub type IMM_PAD_HOLD_ALL = crate::Reg<imm_pad_hold_all::IMM_PAD_HOLD_ALL_SPEC>;
+#[doc = "need_des"]
+pub mod imm_pad_hold_all;
+#[doc = "IMM_I2C_ISO (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_i2c_iso::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@imm_i2c_iso`] module"]
+pub type IMM_I2C_ISO = crate::Reg<imm_i2c_iso::IMM_I2C_ISO_SPEC>;
+#[doc = "need_des"]
+pub mod imm_i2c_iso;
+#[doc = "POWER_WAIT_TIMER0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_wait_timer0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_wait_timer0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_wait_timer0`] module"]
+pub type POWER_WAIT_TIMER0 = crate::Reg<power_wait_timer0::POWER_WAIT_TIMER0_SPEC>;
+#[doc = "need_des"]
+pub mod power_wait_timer0;
+#[doc = "POWER_WAIT_TIMER1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_wait_timer1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_wait_timer1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_wait_timer1`] module"]
+pub type POWER_WAIT_TIMER1 = crate::Reg<power_wait_timer1::POWER_WAIT_TIMER1_SPEC>;
+#[doc = "need_des"]
+pub mod power_wait_timer1;
+#[doc = "POWER_PD_TOP_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_top_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_top_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_top_cntl`] module"]
+pub type POWER_PD_TOP_CNTL = crate::Reg<power_pd_top_cntl::POWER_PD_TOP_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_top_cntl;
+#[doc = "POWER_PD_HPAON_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpaon_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpaon_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_hpaon_cntl`] module"]
+pub type POWER_PD_HPAON_CNTL = crate::Reg<power_pd_hpaon_cntl::POWER_PD_HPAON_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_hpaon_cntl;
+#[doc = "POWER_PD_HPCPU_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpcpu_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpcpu_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_hpcpu_cntl`] module"]
+pub type POWER_PD_HPCPU_CNTL = crate::Reg<power_pd_hpcpu_cntl::POWER_PD_HPCPU_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_hpcpu_cntl;
+#[doc = "POWER_PD_HPPERI_RESERVE (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpperi_reserve::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_hpperi_reserve`] module"]
+pub type POWER_PD_HPPERI_RESERVE =
+    crate::Reg<power_pd_hpperi_reserve::POWER_PD_HPPERI_RESERVE_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_hpperi_reserve;
+#[doc = "POWER_PD_HPWIFI_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpwifi_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpwifi_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_hpwifi_cntl`] module"]
+pub type POWER_PD_HPWIFI_CNTL = crate::Reg<power_pd_hpwifi_cntl::POWER_PD_HPWIFI_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_hpwifi_cntl;
+#[doc = "POWER_PD_LPPERI_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_lpperi_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_lpperi_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_lpperi_cntl`] module"]
+pub type POWER_PD_LPPERI_CNTL = crate::Reg<power_pd_lpperi_cntl::POWER_PD_LPPERI_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_lpperi_cntl;
+#[doc = "POWER_PD_MEM_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_mem_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_mem_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_mem_cntl`] module"]
+pub type POWER_PD_MEM_CNTL = crate::Reg<power_pd_mem_cntl::POWER_PD_MEM_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_mem_cntl;
+#[doc = "POWER_PD_MEM_MASK (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_mem_mask::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_mem_mask::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_pd_mem_mask`] module"]
+pub type POWER_PD_MEM_MASK = crate::Reg<power_pd_mem_mask::POWER_PD_MEM_MASK_SPEC>;
+#[doc = "need_des"]
+pub mod power_pd_mem_mask;
+#[doc = "POWER_HP_PAD (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_hp_pad::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_hp_pad::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_hp_pad`] module"]
+pub type POWER_HP_PAD = crate::Reg<power_hp_pad::POWER_HP_PAD_SPEC>;
+#[doc = "need_des"]
+pub mod power_hp_pad;
+#[doc = "POWER_VDD_SPI_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_vdd_spi_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_vdd_spi_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_vdd_spi_cntl`] module"]
+pub type POWER_VDD_SPI_CNTL = crate::Reg<power_vdd_spi_cntl::POWER_VDD_SPI_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_vdd_spi_cntl;
+#[doc = "POWER_CK_WAIT_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_ck_wait_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_ck_wait_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@power_ck_wait_cntl`] module"]
+pub type POWER_CK_WAIT_CNTL = crate::Reg<power_ck_wait_cntl::POWER_CK_WAIT_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod power_ck_wait_cntl;
+#[doc = "SLP_WAKEUP_CNTL0 (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl0::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl0`] module"]
+pub type SLP_WAKEUP_CNTL0 = crate::Reg<slp_wakeup_cntl0::SLP_WAKEUP_CNTL0_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl0;
+#[doc = "SLP_WAKEUP_CNTL1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl1`] module"]
+pub type SLP_WAKEUP_CNTL1 = crate::Reg<slp_wakeup_cntl1::SLP_WAKEUP_CNTL1_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl1;
+#[doc = "SLP_WAKEUP_CNTL2 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl2`] module"]
+pub type SLP_WAKEUP_CNTL2 = crate::Reg<slp_wakeup_cntl2::SLP_WAKEUP_CNTL2_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl2;
+#[doc = "SLP_WAKEUP_CNTL3 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl3`] module"]
+pub type SLP_WAKEUP_CNTL3 = crate::Reg<slp_wakeup_cntl3::SLP_WAKEUP_CNTL3_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl3;
+#[doc = "SLP_WAKEUP_CNTL4 (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl4::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl4`] module"]
+pub type SLP_WAKEUP_CNTL4 = crate::Reg<slp_wakeup_cntl4::SLP_WAKEUP_CNTL4_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl4;
+#[doc = "SLP_WAKEUP_CNTL5 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl5`] module"]
+pub type SLP_WAKEUP_CNTL5 = crate::Reg<slp_wakeup_cntl5::SLP_WAKEUP_CNTL5_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl5;
+#[doc = "SLP_WAKEUP_CNTL6 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl6::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl6`] module"]
+pub type SLP_WAKEUP_CNTL6 = crate::Reg<slp_wakeup_cntl6::SLP_WAKEUP_CNTL6_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl6;
+#[doc = "SLP_WAKEUP_CNTL7 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_cntl7`] module"]
+pub type SLP_WAKEUP_CNTL7 = crate::Reg<slp_wakeup_cntl7::SLP_WAKEUP_CNTL7_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_cntl7;
+#[doc = "SLP_WAKEUP_STATUS0 (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_status0::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_status0`] module"]
+pub type SLP_WAKEUP_STATUS0 = crate::Reg<slp_wakeup_status0::SLP_WAKEUP_STATUS0_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_status0;
+#[doc = "SLP_WAKEUP_STATUS1 (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_status1::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slp_wakeup_status1`] module"]
+pub type SLP_WAKEUP_STATUS1 = crate::Reg<slp_wakeup_status1::SLP_WAKEUP_STATUS1_SPEC>;
+#[doc = "need_des"]
+pub mod slp_wakeup_status1;
+#[doc = "HP_CK_POWERON (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_ck_poweron::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_ck_poweron::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_ck_poweron`] module"]
+pub type HP_CK_POWERON = crate::Reg<hp_ck_poweron::HP_CK_POWERON_SPEC>;
+#[doc = "need_des"]
+pub mod hp_ck_poweron;
+#[doc = "HP_CK_CNTL (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_ck_cntl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_ck_cntl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_ck_cntl`] module"]
+pub type HP_CK_CNTL = crate::Reg<hp_ck_cntl::HP_CK_CNTL_SPEC>;
+#[doc = "need_des"]
+pub mod hp_ck_cntl;
+#[doc = "POR_STATUS (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`por_status::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@por_status`] module"]
+pub type POR_STATUS = crate::Reg<por_status::POR_STATUS_SPEC>;
+#[doc = "need_des"]
+pub mod por_status;
+#[doc = "RF_PWC (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rf_pwc::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rf_pwc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rf_pwc`] module"]
+pub type RF_PWC = crate::Reg<rf_pwc::RF_PWC_SPEC>;
+#[doc = "need_des"]
+pub mod rf_pwc;
+#[doc = "BACKUP_CFG (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`backup_cfg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`backup_cfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@backup_cfg`] module"]
+pub type BACKUP_CFG = crate::Reg<backup_cfg::BACKUP_CFG_SPEC>;
+#[doc = "need_des"]
+pub mod backup_cfg;
+#[doc = "INT_RAW (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_raw::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_raw::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@int_raw`] module"]
+pub type INT_RAW = crate::Reg<int_raw::INT_RAW_SPEC>;
+#[doc = "need_des"]
+pub mod int_raw;
+#[doc = "INT_ST (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_st::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@int_st`] module"]
+pub type INT_ST = crate::Reg<int_st::INT_ST_SPEC>;
+#[doc = "need_des"]
+pub mod int_st;
+#[doc = "INT_ENA (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_ena::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_ena::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@int_ena`] module"]
+pub type INT_ENA = crate::Reg<int_ena::INT_ENA_SPEC>;
+#[doc = "need_des"]
+pub mod int_ena;
+#[doc = "INT_CLR (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_clr::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@int_clr`] module"]
+pub type INT_CLR = crate::Reg<int_clr::INT_CLR_SPEC>;
+#[doc = "need_des"]
+pub mod int_clr;
+#[doc = "LP_INT_RAW (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_raw::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_raw::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_int_raw`] module"]
+pub type LP_INT_RAW = crate::Reg<lp_int_raw::LP_INT_RAW_SPEC>;
+#[doc = "need_des"]
+pub mod lp_int_raw;
+#[doc = "LP_INT_ST (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_st::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_int_st`] module"]
+pub type LP_INT_ST = crate::Reg<lp_int_st::LP_INT_ST_SPEC>;
+#[doc = "need_des"]
+pub mod lp_int_st;
+#[doc = "LP_INT_ENA (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_ena::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_ena::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_int_ena`] module"]
+pub type LP_INT_ENA = crate::Reg<lp_int_ena::LP_INT_ENA_SPEC>;
+#[doc = "need_des"]
+pub mod lp_int_ena;
+#[doc = "LP_INT_CLR (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_clr::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_int_clr`] module"]
+pub type LP_INT_CLR = crate::Reg<lp_int_clr::LP_INT_CLR_SPEC>;
+#[doc = "need_des"]
+pub mod lp_int_clr;
+#[doc = "LP_CPU_PWR0 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_cpu_pwr0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_cpu_pwr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_cpu_pwr0`] module"]
+pub type LP_CPU_PWR0 = crate::Reg<lp_cpu_pwr0::LP_CPU_PWR0_SPEC>;
+#[doc = "need_des"]
+pub mod lp_cpu_pwr0;
+#[doc = "LP_CPU_PWR1 (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_cpu_pwr1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_cpu_pwr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@lp_cpu_pwr1`] module"]
+pub type LP_CPU_PWR1 = crate::Reg<lp_cpu_pwr1::LP_CPU_PWR1_SPEC>;
+#[doc = "need_des"]
+pub mod lp_cpu_pwr1;
+#[doc = "HP_LP_CPU_COMM (w) register accessor: need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_lp_cpu_comm::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_lp_cpu_comm`] module"]
+pub type HP_LP_CPU_COMM = crate::Reg<hp_lp_cpu_comm::HP_LP_CPU_COMM_SPEC>;
+#[doc = "need_des"]
+pub mod hp_lp_cpu_comm;
+#[doc = "HP_REGULATOR_CFG (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_regulator_cfg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_regulator_cfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@hp_regulator_cfg`] module"]
+pub type HP_REGULATOR_CFG = crate::Reg<hp_regulator_cfg::HP_REGULATOR_CFG_SPEC>;
+#[doc = "need_des"]
+pub mod hp_regulator_cfg;
+#[doc = "MAIN_STATE (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`main_state::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@main_state`] module"]
+pub type MAIN_STATE = crate::Reg<main_state::MAIN_STATE_SPEC>;
+#[doc = "need_des"]
+pub mod main_state;
+#[doc = "PWR_STATE (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pwr_state::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pwr_state`] module"]
+pub type PWR_STATE = crate::Reg<pwr_state::PWR_STATE_SPEC>;
+#[doc = "need_des"]
+pub mod pwr_state;
+#[doc = "CLK_STATE0 (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state0::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_state0`] module"]
+pub type CLK_STATE0 = crate::Reg<clk_state0::CLK_STATE0_SPEC>;
+#[doc = "need_des"]
+pub mod clk_state0;
+#[doc = "CLK_STATE1 (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state1::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_state1`] module"]
+pub type CLK_STATE1 = crate::Reg<clk_state1::CLK_STATE1_SPEC>;
+#[doc = "need_des"]
+pub mod clk_state1;
+#[doc = "CLK_STATE2 (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state2::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_state2`] module"]
+pub type CLK_STATE2 = crate::Reg<clk_state2::CLK_STATE2_SPEC>;
+#[doc = "need_des"]
+pub mod clk_state2;
+#[doc = "VDD_SPI_STATUS (r) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`vdd_spi_status::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@vdd_spi_status`] module"]
+pub type VDD_SPI_STATUS = crate::Reg<vdd_spi_status::VDD_SPI_STATUS_SPEC>;
+#[doc = "need_des"]
+pub mod vdd_spi_status;
+#[doc = "DATE (rw) register accessor: need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`date::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`date::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@date`] module"]
+pub type DATE = crate::Reg<date::DATE_SPEC>;
+#[doc = "need_des"]
+pub mod date;

--- a/esp32c6-lp/src/pmu/backup_cfg.rs
+++ b/esp32c6-lp/src/pmu/backup_cfg.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `BACKUP_CFG` reader"]
+pub type R = crate::R<BACKUP_CFG_SPEC>;
+#[doc = "Register `BACKUP_CFG` writer"]
+pub type W = crate::W<BACKUP_CFG_SPEC>;
+#[doc = "Field `BACKUP_SYS_CLK_NO_DIV` reader - need_des"]
+pub type BACKUP_SYS_CLK_NO_DIV_R = crate::BitReader;
+#[doc = "Field `BACKUP_SYS_CLK_NO_DIV` writer - need_des"]
+pub type BACKUP_SYS_CLK_NO_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn backup_sys_clk_no_div(&self) -> BACKUP_SYS_CLK_NO_DIV_R {
+        BACKUP_SYS_CLK_NO_DIV_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BACKUP_CFG")
+            .field(
+                "backup_sys_clk_no_div",
+                &format_args!("{}", self.backup_sys_clk_no_div().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<BACKUP_CFG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn backup_sys_clk_no_div(&mut self) -> BACKUP_SYS_CLK_NO_DIV_W<BACKUP_CFG_SPEC> {
+        BACKUP_SYS_CLK_NO_DIV_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`backup_cfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`backup_cfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct BACKUP_CFG_SPEC;
+impl crate::RegisterSpec for BACKUP_CFG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`backup_cfg::R`](R) reader structure"]
+impl crate::Readable for BACKUP_CFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`backup_cfg::W`](W) writer structure"]
+impl crate::Writable for BACKUP_CFG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets BACKUP_CFG to value 0x8000_0000"]
+impl crate::Resettable for BACKUP_CFG_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/clk_state0.rs
+++ b/esp32c6-lp/src/pmu/clk_state0.rs
@@ -1,0 +1,215 @@
+#[doc = "Register `CLK_STATE0` reader"]
+pub type R = crate::R<CLK_STATE0_SPEC>;
+#[doc = "Field `STABLE_XPD_BBPLL_STATE` reader - need_des"]
+pub type STABLE_XPD_BBPLL_STATE_R = crate::BitReader;
+#[doc = "Field `STABLE_XPD_XTAL_STATE` reader - need_des"]
+pub type STABLE_XPD_XTAL_STATE_R = crate::BitReader;
+#[doc = "Field `SYS_CLK_SLP_SEL_STATE` reader - need_des"]
+pub type SYS_CLK_SLP_SEL_STATE_R = crate::BitReader;
+#[doc = "Field `SYS_CLK_SEL_STATE` reader - need_des"]
+pub type SYS_CLK_SEL_STATE_R = crate::FieldReader;
+#[doc = "Field `SYS_CLK_NO_DIV_STATE` reader - need_des"]
+pub type SYS_CLK_NO_DIV_STATE_R = crate::BitReader;
+#[doc = "Field `ICG_SYS_CLK_EN_STATE` reader - need_des"]
+pub type ICG_SYS_CLK_EN_STATE_R = crate::BitReader;
+#[doc = "Field `ICG_MODEM_SWITCH_STATE` reader - need_des"]
+pub type ICG_MODEM_SWITCH_STATE_R = crate::BitReader;
+#[doc = "Field `ICG_MODEM_CODE_STATE` reader - need_des"]
+pub type ICG_MODEM_CODE_STATE_R = crate::FieldReader;
+#[doc = "Field `ICG_SLP_SEL_STATE` reader - need_des"]
+pub type ICG_SLP_SEL_STATE_R = crate::BitReader;
+#[doc = "Field `ICG_GLOBAL_XTAL_STATE` reader - need_des"]
+pub type ICG_GLOBAL_XTAL_STATE_R = crate::BitReader;
+#[doc = "Field `ICG_GLOBAL_PLL_STATE` reader - need_des"]
+pub type ICG_GLOBAL_PLL_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_I2C_ISO_EN_STATE` reader - need_des"]
+pub type ANA_I2C_ISO_EN_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_I2C_RETENTION_STATE` reader - need_des"]
+pub type ANA_I2C_RETENTION_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_XPD_BB_I2C_STATE` reader - need_des"]
+pub type ANA_XPD_BB_I2C_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_XPD_BBPLL_I2C_STATE` reader - need_des"]
+pub type ANA_XPD_BBPLL_I2C_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_XPD_BBPLL_STATE` reader - need_des"]
+pub type ANA_XPD_BBPLL_STATE_R = crate::BitReader;
+#[doc = "Field `ANA_XPD_XTAL_STATE` reader - need_des"]
+pub type ANA_XPD_XTAL_STATE_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn stable_xpd_bbpll_state(&self) -> STABLE_XPD_BBPLL_STATE_R {
+        STABLE_XPD_BBPLL_STATE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn stable_xpd_xtal_state(&self) -> STABLE_XPD_XTAL_STATE_R {
+        STABLE_XPD_XTAL_STATE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 15 - need_des"]
+    #[inline(always)]
+    pub fn sys_clk_slp_sel_state(&self) -> SYS_CLK_SLP_SEL_STATE_R {
+        SYS_CLK_SLP_SEL_STATE_R::new(((self.bits >> 15) & 1) != 0)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    pub fn sys_clk_sel_state(&self) -> SYS_CLK_SEL_STATE_R {
+        SYS_CLK_SEL_STATE_R::new(((self.bits >> 16) & 3) as u8)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    pub fn sys_clk_no_div_state(&self) -> SYS_CLK_NO_DIV_STATE_R {
+        SYS_CLK_NO_DIV_STATE_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - need_des"]
+    #[inline(always)]
+    pub fn icg_sys_clk_en_state(&self) -> ICG_SYS_CLK_EN_STATE_R {
+        ICG_SYS_CLK_EN_STATE_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    pub fn icg_modem_switch_state(&self) -> ICG_MODEM_SWITCH_STATE_R {
+        ICG_MODEM_SWITCH_STATE_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bits 21:22 - need_des"]
+    #[inline(always)]
+    pub fn icg_modem_code_state(&self) -> ICG_MODEM_CODE_STATE_R {
+        ICG_MODEM_CODE_STATE_R::new(((self.bits >> 21) & 3) as u8)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    pub fn icg_slp_sel_state(&self) -> ICG_SLP_SEL_STATE_R {
+        ICG_SLP_SEL_STATE_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn icg_global_xtal_state(&self) -> ICG_GLOBAL_XTAL_STATE_R {
+        ICG_GLOBAL_XTAL_STATE_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn icg_global_pll_state(&self) -> ICG_GLOBAL_PLL_STATE_R {
+        ICG_GLOBAL_PLL_STATE_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn ana_i2c_iso_en_state(&self) -> ANA_I2C_ISO_EN_STATE_R {
+        ANA_I2C_ISO_EN_STATE_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn ana_i2c_retention_state(&self) -> ANA_I2C_RETENTION_STATE_R {
+        ANA_I2C_RETENTION_STATE_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn ana_xpd_bb_i2c_state(&self) -> ANA_XPD_BB_I2C_STATE_R {
+        ANA_XPD_BB_I2C_STATE_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn ana_xpd_bbpll_i2c_state(&self) -> ANA_XPD_BBPLL_I2C_STATE_R {
+        ANA_XPD_BBPLL_I2C_STATE_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn ana_xpd_bbpll_state(&self) -> ANA_XPD_BBPLL_STATE_R {
+        ANA_XPD_BBPLL_STATE_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn ana_xpd_xtal_state(&self) -> ANA_XPD_XTAL_STATE_R {
+        ANA_XPD_XTAL_STATE_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_STATE0")
+            .field(
+                "stable_xpd_bbpll_state",
+                &format_args!("{}", self.stable_xpd_bbpll_state().bit()),
+            )
+            .field(
+                "stable_xpd_xtal_state",
+                &format_args!("{}", self.stable_xpd_xtal_state().bit()),
+            )
+            .field(
+                "sys_clk_slp_sel_state",
+                &format_args!("{}", self.sys_clk_slp_sel_state().bit()),
+            )
+            .field(
+                "sys_clk_sel_state",
+                &format_args!("{}", self.sys_clk_sel_state().bits()),
+            )
+            .field(
+                "sys_clk_no_div_state",
+                &format_args!("{}", self.sys_clk_no_div_state().bit()),
+            )
+            .field(
+                "icg_sys_clk_en_state",
+                &format_args!("{}", self.icg_sys_clk_en_state().bit()),
+            )
+            .field(
+                "icg_modem_switch_state",
+                &format_args!("{}", self.icg_modem_switch_state().bit()),
+            )
+            .field(
+                "icg_modem_code_state",
+                &format_args!("{}", self.icg_modem_code_state().bits()),
+            )
+            .field(
+                "icg_slp_sel_state",
+                &format_args!("{}", self.icg_slp_sel_state().bit()),
+            )
+            .field(
+                "icg_global_xtal_state",
+                &format_args!("{}", self.icg_global_xtal_state().bit()),
+            )
+            .field(
+                "icg_global_pll_state",
+                &format_args!("{}", self.icg_global_pll_state().bit()),
+            )
+            .field(
+                "ana_i2c_iso_en_state",
+                &format_args!("{}", self.ana_i2c_iso_en_state().bit()),
+            )
+            .field(
+                "ana_i2c_retention_state",
+                &format_args!("{}", self.ana_i2c_retention_state().bit()),
+            )
+            .field(
+                "ana_xpd_bb_i2c_state",
+                &format_args!("{}", self.ana_xpd_bb_i2c_state().bit()),
+            )
+            .field(
+                "ana_xpd_bbpll_i2c_state",
+                &format_args!("{}", self.ana_xpd_bbpll_i2c_state().bit()),
+            )
+            .field(
+                "ana_xpd_bbpll_state",
+                &format_args!("{}", self.ana_xpd_bbpll_state().bit()),
+            )
+            .field(
+                "ana_xpd_xtal_state",
+                &format_args!("{}", self.ana_xpd_xtal_state().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<CLK_STATE0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state0::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLK_STATE0_SPEC;
+impl crate::RegisterSpec for CLK_STATE0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clk_state0::R`](R) reader structure"]
+impl crate::Readable for CLK_STATE0_SPEC {}
+#[doc = "`reset()` method sets CLK_STATE0 to value 0x03"]
+impl crate::Resettable for CLK_STATE0_SPEC {
+    const RESET_VALUE: u32 = 0x03;
+}

--- a/esp32c6-lp/src/pmu/clk_state1.rs
+++ b/esp32c6-lp/src/pmu/clk_state1.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `CLK_STATE1` reader"]
+pub type R = crate::R<CLK_STATE1_SPEC>;
+#[doc = "Field `ICG_FUNC_EN_STATE` reader - need_des"]
+pub type ICG_FUNC_EN_STATE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn icg_func_en_state(&self) -> ICG_FUNC_EN_STATE_R {
+        ICG_FUNC_EN_STATE_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_STATE1")
+            .field(
+                "icg_func_en_state",
+                &format_args!("{}", self.icg_func_en_state().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<CLK_STATE1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state1::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLK_STATE1_SPEC;
+impl crate::RegisterSpec for CLK_STATE1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clk_state1::R`](R) reader structure"]
+impl crate::Readable for CLK_STATE1_SPEC {}
+#[doc = "`reset()` method sets CLK_STATE1 to value 0xffff_ffff"]
+impl crate::Resettable for CLK_STATE1_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/clk_state2.rs
+++ b/esp32c6-lp/src/pmu/clk_state2.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `CLK_STATE2` reader"]
+pub type R = crate::R<CLK_STATE2_SPEC>;
+#[doc = "Field `ICG_APB_EN_STATE` reader - need_des"]
+pub type ICG_APB_EN_STATE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn icg_apb_en_state(&self) -> ICG_APB_EN_STATE_R {
+        ICG_APB_EN_STATE_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_STATE2")
+            .field(
+                "icg_apb_en_state",
+                &format_args!("{}", self.icg_apb_en_state().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<CLK_STATE2_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_state2::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLK_STATE2_SPEC;
+impl crate::RegisterSpec for CLK_STATE2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clk_state2::R`](R) reader structure"]
+impl crate::Readable for CLK_STATE2_SPEC {}
+#[doc = "`reset()` method sets CLK_STATE2 to value 0xffff_ffff"]
+impl crate::Resettable for CLK_STATE2_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/date.rs
+++ b/esp32c6-lp/src/pmu/date.rs
@@ -1,0 +1,70 @@
+#[doc = "Register `DATE` reader"]
+pub type R = crate::R<DATE_SPEC>;
+#[doc = "Register `DATE` writer"]
+pub type W = crate::W<DATE_SPEC>;
+#[doc = "Field `PMU_DATE` reader - need_des"]
+pub type PMU_DATE_R = crate::FieldReader<u32>;
+#[doc = "Field `PMU_DATE` writer - need_des"]
+pub type PMU_DATE_W<'a, REG> = crate::FieldWriter<'a, REG, 31, u32>;
+#[doc = "Field `CLK_EN` reader - need_des"]
+pub type CLK_EN_R = crate::BitReader;
+#[doc = "Field `CLK_EN` writer - need_des"]
+pub type CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 0:30 - need_des"]
+    #[inline(always)]
+    pub fn pmu_date(&self) -> PMU_DATE_R {
+        PMU_DATE_R::new(self.bits & 0x7fff_ffff)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn clk_en(&self) -> CLK_EN_R {
+        CLK_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DATE")
+            .field("pmu_date", &format_args!("{}", self.pmu_date().bits()))
+            .field("clk_en", &format_args!("{}", self.clk_en().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<DATE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pmu_date(&mut self) -> PMU_DATE_W<DATE_SPEC> {
+        PMU_DATE_W::new(self, 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn clk_en(&mut self) -> CLK_EN_W<DATE_SPEC> {
+        CLK_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`date::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`date::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct DATE_SPEC;
+impl crate::RegisterSpec for DATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`date::R`](R) reader structure"]
+impl crate::Readable for DATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`date::W`](W) writer structure"]
+impl crate::Writable for DATE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets DATE to value 0x0220_6250"]
+impl crate::Resettable for DATE_SPEC {
+    const RESET_VALUE: u32 = 0x0220_6250;
+}

--- a/esp32c6-lp/src/pmu/hp_active_backup.rs
+++ b/esp32c6-lp/src/pmu/hp_active_backup.rs
@@ -1,0 +1,269 @@
+#[doc = "Register `HP_ACTIVE_BACKUP` reader"]
+pub type R = crate::R<HP_ACTIVE_BACKUP_SPEC>;
+#[doc = "Register `HP_ACTIVE_BACKUP` writer"]
+pub type W = crate::W<HP_ACTIVE_BACKUP_SPEC>;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE` reader - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE` writer - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE` reader - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE` writer - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_ACTIVE_RETENTION_MODE` reader - need_des"]
+pub type HP_ACTIVE_RETENTION_MODE_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_RETENTION_MODE` writer - need_des"]
+pub type HP_ACTIVE_RETENTION_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP2ACTIVE_RETENTION_EN` reader - need_des"]
+pub type HP_SLEEP2ACTIVE_RETENTION_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP2ACTIVE_RETENTION_EN` writer - need_des"]
+pub type HP_SLEEP2ACTIVE_RETENTION_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM2ACTIVE_RETENTION_EN` reader - need_des"]
+pub type HP_MODEM2ACTIVE_RETENTION_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM2ACTIVE_RETENTION_EN` writer - need_des"]
+pub type HP_MODEM2ACTIVE_RETENTION_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_CLK_SEL` reader - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_CLK_SEL` writer - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_CLK_SEL` reader - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_CLK_SEL` writer - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_MODE` reader - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_MODE_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_MODE` writer - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_MODE` reader - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_MODE_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_MODE` writer - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_EN` reader - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP2ACTIVE_BACKUP_EN` writer - need_des"]
+pub type HP_SLEEP2ACTIVE_BACKUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_EN` reader - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM2ACTIVE_BACKUP_EN` writer - need_des"]
+pub type HP_MODEM2ACTIVE_BACKUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 4:5 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2active_backup_modem_clk_code(&self) -> HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_R {
+        HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bits 6:7 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2active_backup_modem_clk_code(&self) -> HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_R {
+        HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_R::new(((self.bits >> 6) & 3) as u8)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_retention_mode(&self) -> HP_ACTIVE_RETENTION_MODE_R {
+        HP_ACTIVE_RETENTION_MODE_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2active_retention_en(&self) -> HP_SLEEP2ACTIVE_RETENTION_EN_R {
+        HP_SLEEP2ACTIVE_RETENTION_EN_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2active_retention_en(&self) -> HP_MODEM2ACTIVE_RETENTION_EN_R {
+        HP_MODEM2ACTIVE_RETENTION_EN_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bits 14:15 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2active_backup_clk_sel(&self) -> HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_R {
+        HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_R::new(((self.bits >> 14) & 3) as u8)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2active_backup_clk_sel(&self) -> HP_MODEM2ACTIVE_BACKUP_CLK_SEL_R {
+        HP_MODEM2ACTIVE_BACKUP_CLK_SEL_R::new(((self.bits >> 16) & 3) as u8)
+    }
+    #[doc = "Bits 20:22 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2active_backup_mode(&self) -> HP_SLEEP2ACTIVE_BACKUP_MODE_R {
+        HP_SLEEP2ACTIVE_BACKUP_MODE_R::new(((self.bits >> 20) & 7) as u8)
+    }
+    #[doc = "Bits 23:25 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2active_backup_mode(&self) -> HP_MODEM2ACTIVE_BACKUP_MODE_R {
+        HP_MODEM2ACTIVE_BACKUP_MODE_R::new(((self.bits >> 23) & 7) as u8)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2active_backup_en(&self) -> HP_SLEEP2ACTIVE_BACKUP_EN_R {
+        HP_SLEEP2ACTIVE_BACKUP_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2active_backup_en(&self) -> HP_MODEM2ACTIVE_BACKUP_EN_R {
+        HP_MODEM2ACTIVE_BACKUP_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_BACKUP")
+            .field(
+                "hp_sleep2active_backup_modem_clk_code",
+                &format_args!("{}", self.hp_sleep2active_backup_modem_clk_code().bits()),
+            )
+            .field(
+                "hp_modem2active_backup_modem_clk_code",
+                &format_args!("{}", self.hp_modem2active_backup_modem_clk_code().bits()),
+            )
+            .field(
+                "hp_active_retention_mode",
+                &format_args!("{}", self.hp_active_retention_mode().bit()),
+            )
+            .field(
+                "hp_sleep2active_retention_en",
+                &format_args!("{}", self.hp_sleep2active_retention_en().bit()),
+            )
+            .field(
+                "hp_modem2active_retention_en",
+                &format_args!("{}", self.hp_modem2active_retention_en().bit()),
+            )
+            .field(
+                "hp_sleep2active_backup_clk_sel",
+                &format_args!("{}", self.hp_sleep2active_backup_clk_sel().bits()),
+            )
+            .field(
+                "hp_modem2active_backup_clk_sel",
+                &format_args!("{}", self.hp_modem2active_backup_clk_sel().bits()),
+            )
+            .field(
+                "hp_sleep2active_backup_mode",
+                &format_args!("{}", self.hp_sleep2active_backup_mode().bits()),
+            )
+            .field(
+                "hp_modem2active_backup_mode",
+                &format_args!("{}", self.hp_modem2active_backup_mode().bits()),
+            )
+            .field(
+                "hp_sleep2active_backup_en",
+                &format_args!("{}", self.hp_sleep2active_backup_en().bit()),
+            )
+            .field(
+                "hp_modem2active_backup_en",
+                &format_args!("{}", self.hp_modem2active_backup_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_BACKUP_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 4:5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2active_backup_modem_clk_code(
+        &mut self,
+    ) -> HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_SLEEP2ACTIVE_BACKUP_MODEM_CLK_CODE_W::new(self, 4)
+    }
+    #[doc = "Bits 6:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2active_backup_modem_clk_code(
+        &mut self,
+    ) -> HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_MODEM2ACTIVE_BACKUP_MODEM_CLK_CODE_W::new(self, 6)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_retention_mode(
+        &mut self,
+    ) -> HP_ACTIVE_RETENTION_MODE_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_ACTIVE_RETENTION_MODE_W::new(self, 10)
+    }
+    #[doc = "Bit 11 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2active_retention_en(
+        &mut self,
+    ) -> HP_SLEEP2ACTIVE_RETENTION_EN_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_SLEEP2ACTIVE_RETENTION_EN_W::new(self, 11)
+    }
+    #[doc = "Bit 12 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2active_retention_en(
+        &mut self,
+    ) -> HP_MODEM2ACTIVE_RETENTION_EN_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_MODEM2ACTIVE_RETENTION_EN_W::new(self, 12)
+    }
+    #[doc = "Bits 14:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2active_backup_clk_sel(
+        &mut self,
+    ) -> HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_SLEEP2ACTIVE_BACKUP_CLK_SEL_W::new(self, 14)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2active_backup_clk_sel(
+        &mut self,
+    ) -> HP_MODEM2ACTIVE_BACKUP_CLK_SEL_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_MODEM2ACTIVE_BACKUP_CLK_SEL_W::new(self, 16)
+    }
+    #[doc = "Bits 20:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2active_backup_mode(
+        &mut self,
+    ) -> HP_SLEEP2ACTIVE_BACKUP_MODE_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_SLEEP2ACTIVE_BACKUP_MODE_W::new(self, 20)
+    }
+    #[doc = "Bits 23:25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2active_backup_mode(
+        &mut self,
+    ) -> HP_MODEM2ACTIVE_BACKUP_MODE_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_MODEM2ACTIVE_BACKUP_MODE_W::new(self, 23)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2active_backup_en(
+        &mut self,
+    ) -> HP_SLEEP2ACTIVE_BACKUP_EN_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_SLEEP2ACTIVE_BACKUP_EN_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2active_backup_en(
+        &mut self,
+    ) -> HP_MODEM2ACTIVE_BACKUP_EN_W<HP_ACTIVE_BACKUP_SPEC> {
+        HP_MODEM2ACTIVE_BACKUP_EN_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_backup::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_backup::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_BACKUP_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_BACKUP_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_backup::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_BACKUP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_backup::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_BACKUP_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_BACKUP to value 0"]
+impl crate::Resettable for HP_ACTIVE_BACKUP_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_backup_clk.rs
+++ b/esp32c6-lp/src/pmu/hp_active_backup_clk.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_ACTIVE_BACKUP_CLK` reader"]
+pub type R = crate::R<HP_ACTIVE_BACKUP_CLK_SPEC>;
+#[doc = "Register `HP_ACTIVE_BACKUP_CLK` writer"]
+pub type W = crate::W<HP_ACTIVE_BACKUP_CLK_SPEC>;
+#[doc = "Field `HP_ACTIVE_BACKUP_ICG_FUNC_EN` reader - need_des"]
+pub type HP_ACTIVE_BACKUP_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_ACTIVE_BACKUP_ICG_FUNC_EN` writer - need_des"]
+pub type HP_ACTIVE_BACKUP_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_backup_icg_func_en(&self) -> HP_ACTIVE_BACKUP_ICG_FUNC_EN_R {
+        HP_ACTIVE_BACKUP_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_BACKUP_CLK")
+            .field(
+                "hp_active_backup_icg_func_en",
+                &format_args!("{}", self.hp_active_backup_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_BACKUP_CLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_backup_icg_func_en(
+        &mut self,
+    ) -> HP_ACTIVE_BACKUP_ICG_FUNC_EN_W<HP_ACTIVE_BACKUP_CLK_SPEC> {
+        HP_ACTIVE_BACKUP_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_backup_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_backup_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_BACKUP_CLK_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_BACKUP_CLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_backup_clk::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_BACKUP_CLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_backup_clk::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_BACKUP_CLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_BACKUP_CLK to value 0"]
+impl crate::Resettable for HP_ACTIVE_BACKUP_CLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_bias.rs
+++ b/esp32c6-lp/src/pmu/hp_active_bias.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `HP_ACTIVE_BIAS` reader"]
+pub type R = crate::R<HP_ACTIVE_BIAS_SPEC>;
+#[doc = "Register `HP_ACTIVE_BIAS` writer"]
+pub type W = crate::W<HP_ACTIVE_BIAS_SPEC>;
+#[doc = "Field `HP_ACTIVE_XPD_BIAS` reader - need_des"]
+pub type HP_ACTIVE_XPD_BIAS_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_XPD_BIAS` writer - need_des"]
+pub type HP_ACTIVE_XPD_BIAS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_DBG_ATTEN` reader - need_des"]
+pub type HP_ACTIVE_DBG_ATTEN_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_DBG_ATTEN` writer - need_des"]
+pub type HP_ACTIVE_DBG_ATTEN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_ACTIVE_PD_CUR` reader - need_des"]
+pub type HP_ACTIVE_PD_CUR_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_PD_CUR` writer - need_des"]
+pub type HP_ACTIVE_PD_CUR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP` reader - need_des"]
+pub type SLEEP_R = crate::BitReader;
+#[doc = "Field `SLEEP` writer - need_des"]
+pub type SLEEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_xpd_bias(&self) -> HP_ACTIVE_XPD_BIAS_R {
+        HP_ACTIVE_XPD_BIAS_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dbg_atten(&self) -> HP_ACTIVE_DBG_ATTEN_R {
+        HP_ACTIVE_DBG_ATTEN_R::new(((self.bits >> 26) & 0x0f) as u8)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_cur(&self) -> HP_ACTIVE_PD_CUR_R {
+        HP_ACTIVE_PD_CUR_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn sleep(&self) -> SLEEP_R {
+        SLEEP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_BIAS")
+            .field(
+                "hp_active_xpd_bias",
+                &format_args!("{}", self.hp_active_xpd_bias().bit()),
+            )
+            .field(
+                "hp_active_dbg_atten",
+                &format_args!("{}", self.hp_active_dbg_atten().bits()),
+            )
+            .field(
+                "hp_active_pd_cur",
+                &format_args!("{}", self.hp_active_pd_cur().bit()),
+            )
+            .field("sleep", &format_args!("{}", self.sleep().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_BIAS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_xpd_bias(&mut self) -> HP_ACTIVE_XPD_BIAS_W<HP_ACTIVE_BIAS_SPEC> {
+        HP_ACTIVE_XPD_BIAS_W::new(self, 25)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dbg_atten(&mut self) -> HP_ACTIVE_DBG_ATTEN_W<HP_ACTIVE_BIAS_SPEC> {
+        HP_ACTIVE_DBG_ATTEN_W::new(self, 26)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_cur(&mut self) -> HP_ACTIVE_PD_CUR_W<HP_ACTIVE_BIAS_SPEC> {
+        HP_ACTIVE_PD_CUR_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep(&mut self) -> SLEEP_W<HP_ACTIVE_BIAS_SPEC> {
+        SLEEP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_bias::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_bias::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_BIAS_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_BIAS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_bias::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_BIAS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_bias::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_BIAS_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_BIAS to value 0"]
+impl crate::Resettable for HP_ACTIVE_BIAS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_dig_power.rs
+++ b/esp32c6-lp/src/pmu/hp_active_dig_power.rs
@@ -1,0 +1,181 @@
+#[doc = "Register `HP_ACTIVE_DIG_POWER` reader"]
+pub type R = crate::R<HP_ACTIVE_DIG_POWER_SPEC>;
+#[doc = "Register `HP_ACTIVE_DIG_POWER` writer"]
+pub type W = crate::W<HP_ACTIVE_DIG_POWER_SPEC>;
+#[doc = "Field `HP_ACTIVE_VDD_SPI_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_VDD_SPI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_VDD_SPI_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_VDD_SPI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_MEM_DSLP` reader - need_des"]
+pub type HP_ACTIVE_HP_MEM_DSLP_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_HP_MEM_DSLP` writer - need_des"]
+pub type HP_ACTIVE_HP_MEM_DSLP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_PD_HP_MEM_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_PD_HP_MEM_PD_EN_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_PD_HP_MEM_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_PD_HP_MEM_PD_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_ACTIVE_PD_HP_WIFI_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_PD_HP_WIFI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_PD_HP_WIFI_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_PD_HP_WIFI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_PD_HP_CPU_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_PD_HP_CPU_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_PD_HP_CPU_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_PD_HP_CPU_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_PD_HP_AON_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_PD_HP_AON_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_PD_HP_AON_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_PD_HP_AON_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_PD_TOP_PD_EN` reader - need_des"]
+pub type HP_ACTIVE_PD_TOP_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_PD_TOP_PD_EN` writer - need_des"]
+pub type HP_ACTIVE_PD_TOP_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_vdd_spi_pd_en(&self) -> HP_ACTIVE_VDD_SPI_PD_EN_R {
+        HP_ACTIVE_VDD_SPI_PD_EN_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_mem_dslp(&self) -> HP_ACTIVE_HP_MEM_DSLP_R {
+        HP_ACTIVE_HP_MEM_DSLP_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_hp_mem_pd_en(&self) -> HP_ACTIVE_PD_HP_MEM_PD_EN_R {
+        HP_ACTIVE_PD_HP_MEM_PD_EN_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_hp_wifi_pd_en(&self) -> HP_ACTIVE_PD_HP_WIFI_PD_EN_R {
+        HP_ACTIVE_PD_HP_WIFI_PD_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_hp_cpu_pd_en(&self) -> HP_ACTIVE_PD_HP_CPU_PD_EN_R {
+        HP_ACTIVE_PD_HP_CPU_PD_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_hp_aon_pd_en(&self) -> HP_ACTIVE_PD_HP_AON_PD_EN_R {
+        HP_ACTIVE_PD_HP_AON_PD_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_pd_top_pd_en(&self) -> HP_ACTIVE_PD_TOP_PD_EN_R {
+        HP_ACTIVE_PD_TOP_PD_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_DIG_POWER")
+            .field(
+                "hp_active_vdd_spi_pd_en",
+                &format_args!("{}", self.hp_active_vdd_spi_pd_en().bit()),
+            )
+            .field(
+                "hp_active_hp_mem_dslp",
+                &format_args!("{}", self.hp_active_hp_mem_dslp().bit()),
+            )
+            .field(
+                "hp_active_pd_hp_mem_pd_en",
+                &format_args!("{}", self.hp_active_pd_hp_mem_pd_en().bits()),
+            )
+            .field(
+                "hp_active_pd_hp_wifi_pd_en",
+                &format_args!("{}", self.hp_active_pd_hp_wifi_pd_en().bit()),
+            )
+            .field(
+                "hp_active_pd_hp_cpu_pd_en",
+                &format_args!("{}", self.hp_active_pd_hp_cpu_pd_en().bit()),
+            )
+            .field(
+                "hp_active_pd_hp_aon_pd_en",
+                &format_args!("{}", self.hp_active_pd_hp_aon_pd_en().bit()),
+            )
+            .field(
+                "hp_active_pd_top_pd_en",
+                &format_args!("{}", self.hp_active_pd_top_pd_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_DIG_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_vdd_spi_pd_en(
+        &mut self,
+    ) -> HP_ACTIVE_VDD_SPI_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_VDD_SPI_PD_EN_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_mem_dslp(&mut self) -> HP_ACTIVE_HP_MEM_DSLP_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_HP_MEM_DSLP_W::new(self, 22)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_hp_mem_pd_en(
+        &mut self,
+    ) -> HP_ACTIVE_PD_HP_MEM_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_PD_HP_MEM_PD_EN_W::new(self, 23)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_hp_wifi_pd_en(
+        &mut self,
+    ) -> HP_ACTIVE_PD_HP_WIFI_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_PD_HP_WIFI_PD_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_hp_cpu_pd_en(
+        &mut self,
+    ) -> HP_ACTIVE_PD_HP_CPU_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_PD_HP_CPU_PD_EN_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_hp_aon_pd_en(
+        &mut self,
+    ) -> HP_ACTIVE_PD_HP_AON_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_PD_HP_AON_PD_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_pd_top_pd_en(&mut self) -> HP_ACTIVE_PD_TOP_PD_EN_W<HP_ACTIVE_DIG_POWER_SPEC> {
+        HP_ACTIVE_PD_TOP_PD_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_dig_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_dig_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_DIG_POWER_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_DIG_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_dig_power::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_DIG_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_dig_power::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_DIG_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_DIG_POWER to value 0"]
+impl crate::Resettable for HP_ACTIVE_DIG_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_hp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/hp_active_hp_ck_power.rs
@@ -1,0 +1,137 @@
+#[doc = "Register `HP_ACTIVE_HP_CK_POWER` reader"]
+pub type R = crate::R<HP_ACTIVE_HP_CK_POWER_SPEC>;
+#[doc = "Register `HP_ACTIVE_HP_CK_POWER` writer"]
+pub type W = crate::W<HP_ACTIVE_HP_CK_POWER_SPEC>;
+#[doc = "Field `HP_ACTIVE_I2C_ISO_EN` reader - need_des"]
+pub type HP_ACTIVE_I2C_ISO_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_I2C_ISO_EN` writer - need_des"]
+pub type HP_ACTIVE_I2C_ISO_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_I2C_RETENTION` reader - need_des"]
+pub type HP_ACTIVE_I2C_RETENTION_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_I2C_RETENTION` writer - need_des"]
+pub type HP_ACTIVE_I2C_RETENTION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_XPD_BB_I2C` reader - need_des"]
+pub type HP_ACTIVE_XPD_BB_I2C_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_XPD_BB_I2C` writer - need_des"]
+pub type HP_ACTIVE_XPD_BB_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_XPD_BBPLL_I2C` reader - need_des"]
+pub type HP_ACTIVE_XPD_BBPLL_I2C_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_XPD_BBPLL_I2C` writer - need_des"]
+pub type HP_ACTIVE_XPD_BBPLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_XPD_BBPLL` reader - need_des"]
+pub type HP_ACTIVE_XPD_BBPLL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_XPD_BBPLL` writer - need_des"]
+pub type HP_ACTIVE_XPD_BBPLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_i2c_iso_en(&self) -> HP_ACTIVE_I2C_ISO_EN_R {
+        HP_ACTIVE_I2C_ISO_EN_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_i2c_retention(&self) -> HP_ACTIVE_I2C_RETENTION_R {
+        HP_ACTIVE_I2C_RETENTION_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_xpd_bb_i2c(&self) -> HP_ACTIVE_XPD_BB_I2C_R {
+        HP_ACTIVE_XPD_BB_I2C_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_xpd_bbpll_i2c(&self) -> HP_ACTIVE_XPD_BBPLL_I2C_R {
+        HP_ACTIVE_XPD_BBPLL_I2C_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_xpd_bbpll(&self) -> HP_ACTIVE_XPD_BBPLL_R {
+        HP_ACTIVE_XPD_BBPLL_R::new(((self.bits >> 30) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_HP_CK_POWER")
+            .field(
+                "hp_active_i2c_iso_en",
+                &format_args!("{}", self.hp_active_i2c_iso_en().bit()),
+            )
+            .field(
+                "hp_active_i2c_retention",
+                &format_args!("{}", self.hp_active_i2c_retention().bit()),
+            )
+            .field(
+                "hp_active_xpd_bb_i2c",
+                &format_args!("{}", self.hp_active_xpd_bb_i2c().bit()),
+            )
+            .field(
+                "hp_active_xpd_bbpll_i2c",
+                &format_args!("{}", self.hp_active_xpd_bbpll_i2c().bit()),
+            )
+            .field(
+                "hp_active_xpd_bbpll",
+                &format_args!("{}", self.hp_active_xpd_bbpll().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_HP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_i2c_iso_en(&mut self) -> HP_ACTIVE_I2C_ISO_EN_W<HP_ACTIVE_HP_CK_POWER_SPEC> {
+        HP_ACTIVE_I2C_ISO_EN_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_i2c_retention(
+        &mut self,
+    ) -> HP_ACTIVE_I2C_RETENTION_W<HP_ACTIVE_HP_CK_POWER_SPEC> {
+        HP_ACTIVE_I2C_RETENTION_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_xpd_bb_i2c(&mut self) -> HP_ACTIVE_XPD_BB_I2C_W<HP_ACTIVE_HP_CK_POWER_SPEC> {
+        HP_ACTIVE_XPD_BB_I2C_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_xpd_bbpll_i2c(
+        &mut self,
+    ) -> HP_ACTIVE_XPD_BBPLL_I2C_W<HP_ACTIVE_HP_CK_POWER_SPEC> {
+        HP_ACTIVE_XPD_BBPLL_I2C_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_xpd_bbpll(&mut self) -> HP_ACTIVE_XPD_BBPLL_W<HP_ACTIVE_HP_CK_POWER_SPEC> {
+        HP_ACTIVE_XPD_BBPLL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_HP_CK_POWER_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_HP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_hp_ck_power::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_HP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_hp_ck_power::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_HP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_HP_CK_POWER to value 0"]
+impl crate::Resettable for HP_ACTIVE_HP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_hp_regulator0.rs
+++ b/esp32c6-lp/src/pmu/hp_active_hp_regulator0.rs
@@ -1,0 +1,217 @@
+#[doc = "Register `HP_ACTIVE_HP_REGULATOR0` reader"]
+pub type R = crate::R<HP_ACTIVE_HP_REGULATOR0_SPEC>;
+#[doc = "Register `HP_ACTIVE_HP_REGULATOR0` writer"]
+pub type W = crate::W<HP_ACTIVE_HP_REGULATOR0_SPEC>;
+#[doc = "Field `LP_DBIAS_VOL` reader - need_des"]
+pub type LP_DBIAS_VOL_R = crate::FieldReader;
+#[doc = "Field `HP_DBIAS_VOL` reader - need_des"]
+pub type HP_DBIAS_VOL_R = crate::FieldReader;
+#[doc = "Field `DIG_REGULATOR0_DBIAS_SEL` reader - need_des"]
+pub type DIG_REGULATOR0_DBIAS_SEL_R = crate::BitReader;
+#[doc = "Field `DIG_REGULATOR0_DBIAS_SEL` writer - need_des"]
+pub type DIG_REGULATOR0_DBIAS_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `DIG_DBIAS_INIT` writer - need_des"]
+pub type DIG_DBIAS_INIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_XPD` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_XPD_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_XPD` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_DBIAS` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_DBIAS` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bits 4:8 - need_des"]
+    #[inline(always)]
+    pub fn lp_dbias_vol(&self) -> LP_DBIAS_VOL_R {
+        LP_DBIAS_VOL_R::new(((self.bits >> 4) & 0x1f) as u8)
+    }
+    #[doc = "Bits 9:13 - need_des"]
+    #[inline(always)]
+    pub fn hp_dbias_vol(&self) -> HP_DBIAS_VOL_R {
+        HP_DBIAS_VOL_R::new(((self.bits >> 9) & 0x1f) as u8)
+    }
+    #[doc = "Bit 14 - need_des"]
+    #[inline(always)]
+    pub fn dig_regulator0_dbias_sel(&self) -> DIG_REGULATOR0_DBIAS_SEL_R {
+        DIG_REGULATOR0_DBIAS_SEL_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_slp_mem_xpd(&self) -> HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_R {
+        HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_slp_logic_xpd(&self) -> HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_R {
+        HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_xpd(&self) -> HP_ACTIVE_HP_REGULATOR_XPD_R {
+        HP_ACTIVE_HP_REGULATOR_XPD_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_slp_mem_dbias(&self) -> HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_R {
+        HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_R::new(((self.bits >> 19) & 0x0f) as u8)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_slp_logic_dbias(
+        &self,
+    ) -> HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_R {
+        HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_dbias(&self) -> HP_ACTIVE_HP_REGULATOR_DBIAS_R {
+        HP_ACTIVE_HP_REGULATOR_DBIAS_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_HP_REGULATOR0")
+            .field(
+                "lp_dbias_vol",
+                &format_args!("{}", self.lp_dbias_vol().bits()),
+            )
+            .field(
+                "hp_dbias_vol",
+                &format_args!("{}", self.hp_dbias_vol().bits()),
+            )
+            .field(
+                "dig_regulator0_dbias_sel",
+                &format_args!("{}", self.dig_regulator0_dbias_sel().bit()),
+            )
+            .field(
+                "hp_active_hp_regulator_slp_mem_xpd",
+                &format_args!("{}", self.hp_active_hp_regulator_slp_mem_xpd().bit()),
+            )
+            .field(
+                "hp_active_hp_regulator_slp_logic_xpd",
+                &format_args!("{}", self.hp_active_hp_regulator_slp_logic_xpd().bit()),
+            )
+            .field(
+                "hp_active_hp_regulator_xpd",
+                &format_args!("{}", self.hp_active_hp_regulator_xpd().bit()),
+            )
+            .field(
+                "hp_active_hp_regulator_slp_mem_dbias",
+                &format_args!("{}", self.hp_active_hp_regulator_slp_mem_dbias().bits()),
+            )
+            .field(
+                "hp_active_hp_regulator_slp_logic_dbias",
+                &format_args!("{}", self.hp_active_hp_regulator_slp_logic_dbias().bits()),
+            )
+            .field(
+                "hp_active_hp_regulator_dbias",
+                &format_args!("{}", self.hp_active_hp_regulator_dbias().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 14 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dig_regulator0_dbias_sel(
+        &mut self,
+    ) -> DIG_REGULATOR0_DBIAS_SEL_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        DIG_REGULATOR0_DBIAS_SEL_W::new(self, 14)
+    }
+    #[doc = "Bit 15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dig_dbias_init(&mut self) -> DIG_DBIAS_INIT_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        DIG_DBIAS_INIT_W::new(self, 15)
+    }
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_slp_mem_xpd(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_SLP_MEM_XPD_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_slp_logic_xpd(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_XPD_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_xpd(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_XPD_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_XPD_W::new(self, 18)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_slp_mem_dbias(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_SLP_MEM_DBIAS_W::new(self, 19)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_slp_logic_dbias(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_SLP_LOGIC_DBIAS_W::new(self, 23)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_dbias(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_DBIAS_W<HP_ACTIVE_HP_REGULATOR0_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_DBIAS_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_regulator0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_regulator0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_HP_REGULATOR0_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_HP_REGULATOR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_hp_regulator0::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_HP_REGULATOR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_hp_regulator0::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_HP_REGULATOR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_HP_REGULATOR0 to value 0xc667_7180"]
+impl crate::Resettable for HP_ACTIVE_HP_REGULATOR0_SPEC {
+    const RESET_VALUE: u32 = 0xc667_7180;
+}

--- a/esp32c6-lp/src/pmu/hp_active_hp_regulator1.rs
+++ b/esp32c6-lp/src/pmu/hp_active_hp_regulator1.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_ACTIVE_HP_REGULATOR1` reader"]
+pub type R = crate::R<HP_ACTIVE_HP_REGULATOR1_SPEC>;
+#[doc = "Register `HP_ACTIVE_HP_REGULATOR1` writer"]
+pub type W = crate::W<HP_ACTIVE_HP_REGULATOR1_SPEC>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_DRV_B` reader - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_DRV_B_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_ACTIVE_HP_REGULATOR_DRV_B` writer - need_des"]
+pub type HP_ACTIVE_HP_REGULATOR_DRV_B_W<'a, REG> = crate::FieldWriter<'a, REG, 24, u32>;
+impl R {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_regulator_drv_b(&self) -> HP_ACTIVE_HP_REGULATOR_DRV_B_R {
+        HP_ACTIVE_HP_REGULATOR_DRV_B_R::new((self.bits >> 8) & 0x00ff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_HP_REGULATOR1")
+            .field(
+                "hp_active_hp_regulator_drv_b",
+                &format_args!("{}", self.hp_active_hp_regulator_drv_b().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_HP_REGULATOR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_regulator_drv_b(
+        &mut self,
+    ) -> HP_ACTIVE_HP_REGULATOR_DRV_B_W<HP_ACTIVE_HP_REGULATOR1_SPEC> {
+        HP_ACTIVE_HP_REGULATOR_DRV_B_W::new(self, 8)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_regulator1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_regulator1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_HP_REGULATOR1_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_HP_REGULATOR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_hp_regulator1::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_HP_REGULATOR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_hp_regulator1::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_HP_REGULATOR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_HP_REGULATOR1 to value 0"]
+impl crate::Resettable for HP_ACTIVE_HP_REGULATOR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_hp_sys_cntl.rs
+++ b/esp32c6-lp/src/pmu/hp_active_hp_sys_cntl.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `HP_ACTIVE_HP_SYS_CNTL` reader"]
+pub type R = crate::R<HP_ACTIVE_HP_SYS_CNTL_SPEC>;
+#[doc = "Register `HP_ACTIVE_HP_SYS_CNTL` writer"]
+pub type W = crate::W<HP_ACTIVE_HP_SYS_CNTL_SPEC>;
+#[doc = "Field `HP_ACTIVE_UART_WAKEUP_EN` reader - need_des"]
+pub type HP_ACTIVE_UART_WAKEUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_UART_WAKEUP_EN` writer - need_des"]
+pub type HP_ACTIVE_UART_WAKEUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_LP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_ACTIVE_LP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_LP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_ACTIVE_LP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_HP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_ACTIVE_HP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_HP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_ACTIVE_HP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_DIG_PAD_SLP_SEL` reader - need_des"]
+pub type HP_ACTIVE_DIG_PAD_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_DIG_PAD_SLP_SEL` writer - need_des"]
+pub type HP_ACTIVE_DIG_PAD_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_DIG_PAUSE_WDT` reader - need_des"]
+pub type HP_ACTIVE_DIG_PAUSE_WDT_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_DIG_PAUSE_WDT` writer - need_des"]
+pub type HP_ACTIVE_DIG_PAUSE_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_DIG_CPU_STALL` reader - need_des"]
+pub type HP_ACTIVE_DIG_CPU_STALL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_DIG_CPU_STALL` writer - need_des"]
+pub type HP_ACTIVE_DIG_CPU_STALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_uart_wakeup_en(&self) -> HP_ACTIVE_UART_WAKEUP_EN_R {
+        HP_ACTIVE_UART_WAKEUP_EN_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_lp_pad_hold_all(&self) -> HP_ACTIVE_LP_PAD_HOLD_ALL_R {
+        HP_ACTIVE_LP_PAD_HOLD_ALL_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_hp_pad_hold_all(&self) -> HP_ACTIVE_HP_PAD_HOLD_ALL_R {
+        HP_ACTIVE_HP_PAD_HOLD_ALL_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_pad_slp_sel(&self) -> HP_ACTIVE_DIG_PAD_SLP_SEL_R {
+        HP_ACTIVE_DIG_PAD_SLP_SEL_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_pause_wdt(&self) -> HP_ACTIVE_DIG_PAUSE_WDT_R {
+        HP_ACTIVE_DIG_PAUSE_WDT_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_cpu_stall(&self) -> HP_ACTIVE_DIG_CPU_STALL_R {
+        HP_ACTIVE_DIG_CPU_STALL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_HP_SYS_CNTL")
+            .field(
+                "hp_active_uart_wakeup_en",
+                &format_args!("{}", self.hp_active_uart_wakeup_en().bit()),
+            )
+            .field(
+                "hp_active_lp_pad_hold_all",
+                &format_args!("{}", self.hp_active_lp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_active_hp_pad_hold_all",
+                &format_args!("{}", self.hp_active_hp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_active_dig_pad_slp_sel",
+                &format_args!("{}", self.hp_active_dig_pad_slp_sel().bit()),
+            )
+            .field(
+                "hp_active_dig_pause_wdt",
+                &format_args!("{}", self.hp_active_dig_pause_wdt().bit()),
+            )
+            .field(
+                "hp_active_dig_cpu_stall",
+                &format_args!("{}", self.hp_active_dig_cpu_stall().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_uart_wakeup_en(
+        &mut self,
+    ) -> HP_ACTIVE_UART_WAKEUP_EN_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_UART_WAKEUP_EN_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_lp_pad_hold_all(
+        &mut self,
+    ) -> HP_ACTIVE_LP_PAD_HOLD_ALL_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_LP_PAD_HOLD_ALL_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_hp_pad_hold_all(
+        &mut self,
+    ) -> HP_ACTIVE_HP_PAD_HOLD_ALL_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_HP_PAD_HOLD_ALL_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_pad_slp_sel(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_PAD_SLP_SEL_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_DIG_PAD_SLP_SEL_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_pause_wdt(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_PAUSE_WDT_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_DIG_PAUSE_WDT_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_cpu_stall(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_CPU_STALL_W<HP_ACTIVE_HP_SYS_CNTL_SPEC> {
+        HP_ACTIVE_DIG_CPU_STALL_W::new(self, 29)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_hp_sys_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_hp_sys_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_HP_SYS_CNTL_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_HP_SYS_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_hp_sys_cntl::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_HP_SYS_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_hp_sys_cntl::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_HP_SYS_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_HP_SYS_CNTL to value 0"]
+impl crate::Resettable for HP_ACTIVE_HP_SYS_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_icg_hp_apb.rs
+++ b/esp32c6-lp/src/pmu/hp_active_icg_hp_apb.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_ACTIVE_ICG_HP_APB` reader"]
+pub type R = crate::R<HP_ACTIVE_ICG_HP_APB_SPEC>;
+#[doc = "Register `HP_ACTIVE_ICG_HP_APB` writer"]
+pub type W = crate::W<HP_ACTIVE_ICG_HP_APB_SPEC>;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_APB_EN` reader - need_des"]
+pub type HP_ACTIVE_DIG_ICG_APB_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_APB_EN` writer - need_des"]
+pub type HP_ACTIVE_DIG_ICG_APB_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_icg_apb_en(&self) -> HP_ACTIVE_DIG_ICG_APB_EN_R {
+        HP_ACTIVE_DIG_ICG_APB_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_ICG_HP_APB")
+            .field(
+                "hp_active_dig_icg_apb_en",
+                &format_args!("{}", self.hp_active_dig_icg_apb_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_ICG_HP_APB_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_icg_apb_en(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_ICG_APB_EN_W<HP_ACTIVE_ICG_HP_APB_SPEC> {
+        HP_ACTIVE_DIG_ICG_APB_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_hp_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_hp_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_ICG_HP_APB_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_ICG_HP_APB_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_icg_hp_apb::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_ICG_HP_APB_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_icg_hp_apb::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_ICG_HP_APB_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_ICG_HP_APB to value 0xffff_ffff"]
+impl crate::Resettable for HP_ACTIVE_ICG_HP_APB_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_active_icg_hp_func.rs
+++ b/esp32c6-lp/src/pmu/hp_active_icg_hp_func.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_ACTIVE_ICG_HP_FUNC` reader"]
+pub type R = crate::R<HP_ACTIVE_ICG_HP_FUNC_SPEC>;
+#[doc = "Register `HP_ACTIVE_ICG_HP_FUNC` writer"]
+pub type W = crate::W<HP_ACTIVE_ICG_HP_FUNC_SPEC>;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_FUNC_EN` reader - need_des"]
+pub type HP_ACTIVE_DIG_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_FUNC_EN` writer - need_des"]
+pub type HP_ACTIVE_DIG_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_icg_func_en(&self) -> HP_ACTIVE_DIG_ICG_FUNC_EN_R {
+        HP_ACTIVE_DIG_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_ICG_HP_FUNC")
+            .field(
+                "hp_active_dig_icg_func_en",
+                &format_args!("{}", self.hp_active_dig_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_ICG_HP_FUNC_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_icg_func_en(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_ICG_FUNC_EN_W<HP_ACTIVE_ICG_HP_FUNC_SPEC> {
+        HP_ACTIVE_DIG_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_hp_func::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_hp_func::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_ICG_HP_FUNC_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_ICG_HP_FUNC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_icg_hp_func::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_ICG_HP_FUNC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_icg_hp_func::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_ICG_HP_FUNC_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_ICG_HP_FUNC to value 0xffff_ffff"]
+impl crate::Resettable for HP_ACTIVE_ICG_HP_FUNC_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_active_icg_modem.rs
+++ b/esp32c6-lp/src/pmu/hp_active_icg_modem.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_ACTIVE_ICG_MODEM` reader"]
+pub type R = crate::R<HP_ACTIVE_ICG_MODEM_SPEC>;
+#[doc = "Register `HP_ACTIVE_ICG_MODEM` writer"]
+pub type W = crate::W<HP_ACTIVE_ICG_MODEM_SPEC>;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_MODEM_CODE` reader - need_des"]
+pub type HP_ACTIVE_DIG_ICG_MODEM_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_DIG_ICG_MODEM_CODE` writer - need_des"]
+pub type HP_ACTIVE_DIG_ICG_MODEM_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_icg_modem_code(&self) -> HP_ACTIVE_DIG_ICG_MODEM_CODE_R {
+        HP_ACTIVE_DIG_ICG_MODEM_CODE_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_ICG_MODEM")
+            .field(
+                "hp_active_dig_icg_modem_code",
+                &format_args!("{}", self.hp_active_dig_icg_modem_code().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_ICG_MODEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_icg_modem_code(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_ICG_MODEM_CODE_W<HP_ACTIVE_ICG_MODEM_SPEC> {
+        HP_ACTIVE_DIG_ICG_MODEM_CODE_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_icg_modem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_icg_modem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_ICG_MODEM_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_ICG_MODEM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_icg_modem::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_ICG_MODEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_icg_modem::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_ICG_MODEM_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_ICG_MODEM to value 0"]
+impl crate::Resettable for HP_ACTIVE_ICG_MODEM_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_sysclk.rs
+++ b/esp32c6-lp/src/pmu/hp_active_sysclk.rs
@@ -1,0 +1,141 @@
+#[doc = "Register `HP_ACTIVE_SYSCLK` reader"]
+pub type R = crate::R<HP_ACTIVE_SYSCLK_SPEC>;
+#[doc = "Register `HP_ACTIVE_SYSCLK` writer"]
+pub type W = crate::W<HP_ACTIVE_SYSCLK_SPEC>;
+#[doc = "Field `HP_ACTIVE_DIG_SYS_CLK_NO_DIV` reader - need_des"]
+pub type HP_ACTIVE_DIG_SYS_CLK_NO_DIV_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_DIG_SYS_CLK_NO_DIV` writer - need_des"]
+pub type HP_ACTIVE_DIG_SYS_CLK_NO_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_ICG_SYS_CLOCK_EN` reader - need_des"]
+pub type HP_ACTIVE_ICG_SYS_CLOCK_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_ICG_SYS_CLOCK_EN` writer - need_des"]
+pub type HP_ACTIVE_ICG_SYS_CLOCK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_SYS_CLK_SLP_SEL` reader - need_des"]
+pub type HP_ACTIVE_SYS_CLK_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_SYS_CLK_SLP_SEL` writer - need_des"]
+pub type HP_ACTIVE_SYS_CLK_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_ICG_SLP_SEL` reader - need_des"]
+pub type HP_ACTIVE_ICG_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_ICG_SLP_SEL` writer - need_des"]
+pub type HP_ACTIVE_ICG_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE_DIG_SYS_CLK_SEL` reader - need_des"]
+pub type HP_ACTIVE_DIG_SYS_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE_DIG_SYS_CLK_SEL` writer - need_des"]
+pub type HP_ACTIVE_DIG_SYS_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_sys_clk_no_div(&self) -> HP_ACTIVE_DIG_SYS_CLK_NO_DIV_R {
+        HP_ACTIVE_DIG_SYS_CLK_NO_DIV_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_icg_sys_clock_en(&self) -> HP_ACTIVE_ICG_SYS_CLOCK_EN_R {
+        HP_ACTIVE_ICG_SYS_CLOCK_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_sys_clk_slp_sel(&self) -> HP_ACTIVE_SYS_CLK_SLP_SEL_R {
+        HP_ACTIVE_SYS_CLK_SLP_SEL_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_icg_slp_sel(&self) -> HP_ACTIVE_ICG_SLP_SEL_R {
+        HP_ACTIVE_ICG_SLP_SEL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_dig_sys_clk_sel(&self) -> HP_ACTIVE_DIG_SYS_CLK_SEL_R {
+        HP_ACTIVE_DIG_SYS_CLK_SEL_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_SYSCLK")
+            .field(
+                "hp_active_dig_sys_clk_no_div",
+                &format_args!("{}", self.hp_active_dig_sys_clk_no_div().bit()),
+            )
+            .field(
+                "hp_active_icg_sys_clock_en",
+                &format_args!("{}", self.hp_active_icg_sys_clock_en().bit()),
+            )
+            .field(
+                "hp_active_sys_clk_slp_sel",
+                &format_args!("{}", self.hp_active_sys_clk_slp_sel().bit()),
+            )
+            .field(
+                "hp_active_icg_slp_sel",
+                &format_args!("{}", self.hp_active_icg_slp_sel().bit()),
+            )
+            .field(
+                "hp_active_dig_sys_clk_sel",
+                &format_args!("{}", self.hp_active_dig_sys_clk_sel().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_SYSCLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_sys_clk_no_div(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_SYS_CLK_NO_DIV_W<HP_ACTIVE_SYSCLK_SPEC> {
+        HP_ACTIVE_DIG_SYS_CLK_NO_DIV_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_icg_sys_clock_en(
+        &mut self,
+    ) -> HP_ACTIVE_ICG_SYS_CLOCK_EN_W<HP_ACTIVE_SYSCLK_SPEC> {
+        HP_ACTIVE_ICG_SYS_CLOCK_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_sys_clk_slp_sel(
+        &mut self,
+    ) -> HP_ACTIVE_SYS_CLK_SLP_SEL_W<HP_ACTIVE_SYSCLK_SPEC> {
+        HP_ACTIVE_SYS_CLK_SLP_SEL_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_icg_slp_sel(&mut self) -> HP_ACTIVE_ICG_SLP_SEL_W<HP_ACTIVE_SYSCLK_SPEC> {
+        HP_ACTIVE_ICG_SLP_SEL_W::new(self, 29)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_dig_sys_clk_sel(
+        &mut self,
+    ) -> HP_ACTIVE_DIG_SYS_CLK_SEL_W<HP_ACTIVE_SYSCLK_SPEC> {
+        HP_ACTIVE_DIG_SYS_CLK_SEL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_sysclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_sysclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_SYSCLK_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_SYSCLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_sysclk::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_SYSCLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_sysclk::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_SYSCLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_SYSCLK to value 0"]
+impl crate::Resettable for HP_ACTIVE_SYSCLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_active_xtal.rs
+++ b/esp32c6-lp/src/pmu/hp_active_xtal.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `HP_ACTIVE_XTAL` reader"]
+pub type R = crate::R<HP_ACTIVE_XTAL_SPEC>;
+#[doc = "Register `HP_ACTIVE_XTAL` writer"]
+pub type W = crate::W<HP_ACTIVE_XTAL_SPEC>;
+#[doc = "Field `HP_ACTIVE_XPD_XTAL` reader - need_des"]
+pub type HP_ACTIVE_XPD_XTAL_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE_XPD_XTAL` writer - need_des"]
+pub type HP_ACTIVE_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active_xpd_xtal(&self) -> HP_ACTIVE_XPD_XTAL_R {
+        HP_ACTIVE_XPD_XTAL_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_ACTIVE_XTAL")
+            .field(
+                "hp_active_xpd_xtal",
+                &format_args!("{}", self.hp_active_xpd_xtal().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_ACTIVE_XTAL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active_xpd_xtal(&mut self) -> HP_ACTIVE_XPD_XTAL_W<HP_ACTIVE_XTAL_SPEC> {
+        HP_ACTIVE_XPD_XTAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_active_xtal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_active_xtal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_ACTIVE_XTAL_SPEC;
+impl crate::RegisterSpec for HP_ACTIVE_XTAL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_active_xtal::R`](R) reader structure"]
+impl crate::Readable for HP_ACTIVE_XTAL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_active_xtal::W`](W) writer structure"]
+impl crate::Writable for HP_ACTIVE_XTAL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_ACTIVE_XTAL to value 0x8000_0000"]
+impl crate::Resettable for HP_ACTIVE_XTAL_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_ck_cntl.rs
+++ b/esp32c6-lp/src/pmu/hp_ck_cntl.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `HP_CK_CNTL` reader"]
+pub type R = crate::R<HP_CK_CNTL_SPEC>;
+#[doc = "Register `HP_CK_CNTL` writer"]
+pub type W = crate::W<HP_CK_CNTL_SPEC>;
+#[doc = "Field `MODIFY_ICG_CNTL_WAIT` reader - need_des"]
+pub type MODIFY_ICG_CNTL_WAIT_R = crate::FieldReader;
+#[doc = "Field `MODIFY_ICG_CNTL_WAIT` writer - need_des"]
+pub type MODIFY_ICG_CNTL_WAIT_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `SWITCH_ICG_CNTL_WAIT` reader - need_des"]
+pub type SWITCH_ICG_CNTL_WAIT_R = crate::FieldReader;
+#[doc = "Field `SWITCH_ICG_CNTL_WAIT` writer - need_des"]
+pub type SWITCH_ICG_CNTL_WAIT_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+impl R {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    pub fn modify_icg_cntl_wait(&self) -> MODIFY_ICG_CNTL_WAIT_R {
+        MODIFY_ICG_CNTL_WAIT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 8:15 - need_des"]
+    #[inline(always)]
+    pub fn switch_icg_cntl_wait(&self) -> SWITCH_ICG_CNTL_WAIT_R {
+        SWITCH_ICG_CNTL_WAIT_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_CK_CNTL")
+            .field(
+                "modify_icg_cntl_wait",
+                &format_args!("{}", self.modify_icg_cntl_wait().bits()),
+            )
+            .field(
+                "switch_icg_cntl_wait",
+                &format_args!("{}", self.switch_icg_cntl_wait().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_CK_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modify_icg_cntl_wait(&mut self) -> MODIFY_ICG_CNTL_WAIT_W<HP_CK_CNTL_SPEC> {
+        MODIFY_ICG_CNTL_WAIT_W::new(self, 0)
+    }
+    #[doc = "Bits 8:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn switch_icg_cntl_wait(&mut self) -> SWITCH_ICG_CNTL_WAIT_W<HP_CK_CNTL_SPEC> {
+        SWITCH_ICG_CNTL_WAIT_W::new(self, 8)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_ck_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_ck_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_CK_CNTL_SPEC;
+impl crate::RegisterSpec for HP_CK_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_ck_cntl::R`](R) reader structure"]
+impl crate::Readable for HP_CK_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_ck_cntl::W`](W) writer structure"]
+impl crate::Writable for HP_CK_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_CK_CNTL to value 0x0a0a"]
+impl crate::Resettable for HP_CK_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x0a0a;
+}

--- a/esp32c6-lp/src/pmu/hp_ck_poweron.rs
+++ b/esp32c6-lp/src/pmu/hp_ck_poweron.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `HP_CK_POWERON` reader"]
+pub type R = crate::R<HP_CK_POWERON_SPEC>;
+#[doc = "Register `HP_CK_POWERON` writer"]
+pub type W = crate::W<HP_CK_POWERON_SPEC>;
+#[doc = "Field `I2C_POR_WAIT_TARGET` reader - need_des"]
+pub type I2C_POR_WAIT_TARGET_R = crate::FieldReader;
+#[doc = "Field `I2C_POR_WAIT_TARGET` writer - need_des"]
+pub type I2C_POR_WAIT_TARGET_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+impl R {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    pub fn i2c_por_wait_target(&self) -> I2C_POR_WAIT_TARGET_R {
+        I2C_POR_WAIT_TARGET_R::new((self.bits & 0xff) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_CK_POWERON")
+            .field(
+                "i2c_por_wait_target",
+                &format_args!("{}", self.i2c_por_wait_target().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_CK_POWERON_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn i2c_por_wait_target(&mut self) -> I2C_POR_WAIT_TARGET_W<HP_CK_POWERON_SPEC> {
+        I2C_POR_WAIT_TARGET_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_ck_poweron::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_ck_poweron::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_CK_POWERON_SPEC;
+impl crate::RegisterSpec for HP_CK_POWERON_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_ck_poweron::R`](R) reader structure"]
+impl crate::Readable for HP_CK_POWERON_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_ck_poweron::W`](W) writer structure"]
+impl crate::Writable for HP_CK_POWERON_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_CK_POWERON to value 0x32"]
+impl crate::Resettable for HP_CK_POWERON_SPEC {
+    const RESET_VALUE: u32 = 0x32;
+}

--- a/esp32c6-lp/src/pmu/hp_lp_cpu_comm.rs
+++ b/esp32c6-lp/src/pmu/hp_lp_cpu_comm.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `HP_LP_CPU_COMM` writer"]
+pub type W = crate::W<HP_LP_CPU_COMM_SPEC>;
+#[doc = "Field `LP_TRIGGER_HP` writer - need_des"]
+pub type LP_TRIGGER_HP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_TRIGGER_LP` writer - need_des"]
+pub type HP_TRIGGER_LP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_LP_CPU_COMM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_trigger_hp(&mut self) -> LP_TRIGGER_HP_W<HP_LP_CPU_COMM_SPEC> {
+        LP_TRIGGER_HP_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_trigger_lp(&mut self) -> HP_TRIGGER_LP_W<HP_LP_CPU_COMM_SPEC> {
+        HP_TRIGGER_LP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_lp_cpu_comm::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_LP_CPU_COMM_SPEC;
+impl crate::RegisterSpec for HP_LP_CPU_COMM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`hp_lp_cpu_comm::W`](W) writer structure"]
+impl crate::Writable for HP_LP_CPU_COMM_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_LP_CPU_COMM to value 0"]
+impl crate::Resettable for HP_LP_CPU_COMM_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_backup.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_backup.rs
@@ -1,0 +1,160 @@
+#[doc = "Register `HP_MODEM_BACKUP` reader"]
+pub type R = crate::R<HP_MODEM_BACKUP_SPEC>;
+#[doc = "Register `HP_MODEM_BACKUP` writer"]
+pub type W = crate::W<HP_MODEM_BACKUP_SPEC>;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE` reader - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE` writer - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_MODEM_RETENTION_MODE` reader - need_des"]
+pub type HP_MODEM_RETENTION_MODE_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_RETENTION_MODE` writer - need_des"]
+pub type HP_MODEM_RETENTION_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP2MODEM_RETENTION_EN` reader - need_des"]
+pub type HP_SLEEP2MODEM_RETENTION_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP2MODEM_RETENTION_EN` writer - need_des"]
+pub type HP_SLEEP2MODEM_RETENTION_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_CLK_SEL` reader - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_CLK_SEL` writer - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_MODE` reader - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_MODE_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_MODE` writer - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_EN` reader - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP2MODEM_BACKUP_EN` writer - need_des"]
+pub type HP_SLEEP2MODEM_BACKUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 4:5 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2modem_backup_modem_clk_code(&self) -> HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_R {
+        HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_retention_mode(&self) -> HP_MODEM_RETENTION_MODE_R {
+        HP_MODEM_RETENTION_MODE_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2modem_retention_en(&self) -> HP_SLEEP2MODEM_RETENTION_EN_R {
+        HP_SLEEP2MODEM_RETENTION_EN_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bits 14:15 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2modem_backup_clk_sel(&self) -> HP_SLEEP2MODEM_BACKUP_CLK_SEL_R {
+        HP_SLEEP2MODEM_BACKUP_CLK_SEL_R::new(((self.bits >> 14) & 3) as u8)
+    }
+    #[doc = "Bits 20:22 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2modem_backup_mode(&self) -> HP_SLEEP2MODEM_BACKUP_MODE_R {
+        HP_SLEEP2MODEM_BACKUP_MODE_R::new(((self.bits >> 20) & 7) as u8)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep2modem_backup_en(&self) -> HP_SLEEP2MODEM_BACKUP_EN_R {
+        HP_SLEEP2MODEM_BACKUP_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_BACKUP")
+            .field(
+                "hp_sleep2modem_backup_modem_clk_code",
+                &format_args!("{}", self.hp_sleep2modem_backup_modem_clk_code().bits()),
+            )
+            .field(
+                "hp_modem_retention_mode",
+                &format_args!("{}", self.hp_modem_retention_mode().bit()),
+            )
+            .field(
+                "hp_sleep2modem_retention_en",
+                &format_args!("{}", self.hp_sleep2modem_retention_en().bit()),
+            )
+            .field(
+                "hp_sleep2modem_backup_clk_sel",
+                &format_args!("{}", self.hp_sleep2modem_backup_clk_sel().bits()),
+            )
+            .field(
+                "hp_sleep2modem_backup_mode",
+                &format_args!("{}", self.hp_sleep2modem_backup_mode().bits()),
+            )
+            .field(
+                "hp_sleep2modem_backup_en",
+                &format_args!("{}", self.hp_sleep2modem_backup_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_BACKUP_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 4:5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2modem_backup_modem_clk_code(
+        &mut self,
+    ) -> HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_W<HP_MODEM_BACKUP_SPEC> {
+        HP_SLEEP2MODEM_BACKUP_MODEM_CLK_CODE_W::new(self, 4)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_retention_mode(&mut self) -> HP_MODEM_RETENTION_MODE_W<HP_MODEM_BACKUP_SPEC> {
+        HP_MODEM_RETENTION_MODE_W::new(self, 10)
+    }
+    #[doc = "Bit 11 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2modem_retention_en(
+        &mut self,
+    ) -> HP_SLEEP2MODEM_RETENTION_EN_W<HP_MODEM_BACKUP_SPEC> {
+        HP_SLEEP2MODEM_RETENTION_EN_W::new(self, 11)
+    }
+    #[doc = "Bits 14:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2modem_backup_clk_sel(
+        &mut self,
+    ) -> HP_SLEEP2MODEM_BACKUP_CLK_SEL_W<HP_MODEM_BACKUP_SPEC> {
+        HP_SLEEP2MODEM_BACKUP_CLK_SEL_W::new(self, 14)
+    }
+    #[doc = "Bits 20:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2modem_backup_mode(
+        &mut self,
+    ) -> HP_SLEEP2MODEM_BACKUP_MODE_W<HP_MODEM_BACKUP_SPEC> {
+        HP_SLEEP2MODEM_BACKUP_MODE_W::new(self, 20)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep2modem_backup_en(&mut self) -> HP_SLEEP2MODEM_BACKUP_EN_W<HP_MODEM_BACKUP_SPEC> {
+        HP_SLEEP2MODEM_BACKUP_EN_W::new(self, 29)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_backup::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_backup::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_BACKUP_SPEC;
+impl crate::RegisterSpec for HP_MODEM_BACKUP_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_backup::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_BACKUP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_backup::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_BACKUP_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_BACKUP to value 0"]
+impl crate::Resettable for HP_MODEM_BACKUP_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_backup_clk.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_backup_clk.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_MODEM_BACKUP_CLK` reader"]
+pub type R = crate::R<HP_MODEM_BACKUP_CLK_SPEC>;
+#[doc = "Register `HP_MODEM_BACKUP_CLK` writer"]
+pub type W = crate::W<HP_MODEM_BACKUP_CLK_SPEC>;
+#[doc = "Field `HP_MODEM_BACKUP_ICG_FUNC_EN` reader - need_des"]
+pub type HP_MODEM_BACKUP_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_MODEM_BACKUP_ICG_FUNC_EN` writer - need_des"]
+pub type HP_MODEM_BACKUP_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_backup_icg_func_en(&self) -> HP_MODEM_BACKUP_ICG_FUNC_EN_R {
+        HP_MODEM_BACKUP_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_BACKUP_CLK")
+            .field(
+                "hp_modem_backup_icg_func_en",
+                &format_args!("{}", self.hp_modem_backup_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_BACKUP_CLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_backup_icg_func_en(
+        &mut self,
+    ) -> HP_MODEM_BACKUP_ICG_FUNC_EN_W<HP_MODEM_BACKUP_CLK_SPEC> {
+        HP_MODEM_BACKUP_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_backup_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_backup_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_BACKUP_CLK_SPEC;
+impl crate::RegisterSpec for HP_MODEM_BACKUP_CLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_backup_clk::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_BACKUP_CLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_backup_clk::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_BACKUP_CLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_BACKUP_CLK to value 0"]
+impl crate::Resettable for HP_MODEM_BACKUP_CLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_bias.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_bias.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `HP_MODEM_BIAS` reader"]
+pub type R = crate::R<HP_MODEM_BIAS_SPEC>;
+#[doc = "Register `HP_MODEM_BIAS` writer"]
+pub type W = crate::W<HP_MODEM_BIAS_SPEC>;
+#[doc = "Field `HP_MODEM_XPD_BIAS` reader - need_des"]
+pub type HP_MODEM_XPD_BIAS_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_XPD_BIAS` writer - need_des"]
+pub type HP_MODEM_XPD_BIAS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_DBG_ATTEN` reader - need_des"]
+pub type HP_MODEM_DBG_ATTEN_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_DBG_ATTEN` writer - need_des"]
+pub type HP_MODEM_DBG_ATTEN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_MODEM_PD_CUR` reader - need_des"]
+pub type HP_MODEM_PD_CUR_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_PD_CUR` writer - need_des"]
+pub type HP_MODEM_PD_CUR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP` reader - need_des"]
+pub type SLEEP_R = crate::BitReader;
+#[doc = "Field `SLEEP` writer - need_des"]
+pub type SLEEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_xpd_bias(&self) -> HP_MODEM_XPD_BIAS_R {
+        HP_MODEM_XPD_BIAS_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dbg_atten(&self) -> HP_MODEM_DBG_ATTEN_R {
+        HP_MODEM_DBG_ATTEN_R::new(((self.bits >> 26) & 0x0f) as u8)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_cur(&self) -> HP_MODEM_PD_CUR_R {
+        HP_MODEM_PD_CUR_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn sleep(&self) -> SLEEP_R {
+        SLEEP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_BIAS")
+            .field(
+                "hp_modem_xpd_bias",
+                &format_args!("{}", self.hp_modem_xpd_bias().bit()),
+            )
+            .field(
+                "hp_modem_dbg_atten",
+                &format_args!("{}", self.hp_modem_dbg_atten().bits()),
+            )
+            .field(
+                "hp_modem_pd_cur",
+                &format_args!("{}", self.hp_modem_pd_cur().bit()),
+            )
+            .field("sleep", &format_args!("{}", self.sleep().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_BIAS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_xpd_bias(&mut self) -> HP_MODEM_XPD_BIAS_W<HP_MODEM_BIAS_SPEC> {
+        HP_MODEM_XPD_BIAS_W::new(self, 25)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dbg_atten(&mut self) -> HP_MODEM_DBG_ATTEN_W<HP_MODEM_BIAS_SPEC> {
+        HP_MODEM_DBG_ATTEN_W::new(self, 26)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_cur(&mut self) -> HP_MODEM_PD_CUR_W<HP_MODEM_BIAS_SPEC> {
+        HP_MODEM_PD_CUR_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep(&mut self) -> SLEEP_W<HP_MODEM_BIAS_SPEC> {
+        SLEEP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_bias::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_bias::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_BIAS_SPEC;
+impl crate::RegisterSpec for HP_MODEM_BIAS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_bias::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_BIAS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_bias::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_BIAS_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_BIAS to value 0"]
+impl crate::Resettable for HP_MODEM_BIAS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_dig_power.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_dig_power.rs
@@ -1,0 +1,179 @@
+#[doc = "Register `HP_MODEM_DIG_POWER` reader"]
+pub type R = crate::R<HP_MODEM_DIG_POWER_SPEC>;
+#[doc = "Register `HP_MODEM_DIG_POWER` writer"]
+pub type W = crate::W<HP_MODEM_DIG_POWER_SPEC>;
+#[doc = "Field `HP_MODEM_VDD_SPI_PD_EN` reader - need_des"]
+pub type HP_MODEM_VDD_SPI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_VDD_SPI_PD_EN` writer - need_des"]
+pub type HP_MODEM_VDD_SPI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_HP_MEM_DSLP` reader - need_des"]
+pub type HP_MODEM_HP_MEM_DSLP_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_HP_MEM_DSLP` writer - need_des"]
+pub type HP_MODEM_HP_MEM_DSLP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_PD_HP_MEM_PD_EN` reader - need_des"]
+pub type HP_MODEM_PD_HP_MEM_PD_EN_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_PD_HP_MEM_PD_EN` writer - need_des"]
+pub type HP_MODEM_PD_HP_MEM_PD_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_MODEM_PD_HP_WIFI_PD_EN` reader - need_des"]
+pub type HP_MODEM_PD_HP_WIFI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_PD_HP_WIFI_PD_EN` writer - need_des"]
+pub type HP_MODEM_PD_HP_WIFI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_PD_HP_CPU_PD_EN` reader - need_des"]
+pub type HP_MODEM_PD_HP_CPU_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_PD_HP_CPU_PD_EN` writer - need_des"]
+pub type HP_MODEM_PD_HP_CPU_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_PD_HP_AON_PD_EN` reader - need_des"]
+pub type HP_MODEM_PD_HP_AON_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_PD_HP_AON_PD_EN` writer - need_des"]
+pub type HP_MODEM_PD_HP_AON_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_PD_TOP_PD_EN` reader - need_des"]
+pub type HP_MODEM_PD_TOP_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_PD_TOP_PD_EN` writer - need_des"]
+pub type HP_MODEM_PD_TOP_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_vdd_spi_pd_en(&self) -> HP_MODEM_VDD_SPI_PD_EN_R {
+        HP_MODEM_VDD_SPI_PD_EN_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_mem_dslp(&self) -> HP_MODEM_HP_MEM_DSLP_R {
+        HP_MODEM_HP_MEM_DSLP_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_hp_mem_pd_en(&self) -> HP_MODEM_PD_HP_MEM_PD_EN_R {
+        HP_MODEM_PD_HP_MEM_PD_EN_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_hp_wifi_pd_en(&self) -> HP_MODEM_PD_HP_WIFI_PD_EN_R {
+        HP_MODEM_PD_HP_WIFI_PD_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_hp_cpu_pd_en(&self) -> HP_MODEM_PD_HP_CPU_PD_EN_R {
+        HP_MODEM_PD_HP_CPU_PD_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_hp_aon_pd_en(&self) -> HP_MODEM_PD_HP_AON_PD_EN_R {
+        HP_MODEM_PD_HP_AON_PD_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_pd_top_pd_en(&self) -> HP_MODEM_PD_TOP_PD_EN_R {
+        HP_MODEM_PD_TOP_PD_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_DIG_POWER")
+            .field(
+                "hp_modem_vdd_spi_pd_en",
+                &format_args!("{}", self.hp_modem_vdd_spi_pd_en().bit()),
+            )
+            .field(
+                "hp_modem_hp_mem_dslp",
+                &format_args!("{}", self.hp_modem_hp_mem_dslp().bit()),
+            )
+            .field(
+                "hp_modem_pd_hp_mem_pd_en",
+                &format_args!("{}", self.hp_modem_pd_hp_mem_pd_en().bits()),
+            )
+            .field(
+                "hp_modem_pd_hp_wifi_pd_en",
+                &format_args!("{}", self.hp_modem_pd_hp_wifi_pd_en().bit()),
+            )
+            .field(
+                "hp_modem_pd_hp_cpu_pd_en",
+                &format_args!("{}", self.hp_modem_pd_hp_cpu_pd_en().bit()),
+            )
+            .field(
+                "hp_modem_pd_hp_aon_pd_en",
+                &format_args!("{}", self.hp_modem_pd_hp_aon_pd_en().bit()),
+            )
+            .field(
+                "hp_modem_pd_top_pd_en",
+                &format_args!("{}", self.hp_modem_pd_top_pd_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_DIG_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_vdd_spi_pd_en(&mut self) -> HP_MODEM_VDD_SPI_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_VDD_SPI_PD_EN_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_mem_dslp(&mut self) -> HP_MODEM_HP_MEM_DSLP_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_HP_MEM_DSLP_W::new(self, 22)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_hp_mem_pd_en(
+        &mut self,
+    ) -> HP_MODEM_PD_HP_MEM_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_PD_HP_MEM_PD_EN_W::new(self, 23)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_hp_wifi_pd_en(
+        &mut self,
+    ) -> HP_MODEM_PD_HP_WIFI_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_PD_HP_WIFI_PD_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_hp_cpu_pd_en(
+        &mut self,
+    ) -> HP_MODEM_PD_HP_CPU_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_PD_HP_CPU_PD_EN_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_hp_aon_pd_en(
+        &mut self,
+    ) -> HP_MODEM_PD_HP_AON_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_PD_HP_AON_PD_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_pd_top_pd_en(&mut self) -> HP_MODEM_PD_TOP_PD_EN_W<HP_MODEM_DIG_POWER_SPEC> {
+        HP_MODEM_PD_TOP_PD_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_dig_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_dig_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_DIG_POWER_SPEC;
+impl crate::RegisterSpec for HP_MODEM_DIG_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_dig_power::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_DIG_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_dig_power::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_DIG_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_DIG_POWER to value 0"]
+impl crate::Resettable for HP_MODEM_DIG_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_hp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_hp_ck_power.rs
@@ -1,0 +1,137 @@
+#[doc = "Register `HP_MODEM_HP_CK_POWER` reader"]
+pub type R = crate::R<HP_MODEM_HP_CK_POWER_SPEC>;
+#[doc = "Register `HP_MODEM_HP_CK_POWER` writer"]
+pub type W = crate::W<HP_MODEM_HP_CK_POWER_SPEC>;
+#[doc = "Field `HP_MODEM_I2C_ISO_EN` reader - need_des"]
+pub type HP_MODEM_I2C_ISO_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_I2C_ISO_EN` writer - need_des"]
+pub type HP_MODEM_I2C_ISO_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_I2C_RETENTION` reader - need_des"]
+pub type HP_MODEM_I2C_RETENTION_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_I2C_RETENTION` writer - need_des"]
+pub type HP_MODEM_I2C_RETENTION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_XPD_BB_I2C` reader - need_des"]
+pub type HP_MODEM_XPD_BB_I2C_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_XPD_BB_I2C` writer - need_des"]
+pub type HP_MODEM_XPD_BB_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_XPD_BBPLL_I2C` reader - need_des"]
+pub type HP_MODEM_XPD_BBPLL_I2C_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_XPD_BBPLL_I2C` writer - need_des"]
+pub type HP_MODEM_XPD_BBPLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_XPD_BBPLL` reader - need_des"]
+pub type HP_MODEM_XPD_BBPLL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_XPD_BBPLL` writer - need_des"]
+pub type HP_MODEM_XPD_BBPLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_i2c_iso_en(&self) -> HP_MODEM_I2C_ISO_EN_R {
+        HP_MODEM_I2C_ISO_EN_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_i2c_retention(&self) -> HP_MODEM_I2C_RETENTION_R {
+        HP_MODEM_I2C_RETENTION_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_xpd_bb_i2c(&self) -> HP_MODEM_XPD_BB_I2C_R {
+        HP_MODEM_XPD_BB_I2C_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_xpd_bbpll_i2c(&self) -> HP_MODEM_XPD_BBPLL_I2C_R {
+        HP_MODEM_XPD_BBPLL_I2C_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_xpd_bbpll(&self) -> HP_MODEM_XPD_BBPLL_R {
+        HP_MODEM_XPD_BBPLL_R::new(((self.bits >> 30) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_HP_CK_POWER")
+            .field(
+                "hp_modem_i2c_iso_en",
+                &format_args!("{}", self.hp_modem_i2c_iso_en().bit()),
+            )
+            .field(
+                "hp_modem_i2c_retention",
+                &format_args!("{}", self.hp_modem_i2c_retention().bit()),
+            )
+            .field(
+                "hp_modem_xpd_bb_i2c",
+                &format_args!("{}", self.hp_modem_xpd_bb_i2c().bit()),
+            )
+            .field(
+                "hp_modem_xpd_bbpll_i2c",
+                &format_args!("{}", self.hp_modem_xpd_bbpll_i2c().bit()),
+            )
+            .field(
+                "hp_modem_xpd_bbpll",
+                &format_args!("{}", self.hp_modem_xpd_bbpll().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_HP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_i2c_iso_en(&mut self) -> HP_MODEM_I2C_ISO_EN_W<HP_MODEM_HP_CK_POWER_SPEC> {
+        HP_MODEM_I2C_ISO_EN_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_i2c_retention(
+        &mut self,
+    ) -> HP_MODEM_I2C_RETENTION_W<HP_MODEM_HP_CK_POWER_SPEC> {
+        HP_MODEM_I2C_RETENTION_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_xpd_bb_i2c(&mut self) -> HP_MODEM_XPD_BB_I2C_W<HP_MODEM_HP_CK_POWER_SPEC> {
+        HP_MODEM_XPD_BB_I2C_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_xpd_bbpll_i2c(
+        &mut self,
+    ) -> HP_MODEM_XPD_BBPLL_I2C_W<HP_MODEM_HP_CK_POWER_SPEC> {
+        HP_MODEM_XPD_BBPLL_I2C_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_xpd_bbpll(&mut self) -> HP_MODEM_XPD_BBPLL_W<HP_MODEM_HP_CK_POWER_SPEC> {
+        HP_MODEM_XPD_BBPLL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_HP_CK_POWER_SPEC;
+impl crate::RegisterSpec for HP_MODEM_HP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_hp_ck_power::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_HP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_hp_ck_power::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_HP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_HP_CK_POWER to value 0"]
+impl crate::Resettable for HP_MODEM_HP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_hp_regulator0.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_hp_regulator0.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `HP_MODEM_HP_REGULATOR0` reader"]
+pub type R = crate::R<HP_MODEM_HP_REGULATOR0_SPEC>;
+#[doc = "Register `HP_MODEM_HP_REGULATOR0` writer"]
+pub type W = crate::W<HP_MODEM_HP_REGULATOR0_SPEC>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_MEM_XPD` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_MEM_XPD` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_XPD` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_XPD_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_XPD` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_DBIAS` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_DBIAS` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_slp_mem_xpd(&self) -> HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_R {
+        HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_slp_logic_xpd(&self) -> HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_R {
+        HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_xpd(&self) -> HP_MODEM_HP_REGULATOR_XPD_R {
+        HP_MODEM_HP_REGULATOR_XPD_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_slp_mem_dbias(&self) -> HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_R {
+        HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_R::new(((self.bits >> 19) & 0x0f) as u8)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_slp_logic_dbias(&self) -> HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_R {
+        HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_dbias(&self) -> HP_MODEM_HP_REGULATOR_DBIAS_R {
+        HP_MODEM_HP_REGULATOR_DBIAS_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_HP_REGULATOR0")
+            .field(
+                "hp_modem_hp_regulator_slp_mem_xpd",
+                &format_args!("{}", self.hp_modem_hp_regulator_slp_mem_xpd().bit()),
+            )
+            .field(
+                "hp_modem_hp_regulator_slp_logic_xpd",
+                &format_args!("{}", self.hp_modem_hp_regulator_slp_logic_xpd().bit()),
+            )
+            .field(
+                "hp_modem_hp_regulator_xpd",
+                &format_args!("{}", self.hp_modem_hp_regulator_xpd().bit()),
+            )
+            .field(
+                "hp_modem_hp_regulator_slp_mem_dbias",
+                &format_args!("{}", self.hp_modem_hp_regulator_slp_mem_dbias().bits()),
+            )
+            .field(
+                "hp_modem_hp_regulator_slp_logic_dbias",
+                &format_args!("{}", self.hp_modem_hp_regulator_slp_logic_dbias().bits()),
+            )
+            .field(
+                "hp_modem_hp_regulator_dbias",
+                &format_args!("{}", self.hp_modem_hp_regulator_dbias().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_HP_REGULATOR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_slp_mem_xpd(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_SLP_MEM_XPD_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_slp_logic_xpd(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_SLP_LOGIC_XPD_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_xpd(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_XPD_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_XPD_W::new(self, 18)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_slp_mem_dbias(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_SLP_MEM_DBIAS_W::new(self, 19)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_slp_logic_dbias(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_SLP_LOGIC_DBIAS_W::new(self, 23)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_dbias(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_DBIAS_W<HP_MODEM_HP_REGULATOR0_SPEC> {
+        HP_MODEM_HP_REGULATOR_DBIAS_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_regulator0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_regulator0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_HP_REGULATOR0_SPEC;
+impl crate::RegisterSpec for HP_MODEM_HP_REGULATOR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_hp_regulator0::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_HP_REGULATOR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_hp_regulator0::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_HP_REGULATOR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_HP_REGULATOR0 to value 0xc667_0000"]
+impl crate::Resettable for HP_MODEM_HP_REGULATOR0_SPEC {
+    const RESET_VALUE: u32 = 0xc667_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_hp_regulator1.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_hp_regulator1.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_MODEM_HP_REGULATOR1` reader"]
+pub type R = crate::R<HP_MODEM_HP_REGULATOR1_SPEC>;
+#[doc = "Register `HP_MODEM_HP_REGULATOR1` writer"]
+pub type W = crate::W<HP_MODEM_HP_REGULATOR1_SPEC>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_DRV_B` reader - need_des"]
+pub type HP_MODEM_HP_REGULATOR_DRV_B_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_MODEM_HP_REGULATOR_DRV_B` writer - need_des"]
+pub type HP_MODEM_HP_REGULATOR_DRV_B_W<'a, REG> = crate::FieldWriter<'a, REG, 24, u32>;
+impl R {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_regulator_drv_b(&self) -> HP_MODEM_HP_REGULATOR_DRV_B_R {
+        HP_MODEM_HP_REGULATOR_DRV_B_R::new((self.bits >> 8) & 0x00ff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_HP_REGULATOR1")
+            .field(
+                "hp_modem_hp_regulator_drv_b",
+                &format_args!("{}", self.hp_modem_hp_regulator_drv_b().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_HP_REGULATOR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_regulator_drv_b(
+        &mut self,
+    ) -> HP_MODEM_HP_REGULATOR_DRV_B_W<HP_MODEM_HP_REGULATOR1_SPEC> {
+        HP_MODEM_HP_REGULATOR_DRV_B_W::new(self, 8)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_regulator1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_regulator1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_HP_REGULATOR1_SPEC;
+impl crate::RegisterSpec for HP_MODEM_HP_REGULATOR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_hp_regulator1::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_HP_REGULATOR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_hp_regulator1::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_HP_REGULATOR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_HP_REGULATOR1 to value 0"]
+impl crate::Resettable for HP_MODEM_HP_REGULATOR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_hp_sys_cntl.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_hp_sys_cntl.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `HP_MODEM_HP_SYS_CNTL` reader"]
+pub type R = crate::R<HP_MODEM_HP_SYS_CNTL_SPEC>;
+#[doc = "Register `HP_MODEM_HP_SYS_CNTL` writer"]
+pub type W = crate::W<HP_MODEM_HP_SYS_CNTL_SPEC>;
+#[doc = "Field `HP_MODEM_UART_WAKEUP_EN` reader - need_des"]
+pub type HP_MODEM_UART_WAKEUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_UART_WAKEUP_EN` writer - need_des"]
+pub type HP_MODEM_UART_WAKEUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_LP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_MODEM_LP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_LP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_MODEM_LP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_HP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_MODEM_HP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_HP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_MODEM_HP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_DIG_PAD_SLP_SEL` reader - need_des"]
+pub type HP_MODEM_DIG_PAD_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_DIG_PAD_SLP_SEL` writer - need_des"]
+pub type HP_MODEM_DIG_PAD_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_DIG_PAUSE_WDT` reader - need_des"]
+pub type HP_MODEM_DIG_PAUSE_WDT_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_DIG_PAUSE_WDT` writer - need_des"]
+pub type HP_MODEM_DIG_PAUSE_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_DIG_CPU_STALL` reader - need_des"]
+pub type HP_MODEM_DIG_CPU_STALL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_DIG_CPU_STALL` writer - need_des"]
+pub type HP_MODEM_DIG_CPU_STALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_uart_wakeup_en(&self) -> HP_MODEM_UART_WAKEUP_EN_R {
+        HP_MODEM_UART_WAKEUP_EN_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_lp_pad_hold_all(&self) -> HP_MODEM_LP_PAD_HOLD_ALL_R {
+        HP_MODEM_LP_PAD_HOLD_ALL_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_hp_pad_hold_all(&self) -> HP_MODEM_HP_PAD_HOLD_ALL_R {
+        HP_MODEM_HP_PAD_HOLD_ALL_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_pad_slp_sel(&self) -> HP_MODEM_DIG_PAD_SLP_SEL_R {
+        HP_MODEM_DIG_PAD_SLP_SEL_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_pause_wdt(&self) -> HP_MODEM_DIG_PAUSE_WDT_R {
+        HP_MODEM_DIG_PAUSE_WDT_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_cpu_stall(&self) -> HP_MODEM_DIG_CPU_STALL_R {
+        HP_MODEM_DIG_CPU_STALL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_HP_SYS_CNTL")
+            .field(
+                "hp_modem_uart_wakeup_en",
+                &format_args!("{}", self.hp_modem_uart_wakeup_en().bit()),
+            )
+            .field(
+                "hp_modem_lp_pad_hold_all",
+                &format_args!("{}", self.hp_modem_lp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_modem_hp_pad_hold_all",
+                &format_args!("{}", self.hp_modem_hp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_modem_dig_pad_slp_sel",
+                &format_args!("{}", self.hp_modem_dig_pad_slp_sel().bit()),
+            )
+            .field(
+                "hp_modem_dig_pause_wdt",
+                &format_args!("{}", self.hp_modem_dig_pause_wdt().bit()),
+            )
+            .field(
+                "hp_modem_dig_cpu_stall",
+                &format_args!("{}", self.hp_modem_dig_cpu_stall().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_HP_SYS_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_uart_wakeup_en(
+        &mut self,
+    ) -> HP_MODEM_UART_WAKEUP_EN_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_UART_WAKEUP_EN_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_lp_pad_hold_all(
+        &mut self,
+    ) -> HP_MODEM_LP_PAD_HOLD_ALL_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_LP_PAD_HOLD_ALL_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_hp_pad_hold_all(
+        &mut self,
+    ) -> HP_MODEM_HP_PAD_HOLD_ALL_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_HP_PAD_HOLD_ALL_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_pad_slp_sel(
+        &mut self,
+    ) -> HP_MODEM_DIG_PAD_SLP_SEL_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_DIG_PAD_SLP_SEL_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_pause_wdt(
+        &mut self,
+    ) -> HP_MODEM_DIG_PAUSE_WDT_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_DIG_PAUSE_WDT_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_cpu_stall(
+        &mut self,
+    ) -> HP_MODEM_DIG_CPU_STALL_W<HP_MODEM_HP_SYS_CNTL_SPEC> {
+        HP_MODEM_DIG_CPU_STALL_W::new(self, 29)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_hp_sys_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_hp_sys_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_HP_SYS_CNTL_SPEC;
+impl crate::RegisterSpec for HP_MODEM_HP_SYS_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_hp_sys_cntl::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_HP_SYS_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_hp_sys_cntl::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_HP_SYS_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_HP_SYS_CNTL to value 0"]
+impl crate::Resettable for HP_MODEM_HP_SYS_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_icg_hp_apb.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_icg_hp_apb.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_MODEM_ICG_HP_APB` reader"]
+pub type R = crate::R<HP_MODEM_ICG_HP_APB_SPEC>;
+#[doc = "Register `HP_MODEM_ICG_HP_APB` writer"]
+pub type W = crate::W<HP_MODEM_ICG_HP_APB_SPEC>;
+#[doc = "Field `HP_MODEM_DIG_ICG_APB_EN` reader - need_des"]
+pub type HP_MODEM_DIG_ICG_APB_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_MODEM_DIG_ICG_APB_EN` writer - need_des"]
+pub type HP_MODEM_DIG_ICG_APB_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_icg_apb_en(&self) -> HP_MODEM_DIG_ICG_APB_EN_R {
+        HP_MODEM_DIG_ICG_APB_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_ICG_HP_APB")
+            .field(
+                "hp_modem_dig_icg_apb_en",
+                &format_args!("{}", self.hp_modem_dig_icg_apb_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_ICG_HP_APB_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_icg_apb_en(
+        &mut self,
+    ) -> HP_MODEM_DIG_ICG_APB_EN_W<HP_MODEM_ICG_HP_APB_SPEC> {
+        HP_MODEM_DIG_ICG_APB_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_hp_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_hp_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_ICG_HP_APB_SPEC;
+impl crate::RegisterSpec for HP_MODEM_ICG_HP_APB_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_icg_hp_apb::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_ICG_HP_APB_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_icg_hp_apb::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_ICG_HP_APB_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_ICG_HP_APB to value 0xffff_ffff"]
+impl crate::Resettable for HP_MODEM_ICG_HP_APB_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_icg_hp_func.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_icg_hp_func.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_MODEM_ICG_HP_FUNC` reader"]
+pub type R = crate::R<HP_MODEM_ICG_HP_FUNC_SPEC>;
+#[doc = "Register `HP_MODEM_ICG_HP_FUNC` writer"]
+pub type W = crate::W<HP_MODEM_ICG_HP_FUNC_SPEC>;
+#[doc = "Field `HP_MODEM_DIG_ICG_FUNC_EN` reader - need_des"]
+pub type HP_MODEM_DIG_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_MODEM_DIG_ICG_FUNC_EN` writer - need_des"]
+pub type HP_MODEM_DIG_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_icg_func_en(&self) -> HP_MODEM_DIG_ICG_FUNC_EN_R {
+        HP_MODEM_DIG_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_ICG_HP_FUNC")
+            .field(
+                "hp_modem_dig_icg_func_en",
+                &format_args!("{}", self.hp_modem_dig_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_ICG_HP_FUNC_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_icg_func_en(
+        &mut self,
+    ) -> HP_MODEM_DIG_ICG_FUNC_EN_W<HP_MODEM_ICG_HP_FUNC_SPEC> {
+        HP_MODEM_DIG_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_hp_func::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_hp_func::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_ICG_HP_FUNC_SPEC;
+impl crate::RegisterSpec for HP_MODEM_ICG_HP_FUNC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_icg_hp_func::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_ICG_HP_FUNC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_icg_hp_func::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_ICG_HP_FUNC_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_ICG_HP_FUNC to value 0xffff_ffff"]
+impl crate::Resettable for HP_MODEM_ICG_HP_FUNC_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_icg_modem.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_icg_modem.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_MODEM_ICG_MODEM` reader"]
+pub type R = crate::R<HP_MODEM_ICG_MODEM_SPEC>;
+#[doc = "Register `HP_MODEM_ICG_MODEM` writer"]
+pub type W = crate::W<HP_MODEM_ICG_MODEM_SPEC>;
+#[doc = "Field `HP_MODEM_DIG_ICG_MODEM_CODE` reader - need_des"]
+pub type HP_MODEM_DIG_ICG_MODEM_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_DIG_ICG_MODEM_CODE` writer - need_des"]
+pub type HP_MODEM_DIG_ICG_MODEM_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_icg_modem_code(&self) -> HP_MODEM_DIG_ICG_MODEM_CODE_R {
+        HP_MODEM_DIG_ICG_MODEM_CODE_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_ICG_MODEM")
+            .field(
+                "hp_modem_dig_icg_modem_code",
+                &format_args!("{}", self.hp_modem_dig_icg_modem_code().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_ICG_MODEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_icg_modem_code(
+        &mut self,
+    ) -> HP_MODEM_DIG_ICG_MODEM_CODE_W<HP_MODEM_ICG_MODEM_SPEC> {
+        HP_MODEM_DIG_ICG_MODEM_CODE_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_icg_modem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_icg_modem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_ICG_MODEM_SPEC;
+impl crate::RegisterSpec for HP_MODEM_ICG_MODEM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_icg_modem::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_ICG_MODEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_icg_modem::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_ICG_MODEM_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_ICG_MODEM to value 0"]
+impl crate::Resettable for HP_MODEM_ICG_MODEM_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_sysclk.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_sysclk.rs
@@ -1,0 +1,137 @@
+#[doc = "Register `HP_MODEM_SYSCLK` reader"]
+pub type R = crate::R<HP_MODEM_SYSCLK_SPEC>;
+#[doc = "Register `HP_MODEM_SYSCLK` writer"]
+pub type W = crate::W<HP_MODEM_SYSCLK_SPEC>;
+#[doc = "Field `HP_MODEM_DIG_SYS_CLK_NO_DIV` reader - need_des"]
+pub type HP_MODEM_DIG_SYS_CLK_NO_DIV_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_DIG_SYS_CLK_NO_DIV` writer - need_des"]
+pub type HP_MODEM_DIG_SYS_CLK_NO_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_ICG_SYS_CLOCK_EN` reader - need_des"]
+pub type HP_MODEM_ICG_SYS_CLOCK_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_ICG_SYS_CLOCK_EN` writer - need_des"]
+pub type HP_MODEM_ICG_SYS_CLOCK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_SYS_CLK_SLP_SEL` reader - need_des"]
+pub type HP_MODEM_SYS_CLK_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_SYS_CLK_SLP_SEL` writer - need_des"]
+pub type HP_MODEM_SYS_CLK_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_ICG_SLP_SEL` reader - need_des"]
+pub type HP_MODEM_ICG_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_ICG_SLP_SEL` writer - need_des"]
+pub type HP_MODEM_ICG_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM_DIG_SYS_CLK_SEL` reader - need_des"]
+pub type HP_MODEM_DIG_SYS_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM_DIG_SYS_CLK_SEL` writer - need_des"]
+pub type HP_MODEM_DIG_SYS_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_sys_clk_no_div(&self) -> HP_MODEM_DIG_SYS_CLK_NO_DIV_R {
+        HP_MODEM_DIG_SYS_CLK_NO_DIV_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_icg_sys_clock_en(&self) -> HP_MODEM_ICG_SYS_CLOCK_EN_R {
+        HP_MODEM_ICG_SYS_CLOCK_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_sys_clk_slp_sel(&self) -> HP_MODEM_SYS_CLK_SLP_SEL_R {
+        HP_MODEM_SYS_CLK_SLP_SEL_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_icg_slp_sel(&self) -> HP_MODEM_ICG_SLP_SEL_R {
+        HP_MODEM_ICG_SLP_SEL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_dig_sys_clk_sel(&self) -> HP_MODEM_DIG_SYS_CLK_SEL_R {
+        HP_MODEM_DIG_SYS_CLK_SEL_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_SYSCLK")
+            .field(
+                "hp_modem_dig_sys_clk_no_div",
+                &format_args!("{}", self.hp_modem_dig_sys_clk_no_div().bit()),
+            )
+            .field(
+                "hp_modem_icg_sys_clock_en",
+                &format_args!("{}", self.hp_modem_icg_sys_clock_en().bit()),
+            )
+            .field(
+                "hp_modem_sys_clk_slp_sel",
+                &format_args!("{}", self.hp_modem_sys_clk_slp_sel().bit()),
+            )
+            .field(
+                "hp_modem_icg_slp_sel",
+                &format_args!("{}", self.hp_modem_icg_slp_sel().bit()),
+            )
+            .field(
+                "hp_modem_dig_sys_clk_sel",
+                &format_args!("{}", self.hp_modem_dig_sys_clk_sel().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_SYSCLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_sys_clk_no_div(
+        &mut self,
+    ) -> HP_MODEM_DIG_SYS_CLK_NO_DIV_W<HP_MODEM_SYSCLK_SPEC> {
+        HP_MODEM_DIG_SYS_CLK_NO_DIV_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_icg_sys_clock_en(
+        &mut self,
+    ) -> HP_MODEM_ICG_SYS_CLOCK_EN_W<HP_MODEM_SYSCLK_SPEC> {
+        HP_MODEM_ICG_SYS_CLOCK_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_sys_clk_slp_sel(&mut self) -> HP_MODEM_SYS_CLK_SLP_SEL_W<HP_MODEM_SYSCLK_SPEC> {
+        HP_MODEM_SYS_CLK_SLP_SEL_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_icg_slp_sel(&mut self) -> HP_MODEM_ICG_SLP_SEL_W<HP_MODEM_SYSCLK_SPEC> {
+        HP_MODEM_ICG_SLP_SEL_W::new(self, 29)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_dig_sys_clk_sel(&mut self) -> HP_MODEM_DIG_SYS_CLK_SEL_W<HP_MODEM_SYSCLK_SPEC> {
+        HP_MODEM_DIG_SYS_CLK_SEL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_sysclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_sysclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_SYSCLK_SPEC;
+impl crate::RegisterSpec for HP_MODEM_SYSCLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_sysclk::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_SYSCLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_sysclk::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_SYSCLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_SYSCLK to value 0"]
+impl crate::Resettable for HP_MODEM_SYSCLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_modem_xtal.rs
+++ b/esp32c6-lp/src/pmu/hp_modem_xtal.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `HP_MODEM_XTAL` reader"]
+pub type R = crate::R<HP_MODEM_XTAL_SPEC>;
+#[doc = "Register `HP_MODEM_XTAL` writer"]
+pub type W = crate::W<HP_MODEM_XTAL_SPEC>;
+#[doc = "Field `HP_MODEM_XPD_XTAL` reader - need_des"]
+pub type HP_MODEM_XPD_XTAL_R = crate::BitReader;
+#[doc = "Field `HP_MODEM_XPD_XTAL` writer - need_des"]
+pub type HP_MODEM_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem_xpd_xtal(&self) -> HP_MODEM_XPD_XTAL_R {
+        HP_MODEM_XPD_XTAL_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_MODEM_XTAL")
+            .field(
+                "hp_modem_xpd_xtal",
+                &format_args!("{}", self.hp_modem_xpd_xtal().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_MODEM_XTAL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem_xpd_xtal(&mut self) -> HP_MODEM_XPD_XTAL_W<HP_MODEM_XTAL_SPEC> {
+        HP_MODEM_XPD_XTAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_modem_xtal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_modem_xtal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_MODEM_XTAL_SPEC;
+impl crate::RegisterSpec for HP_MODEM_XTAL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_modem_xtal::R`](R) reader structure"]
+impl crate::Readable for HP_MODEM_XTAL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_modem_xtal::W`](W) writer structure"]
+impl crate::Writable for HP_MODEM_XTAL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_MODEM_XTAL to value 0x8000_0000"]
+impl crate::Resettable for HP_MODEM_XTAL_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_regulator_cfg.rs
+++ b/esp32c6-lp/src/pmu/hp_regulator_cfg.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `HP_REGULATOR_CFG` reader"]
+pub type R = crate::R<HP_REGULATOR_CFG_SPEC>;
+#[doc = "Register `HP_REGULATOR_CFG` writer"]
+pub type W = crate::W<HP_REGULATOR_CFG_SPEC>;
+#[doc = "Field `DIG_REGULATOR_EN_CAL` reader - need_des"]
+pub type DIG_REGULATOR_EN_CAL_R = crate::BitReader;
+#[doc = "Field `DIG_REGULATOR_EN_CAL` writer - need_des"]
+pub type DIG_REGULATOR_EN_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn dig_regulator_en_cal(&self) -> DIG_REGULATOR_EN_CAL_R {
+        DIG_REGULATOR_EN_CAL_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_REGULATOR_CFG")
+            .field(
+                "dig_regulator_en_cal",
+                &format_args!("{}", self.dig_regulator_en_cal().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_REGULATOR_CFG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dig_regulator_en_cal(&mut self) -> DIG_REGULATOR_EN_CAL_W<HP_REGULATOR_CFG_SPEC> {
+        DIG_REGULATOR_EN_CAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_regulator_cfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_regulator_cfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_REGULATOR_CFG_SPEC;
+impl crate::RegisterSpec for HP_REGULATOR_CFG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_regulator_cfg::R`](R) reader structure"]
+impl crate::Readable for HP_REGULATOR_CFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_regulator_cfg::W`](W) writer structure"]
+impl crate::Writable for HP_REGULATOR_CFG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_REGULATOR_CFG to value 0"]
+impl crate::Resettable for HP_REGULATOR_CFG_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_backup.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_backup.rs
@@ -1,0 +1,265 @@
+#[doc = "Register `HP_SLEEP_BACKUP` reader"]
+pub type R = crate::R<HP_SLEEP_BACKUP_SPEC>;
+#[doc = "Register `HP_SLEEP_BACKUP` writer"]
+pub type W = crate::W<HP_SLEEP_BACKUP_SPEC>;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE` reader - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE` writer - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE` reader - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE` writer - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_SLEEP_RETENTION_MODE` reader - need_des"]
+pub type HP_SLEEP_RETENTION_MODE_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_RETENTION_MODE` writer - need_des"]
+pub type HP_SLEEP_RETENTION_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM2SLEEP_RETENTION_EN` reader - need_des"]
+pub type HP_MODEM2SLEEP_RETENTION_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM2SLEEP_RETENTION_EN` writer - need_des"]
+pub type HP_MODEM2SLEEP_RETENTION_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE2SLEEP_RETENTION_EN` reader - need_des"]
+pub type HP_ACTIVE2SLEEP_RETENTION_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE2SLEEP_RETENTION_EN` writer - need_des"]
+pub type HP_ACTIVE2SLEEP_RETENTION_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_CLK_SEL` reader - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_CLK_SEL` writer - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_CLK_SEL` reader - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_CLK_SEL` writer - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_MODE` reader - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_MODE_R = crate::FieldReader;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_MODE` writer - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_MODE` reader - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_MODE_R = crate::FieldReader;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_MODE` writer - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_EN` reader - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_MODEM2SLEEP_BACKUP_EN` writer - need_des"]
+pub type HP_MODEM2SLEEP_BACKUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_EN` reader - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_ACTIVE2SLEEP_BACKUP_EN` writer - need_des"]
+pub type HP_ACTIVE2SLEEP_BACKUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 6:7 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2sleep_backup_modem_clk_code(&self) -> HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_R {
+        HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_R::new(((self.bits >> 6) & 3) as u8)
+    }
+    #[doc = "Bits 8:9 - need_des"]
+    #[inline(always)]
+    pub fn hp_active2sleep_backup_modem_clk_code(&self) -> HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_R {
+        HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_R::new(((self.bits >> 8) & 3) as u8)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_retention_mode(&self) -> HP_SLEEP_RETENTION_MODE_R {
+        HP_SLEEP_RETENTION_MODE_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 12 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2sleep_retention_en(&self) -> HP_MODEM2SLEEP_RETENTION_EN_R {
+        HP_MODEM2SLEEP_RETENTION_EN_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - need_des"]
+    #[inline(always)]
+    pub fn hp_active2sleep_retention_en(&self) -> HP_ACTIVE2SLEEP_RETENTION_EN_R {
+        HP_ACTIVE2SLEEP_RETENTION_EN_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2sleep_backup_clk_sel(&self) -> HP_MODEM2SLEEP_BACKUP_CLK_SEL_R {
+        HP_MODEM2SLEEP_BACKUP_CLK_SEL_R::new(((self.bits >> 16) & 3) as u8)
+    }
+    #[doc = "Bits 18:19 - need_des"]
+    #[inline(always)]
+    pub fn hp_active2sleep_backup_clk_sel(&self) -> HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_R {
+        HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_R::new(((self.bits >> 18) & 3) as u8)
+    }
+    #[doc = "Bits 23:25 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2sleep_backup_mode(&self) -> HP_MODEM2SLEEP_BACKUP_MODE_R {
+        HP_MODEM2SLEEP_BACKUP_MODE_R::new(((self.bits >> 23) & 7) as u8)
+    }
+    #[doc = "Bits 26:28 - need_des"]
+    #[inline(always)]
+    pub fn hp_active2sleep_backup_mode(&self) -> HP_ACTIVE2SLEEP_BACKUP_MODE_R {
+        HP_ACTIVE2SLEEP_BACKUP_MODE_R::new(((self.bits >> 26) & 7) as u8)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_modem2sleep_backup_en(&self) -> HP_MODEM2SLEEP_BACKUP_EN_R {
+        HP_MODEM2SLEEP_BACKUP_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_active2sleep_backup_en(&self) -> HP_ACTIVE2SLEEP_BACKUP_EN_R {
+        HP_ACTIVE2SLEEP_BACKUP_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_BACKUP")
+            .field(
+                "hp_modem2sleep_backup_modem_clk_code",
+                &format_args!("{}", self.hp_modem2sleep_backup_modem_clk_code().bits()),
+            )
+            .field(
+                "hp_active2sleep_backup_modem_clk_code",
+                &format_args!("{}", self.hp_active2sleep_backup_modem_clk_code().bits()),
+            )
+            .field(
+                "hp_sleep_retention_mode",
+                &format_args!("{}", self.hp_sleep_retention_mode().bit()),
+            )
+            .field(
+                "hp_modem2sleep_retention_en",
+                &format_args!("{}", self.hp_modem2sleep_retention_en().bit()),
+            )
+            .field(
+                "hp_active2sleep_retention_en",
+                &format_args!("{}", self.hp_active2sleep_retention_en().bit()),
+            )
+            .field(
+                "hp_modem2sleep_backup_clk_sel",
+                &format_args!("{}", self.hp_modem2sleep_backup_clk_sel().bits()),
+            )
+            .field(
+                "hp_active2sleep_backup_clk_sel",
+                &format_args!("{}", self.hp_active2sleep_backup_clk_sel().bits()),
+            )
+            .field(
+                "hp_modem2sleep_backup_mode",
+                &format_args!("{}", self.hp_modem2sleep_backup_mode().bits()),
+            )
+            .field(
+                "hp_active2sleep_backup_mode",
+                &format_args!("{}", self.hp_active2sleep_backup_mode().bits()),
+            )
+            .field(
+                "hp_modem2sleep_backup_en",
+                &format_args!("{}", self.hp_modem2sleep_backup_en().bit()),
+            )
+            .field(
+                "hp_active2sleep_backup_en",
+                &format_args!("{}", self.hp_active2sleep_backup_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_BACKUP_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 6:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2sleep_backup_modem_clk_code(
+        &mut self,
+    ) -> HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_MODEM2SLEEP_BACKUP_MODEM_CLK_CODE_W::new(self, 6)
+    }
+    #[doc = "Bits 8:9 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active2sleep_backup_modem_clk_code(
+        &mut self,
+    ) -> HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_ACTIVE2SLEEP_BACKUP_MODEM_CLK_CODE_W::new(self, 8)
+    }
+    #[doc = "Bit 10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_retention_mode(&mut self) -> HP_SLEEP_RETENTION_MODE_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_SLEEP_RETENTION_MODE_W::new(self, 10)
+    }
+    #[doc = "Bit 12 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2sleep_retention_en(
+        &mut self,
+    ) -> HP_MODEM2SLEEP_RETENTION_EN_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_MODEM2SLEEP_RETENTION_EN_W::new(self, 12)
+    }
+    #[doc = "Bit 13 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active2sleep_retention_en(
+        &mut self,
+    ) -> HP_ACTIVE2SLEEP_RETENTION_EN_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_ACTIVE2SLEEP_RETENTION_EN_W::new(self, 13)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2sleep_backup_clk_sel(
+        &mut self,
+    ) -> HP_MODEM2SLEEP_BACKUP_CLK_SEL_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_MODEM2SLEEP_BACKUP_CLK_SEL_W::new(self, 16)
+    }
+    #[doc = "Bits 18:19 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active2sleep_backup_clk_sel(
+        &mut self,
+    ) -> HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_ACTIVE2SLEEP_BACKUP_CLK_SEL_W::new(self, 18)
+    }
+    #[doc = "Bits 23:25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2sleep_backup_mode(
+        &mut self,
+    ) -> HP_MODEM2SLEEP_BACKUP_MODE_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_MODEM2SLEEP_BACKUP_MODE_W::new(self, 23)
+    }
+    #[doc = "Bits 26:28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active2sleep_backup_mode(
+        &mut self,
+    ) -> HP_ACTIVE2SLEEP_BACKUP_MODE_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_ACTIVE2SLEEP_BACKUP_MODE_W::new(self, 26)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_modem2sleep_backup_en(&mut self) -> HP_MODEM2SLEEP_BACKUP_EN_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_MODEM2SLEEP_BACKUP_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_active2sleep_backup_en(
+        &mut self,
+    ) -> HP_ACTIVE2SLEEP_BACKUP_EN_W<HP_SLEEP_BACKUP_SPEC> {
+        HP_ACTIVE2SLEEP_BACKUP_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_backup::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_backup::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_BACKUP_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_BACKUP_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_backup::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_BACKUP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_backup::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_BACKUP_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_BACKUP to value 0"]
+impl crate::Resettable for HP_SLEEP_BACKUP_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_backup_clk.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_backup_clk.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_BACKUP_CLK` reader"]
+pub type R = crate::R<HP_SLEEP_BACKUP_CLK_SPEC>;
+#[doc = "Register `HP_SLEEP_BACKUP_CLK` writer"]
+pub type W = crate::W<HP_SLEEP_BACKUP_CLK_SPEC>;
+#[doc = "Field `HP_SLEEP_BACKUP_ICG_FUNC_EN` reader - need_des"]
+pub type HP_SLEEP_BACKUP_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_SLEEP_BACKUP_ICG_FUNC_EN` writer - need_des"]
+pub type HP_SLEEP_BACKUP_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_backup_icg_func_en(&self) -> HP_SLEEP_BACKUP_ICG_FUNC_EN_R {
+        HP_SLEEP_BACKUP_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_BACKUP_CLK")
+            .field(
+                "hp_sleep_backup_icg_func_en",
+                &format_args!("{}", self.hp_sleep_backup_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_BACKUP_CLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_backup_icg_func_en(
+        &mut self,
+    ) -> HP_SLEEP_BACKUP_ICG_FUNC_EN_W<HP_SLEEP_BACKUP_CLK_SPEC> {
+        HP_SLEEP_BACKUP_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_backup_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_backup_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_BACKUP_CLK_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_BACKUP_CLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_backup_clk::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_BACKUP_CLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_backup_clk::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_BACKUP_CLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_BACKUP_CLK to value 0"]
+impl crate::Resettable for HP_SLEEP_BACKUP_CLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_bias.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_bias.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `HP_SLEEP_BIAS` reader"]
+pub type R = crate::R<HP_SLEEP_BIAS_SPEC>;
+#[doc = "Register `HP_SLEEP_BIAS` writer"]
+pub type W = crate::W<HP_SLEEP_BIAS_SPEC>;
+#[doc = "Field `HP_SLEEP_XPD_BIAS` reader - need_des"]
+pub type HP_SLEEP_XPD_BIAS_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_BIAS` writer - need_des"]
+pub type HP_SLEEP_XPD_BIAS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_DBG_ATTEN` reader - need_des"]
+pub type HP_SLEEP_DBG_ATTEN_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_DBG_ATTEN` writer - need_des"]
+pub type HP_SLEEP_DBG_ATTEN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_SLEEP_PD_CUR` reader - need_des"]
+pub type HP_SLEEP_PD_CUR_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_CUR` writer - need_des"]
+pub type HP_SLEEP_PD_CUR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP` reader - need_des"]
+pub type SLEEP_R = crate::BitReader;
+#[doc = "Field `SLEEP` writer - need_des"]
+pub type SLEEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_bias(&self) -> HP_SLEEP_XPD_BIAS_R {
+        HP_SLEEP_XPD_BIAS_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dbg_atten(&self) -> HP_SLEEP_DBG_ATTEN_R {
+        HP_SLEEP_DBG_ATTEN_R::new(((self.bits >> 26) & 0x0f) as u8)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_cur(&self) -> HP_SLEEP_PD_CUR_R {
+        HP_SLEEP_PD_CUR_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn sleep(&self) -> SLEEP_R {
+        SLEEP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_BIAS")
+            .field(
+                "hp_sleep_xpd_bias",
+                &format_args!("{}", self.hp_sleep_xpd_bias().bit()),
+            )
+            .field(
+                "hp_sleep_dbg_atten",
+                &format_args!("{}", self.hp_sleep_dbg_atten().bits()),
+            )
+            .field(
+                "hp_sleep_pd_cur",
+                &format_args!("{}", self.hp_sleep_pd_cur().bit()),
+            )
+            .field("sleep", &format_args!("{}", self.sleep().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_BIAS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_bias(&mut self) -> HP_SLEEP_XPD_BIAS_W<HP_SLEEP_BIAS_SPEC> {
+        HP_SLEEP_XPD_BIAS_W::new(self, 25)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dbg_atten(&mut self) -> HP_SLEEP_DBG_ATTEN_W<HP_SLEEP_BIAS_SPEC> {
+        HP_SLEEP_DBG_ATTEN_W::new(self, 26)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_cur(&mut self) -> HP_SLEEP_PD_CUR_W<HP_SLEEP_BIAS_SPEC> {
+        HP_SLEEP_PD_CUR_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep(&mut self) -> SLEEP_W<HP_SLEEP_BIAS_SPEC> {
+        SLEEP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_bias::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_bias::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_BIAS_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_BIAS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_bias::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_BIAS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_bias::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_BIAS_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_BIAS to value 0"]
+impl crate::Resettable for HP_SLEEP_BIAS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_dig_power.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_dig_power.rs
@@ -1,0 +1,179 @@
+#[doc = "Register `HP_SLEEP_DIG_POWER` reader"]
+pub type R = crate::R<HP_SLEEP_DIG_POWER_SPEC>;
+#[doc = "Register `HP_SLEEP_DIG_POWER` writer"]
+pub type W = crate::W<HP_SLEEP_DIG_POWER_SPEC>;
+#[doc = "Field `HP_SLEEP_VDD_SPI_PD_EN` reader - need_des"]
+pub type HP_SLEEP_VDD_SPI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_VDD_SPI_PD_EN` writer - need_des"]
+pub type HP_SLEEP_VDD_SPI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_HP_MEM_DSLP` reader - need_des"]
+pub type HP_SLEEP_HP_MEM_DSLP_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_HP_MEM_DSLP` writer - need_des"]
+pub type HP_SLEEP_HP_MEM_DSLP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_HP_MEM_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_HP_MEM_PD_EN_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_PD_HP_MEM_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_HP_MEM_PD_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_SLEEP_PD_HP_WIFI_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_HP_WIFI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_HP_WIFI_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_HP_WIFI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_HP_CPU_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_HP_CPU_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_HP_CPU_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_HP_CPU_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_HP_AON_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_HP_AON_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_HP_AON_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_HP_AON_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_TOP_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_TOP_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_TOP_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_TOP_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_vdd_spi_pd_en(&self) -> HP_SLEEP_VDD_SPI_PD_EN_R {
+        HP_SLEEP_VDD_SPI_PD_EN_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_mem_dslp(&self) -> HP_SLEEP_HP_MEM_DSLP_R {
+        HP_SLEEP_HP_MEM_DSLP_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_hp_mem_pd_en(&self) -> HP_SLEEP_PD_HP_MEM_PD_EN_R {
+        HP_SLEEP_PD_HP_MEM_PD_EN_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_hp_wifi_pd_en(&self) -> HP_SLEEP_PD_HP_WIFI_PD_EN_R {
+        HP_SLEEP_PD_HP_WIFI_PD_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_hp_cpu_pd_en(&self) -> HP_SLEEP_PD_HP_CPU_PD_EN_R {
+        HP_SLEEP_PD_HP_CPU_PD_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_hp_aon_pd_en(&self) -> HP_SLEEP_PD_HP_AON_PD_EN_R {
+        HP_SLEEP_PD_HP_AON_PD_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_top_pd_en(&self) -> HP_SLEEP_PD_TOP_PD_EN_R {
+        HP_SLEEP_PD_TOP_PD_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_DIG_POWER")
+            .field(
+                "hp_sleep_vdd_spi_pd_en",
+                &format_args!("{}", self.hp_sleep_vdd_spi_pd_en().bit()),
+            )
+            .field(
+                "hp_sleep_hp_mem_dslp",
+                &format_args!("{}", self.hp_sleep_hp_mem_dslp().bit()),
+            )
+            .field(
+                "hp_sleep_pd_hp_mem_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_hp_mem_pd_en().bits()),
+            )
+            .field(
+                "hp_sleep_pd_hp_wifi_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_hp_wifi_pd_en().bit()),
+            )
+            .field(
+                "hp_sleep_pd_hp_cpu_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_hp_cpu_pd_en().bit()),
+            )
+            .field(
+                "hp_sleep_pd_hp_aon_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_hp_aon_pd_en().bit()),
+            )
+            .field(
+                "hp_sleep_pd_top_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_top_pd_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_DIG_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_vdd_spi_pd_en(&mut self) -> HP_SLEEP_VDD_SPI_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_VDD_SPI_PD_EN_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_mem_dslp(&mut self) -> HP_SLEEP_HP_MEM_DSLP_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_HP_MEM_DSLP_W::new(self, 22)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_hp_mem_pd_en(
+        &mut self,
+    ) -> HP_SLEEP_PD_HP_MEM_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_HP_MEM_PD_EN_W::new(self, 23)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_hp_wifi_pd_en(
+        &mut self,
+    ) -> HP_SLEEP_PD_HP_WIFI_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_HP_WIFI_PD_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_hp_cpu_pd_en(
+        &mut self,
+    ) -> HP_SLEEP_PD_HP_CPU_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_HP_CPU_PD_EN_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_hp_aon_pd_en(
+        &mut self,
+    ) -> HP_SLEEP_PD_HP_AON_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_HP_AON_PD_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_top_pd_en(&mut self) -> HP_SLEEP_PD_TOP_PD_EN_W<HP_SLEEP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_TOP_PD_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_dig_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_dig_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_DIG_POWER_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_DIG_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_dig_power::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_DIG_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_dig_power::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_DIG_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_DIG_POWER to value 0"]
+impl crate::Resettable for HP_SLEEP_DIG_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_hp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_hp_ck_power.rs
@@ -1,0 +1,137 @@
+#[doc = "Register `HP_SLEEP_HP_CK_POWER` reader"]
+pub type R = crate::R<HP_SLEEP_HP_CK_POWER_SPEC>;
+#[doc = "Register `HP_SLEEP_HP_CK_POWER` writer"]
+pub type W = crate::W<HP_SLEEP_HP_CK_POWER_SPEC>;
+#[doc = "Field `HP_SLEEP_I2C_ISO_EN` reader - need_des"]
+pub type HP_SLEEP_I2C_ISO_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_I2C_ISO_EN` writer - need_des"]
+pub type HP_SLEEP_I2C_ISO_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_I2C_RETENTION` reader - need_des"]
+pub type HP_SLEEP_I2C_RETENTION_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_I2C_RETENTION` writer - need_des"]
+pub type HP_SLEEP_I2C_RETENTION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_XPD_BB_I2C` reader - need_des"]
+pub type HP_SLEEP_XPD_BB_I2C_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_BB_I2C` writer - need_des"]
+pub type HP_SLEEP_XPD_BB_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_XPD_BBPLL_I2C` reader - need_des"]
+pub type HP_SLEEP_XPD_BBPLL_I2C_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_BBPLL_I2C` writer - need_des"]
+pub type HP_SLEEP_XPD_BBPLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_XPD_BBPLL` reader - need_des"]
+pub type HP_SLEEP_XPD_BBPLL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_BBPLL` writer - need_des"]
+pub type HP_SLEEP_XPD_BBPLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_i2c_iso_en(&self) -> HP_SLEEP_I2C_ISO_EN_R {
+        HP_SLEEP_I2C_ISO_EN_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_i2c_retention(&self) -> HP_SLEEP_I2C_RETENTION_R {
+        HP_SLEEP_I2C_RETENTION_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_bb_i2c(&self) -> HP_SLEEP_XPD_BB_I2C_R {
+        HP_SLEEP_XPD_BB_I2C_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_bbpll_i2c(&self) -> HP_SLEEP_XPD_BBPLL_I2C_R {
+        HP_SLEEP_XPD_BBPLL_I2C_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_bbpll(&self) -> HP_SLEEP_XPD_BBPLL_R {
+        HP_SLEEP_XPD_BBPLL_R::new(((self.bits >> 30) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_HP_CK_POWER")
+            .field(
+                "hp_sleep_i2c_iso_en",
+                &format_args!("{}", self.hp_sleep_i2c_iso_en().bit()),
+            )
+            .field(
+                "hp_sleep_i2c_retention",
+                &format_args!("{}", self.hp_sleep_i2c_retention().bit()),
+            )
+            .field(
+                "hp_sleep_xpd_bb_i2c",
+                &format_args!("{}", self.hp_sleep_xpd_bb_i2c().bit()),
+            )
+            .field(
+                "hp_sleep_xpd_bbpll_i2c",
+                &format_args!("{}", self.hp_sleep_xpd_bbpll_i2c().bit()),
+            )
+            .field(
+                "hp_sleep_xpd_bbpll",
+                &format_args!("{}", self.hp_sleep_xpd_bbpll().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_HP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_i2c_iso_en(&mut self) -> HP_SLEEP_I2C_ISO_EN_W<HP_SLEEP_HP_CK_POWER_SPEC> {
+        HP_SLEEP_I2C_ISO_EN_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_i2c_retention(
+        &mut self,
+    ) -> HP_SLEEP_I2C_RETENTION_W<HP_SLEEP_HP_CK_POWER_SPEC> {
+        HP_SLEEP_I2C_RETENTION_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_bb_i2c(&mut self) -> HP_SLEEP_XPD_BB_I2C_W<HP_SLEEP_HP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_BB_I2C_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_bbpll_i2c(
+        &mut self,
+    ) -> HP_SLEEP_XPD_BBPLL_I2C_W<HP_SLEEP_HP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_BBPLL_I2C_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_bbpll(&mut self) -> HP_SLEEP_XPD_BBPLL_W<HP_SLEEP_HP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_BBPLL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_HP_CK_POWER_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_HP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_hp_ck_power::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_HP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_hp_ck_power::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_HP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_HP_CK_POWER to value 0"]
+impl crate::Resettable for HP_SLEEP_HP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_hp_regulator0.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_hp_regulator0.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `HP_SLEEP_HP_REGULATOR0` reader"]
+pub type R = crate::R<HP_SLEEP_HP_REGULATOR0_SPEC>;
+#[doc = "Register `HP_SLEEP_HP_REGULATOR0` writer"]
+pub type W = crate::W<HP_SLEEP_HP_REGULATOR0_SPEC>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_XPD` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_XPD_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_XPD` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_DBIAS` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_DBIAS` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_slp_mem_xpd(&self) -> HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_R {
+        HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_slp_logic_xpd(&self) -> HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_R {
+        HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_xpd(&self) -> HP_SLEEP_HP_REGULATOR_XPD_R {
+        HP_SLEEP_HP_REGULATOR_XPD_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_slp_mem_dbias(&self) -> HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_R {
+        HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_R::new(((self.bits >> 19) & 0x0f) as u8)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_slp_logic_dbias(&self) -> HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_R {
+        HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_dbias(&self) -> HP_SLEEP_HP_REGULATOR_DBIAS_R {
+        HP_SLEEP_HP_REGULATOR_DBIAS_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_HP_REGULATOR0")
+            .field(
+                "hp_sleep_hp_regulator_slp_mem_xpd",
+                &format_args!("{}", self.hp_sleep_hp_regulator_slp_mem_xpd().bit()),
+            )
+            .field(
+                "hp_sleep_hp_regulator_slp_logic_xpd",
+                &format_args!("{}", self.hp_sleep_hp_regulator_slp_logic_xpd().bit()),
+            )
+            .field(
+                "hp_sleep_hp_regulator_xpd",
+                &format_args!("{}", self.hp_sleep_hp_regulator_xpd().bit()),
+            )
+            .field(
+                "hp_sleep_hp_regulator_slp_mem_dbias",
+                &format_args!("{}", self.hp_sleep_hp_regulator_slp_mem_dbias().bits()),
+            )
+            .field(
+                "hp_sleep_hp_regulator_slp_logic_dbias",
+                &format_args!("{}", self.hp_sleep_hp_regulator_slp_logic_dbias().bits()),
+            )
+            .field(
+                "hp_sleep_hp_regulator_dbias",
+                &format_args!("{}", self.hp_sleep_hp_regulator_dbias().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_HP_REGULATOR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 16 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_slp_mem_xpd(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_SLP_MEM_XPD_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_slp_logic_xpd(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_SLP_LOGIC_XPD_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_xpd(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_XPD_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_XPD_W::new(self, 18)
+    }
+    #[doc = "Bits 19:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_slp_mem_dbias(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_SLP_MEM_DBIAS_W::new(self, 19)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_slp_logic_dbias(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_SLP_LOGIC_DBIAS_W::new(self, 23)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_dbias(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_DBIAS_W<HP_SLEEP_HP_REGULATOR0_SPEC> {
+        HP_SLEEP_HP_REGULATOR_DBIAS_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_regulator0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_regulator0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_HP_REGULATOR0_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_HP_REGULATOR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_hp_regulator0::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_HP_REGULATOR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_hp_regulator0::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_HP_REGULATOR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_HP_REGULATOR0 to value 0xc667_0000"]
+impl crate::Resettable for HP_SLEEP_HP_REGULATOR0_SPEC {
+    const RESET_VALUE: u32 = 0xc667_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_hp_regulator1.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_hp_regulator1.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_HP_REGULATOR1` reader"]
+pub type R = crate::R<HP_SLEEP_HP_REGULATOR1_SPEC>;
+#[doc = "Register `HP_SLEEP_HP_REGULATOR1` writer"]
+pub type W = crate::W<HP_SLEEP_HP_REGULATOR1_SPEC>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_DRV_B` reader - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_DRV_B_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_SLEEP_HP_REGULATOR_DRV_B` writer - need_des"]
+pub type HP_SLEEP_HP_REGULATOR_DRV_B_W<'a, REG> = crate::FieldWriter<'a, REG, 24, u32>;
+impl R {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_regulator_drv_b(&self) -> HP_SLEEP_HP_REGULATOR_DRV_B_R {
+        HP_SLEEP_HP_REGULATOR_DRV_B_R::new((self.bits >> 8) & 0x00ff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_HP_REGULATOR1")
+            .field(
+                "hp_sleep_hp_regulator_drv_b",
+                &format_args!("{}", self.hp_sleep_hp_regulator_drv_b().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_HP_REGULATOR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 8:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_regulator_drv_b(
+        &mut self,
+    ) -> HP_SLEEP_HP_REGULATOR_DRV_B_W<HP_SLEEP_HP_REGULATOR1_SPEC> {
+        HP_SLEEP_HP_REGULATOR_DRV_B_W::new(self, 8)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_regulator1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_regulator1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_HP_REGULATOR1_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_HP_REGULATOR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_hp_regulator1::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_HP_REGULATOR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_hp_regulator1::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_HP_REGULATOR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_HP_REGULATOR1 to value 0"]
+impl crate::Resettable for HP_SLEEP_HP_REGULATOR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_hp_sys_cntl.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_hp_sys_cntl.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `HP_SLEEP_HP_SYS_CNTL` reader"]
+pub type R = crate::R<HP_SLEEP_HP_SYS_CNTL_SPEC>;
+#[doc = "Register `HP_SLEEP_HP_SYS_CNTL` writer"]
+pub type W = crate::W<HP_SLEEP_HP_SYS_CNTL_SPEC>;
+#[doc = "Field `HP_SLEEP_UART_WAKEUP_EN` reader - need_des"]
+pub type HP_SLEEP_UART_WAKEUP_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_UART_WAKEUP_EN` writer - need_des"]
+pub type HP_SLEEP_UART_WAKEUP_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_LP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_SLEEP_LP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_LP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_SLEEP_LP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_HP_PAD_HOLD_ALL` reader - need_des"]
+pub type HP_SLEEP_HP_PAD_HOLD_ALL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_HP_PAD_HOLD_ALL` writer - need_des"]
+pub type HP_SLEEP_HP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_DIG_PAD_SLP_SEL` reader - need_des"]
+pub type HP_SLEEP_DIG_PAD_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_DIG_PAD_SLP_SEL` writer - need_des"]
+pub type HP_SLEEP_DIG_PAD_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_DIG_PAUSE_WDT` reader - need_des"]
+pub type HP_SLEEP_DIG_PAUSE_WDT_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_DIG_PAUSE_WDT` writer - need_des"]
+pub type HP_SLEEP_DIG_PAUSE_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_DIG_CPU_STALL` reader - need_des"]
+pub type HP_SLEEP_DIG_CPU_STALL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_DIG_CPU_STALL` writer - need_des"]
+pub type HP_SLEEP_DIG_CPU_STALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_uart_wakeup_en(&self) -> HP_SLEEP_UART_WAKEUP_EN_R {
+        HP_SLEEP_UART_WAKEUP_EN_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_pad_hold_all(&self) -> HP_SLEEP_LP_PAD_HOLD_ALL_R {
+        HP_SLEEP_LP_PAD_HOLD_ALL_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_hp_pad_hold_all(&self) -> HP_SLEEP_HP_PAD_HOLD_ALL_R {
+        HP_SLEEP_HP_PAD_HOLD_ALL_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_pad_slp_sel(&self) -> HP_SLEEP_DIG_PAD_SLP_SEL_R {
+        HP_SLEEP_DIG_PAD_SLP_SEL_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_pause_wdt(&self) -> HP_SLEEP_DIG_PAUSE_WDT_R {
+        HP_SLEEP_DIG_PAUSE_WDT_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_cpu_stall(&self) -> HP_SLEEP_DIG_CPU_STALL_R {
+        HP_SLEEP_DIG_CPU_STALL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_HP_SYS_CNTL")
+            .field(
+                "hp_sleep_uart_wakeup_en",
+                &format_args!("{}", self.hp_sleep_uart_wakeup_en().bit()),
+            )
+            .field(
+                "hp_sleep_lp_pad_hold_all",
+                &format_args!("{}", self.hp_sleep_lp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_sleep_hp_pad_hold_all",
+                &format_args!("{}", self.hp_sleep_hp_pad_hold_all().bit()),
+            )
+            .field(
+                "hp_sleep_dig_pad_slp_sel",
+                &format_args!("{}", self.hp_sleep_dig_pad_slp_sel().bit()),
+            )
+            .field(
+                "hp_sleep_dig_pause_wdt",
+                &format_args!("{}", self.hp_sleep_dig_pause_wdt().bit()),
+            )
+            .field(
+                "hp_sleep_dig_cpu_stall",
+                &format_args!("{}", self.hp_sleep_dig_cpu_stall().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_uart_wakeup_en(
+        &mut self,
+    ) -> HP_SLEEP_UART_WAKEUP_EN_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_UART_WAKEUP_EN_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_pad_hold_all(
+        &mut self,
+    ) -> HP_SLEEP_LP_PAD_HOLD_ALL_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_LP_PAD_HOLD_ALL_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_hp_pad_hold_all(
+        &mut self,
+    ) -> HP_SLEEP_HP_PAD_HOLD_ALL_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_HP_PAD_HOLD_ALL_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_pad_slp_sel(
+        &mut self,
+    ) -> HP_SLEEP_DIG_PAD_SLP_SEL_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_DIG_PAD_SLP_SEL_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_pause_wdt(
+        &mut self,
+    ) -> HP_SLEEP_DIG_PAUSE_WDT_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_DIG_PAUSE_WDT_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_cpu_stall(
+        &mut self,
+    ) -> HP_SLEEP_DIG_CPU_STALL_W<HP_SLEEP_HP_SYS_CNTL_SPEC> {
+        HP_SLEEP_DIG_CPU_STALL_W::new(self, 29)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_hp_sys_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_hp_sys_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_HP_SYS_CNTL_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_HP_SYS_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_hp_sys_cntl::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_HP_SYS_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_hp_sys_cntl::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_HP_SYS_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_HP_SYS_CNTL to value 0"]
+impl crate::Resettable for HP_SLEEP_HP_SYS_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_icg_hp_apb.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_icg_hp_apb.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_ICG_HP_APB` reader"]
+pub type R = crate::R<HP_SLEEP_ICG_HP_APB_SPEC>;
+#[doc = "Register `HP_SLEEP_ICG_HP_APB` writer"]
+pub type W = crate::W<HP_SLEEP_ICG_HP_APB_SPEC>;
+#[doc = "Field `HP_SLEEP_DIG_ICG_APB_EN` reader - need_des"]
+pub type HP_SLEEP_DIG_ICG_APB_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_SLEEP_DIG_ICG_APB_EN` writer - need_des"]
+pub type HP_SLEEP_DIG_ICG_APB_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_icg_apb_en(&self) -> HP_SLEEP_DIG_ICG_APB_EN_R {
+        HP_SLEEP_DIG_ICG_APB_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_ICG_HP_APB")
+            .field(
+                "hp_sleep_dig_icg_apb_en",
+                &format_args!("{}", self.hp_sleep_dig_icg_apb_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_ICG_HP_APB_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_icg_apb_en(
+        &mut self,
+    ) -> HP_SLEEP_DIG_ICG_APB_EN_W<HP_SLEEP_ICG_HP_APB_SPEC> {
+        HP_SLEEP_DIG_ICG_APB_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_hp_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_hp_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_ICG_HP_APB_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_ICG_HP_APB_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_icg_hp_apb::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_ICG_HP_APB_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_icg_hp_apb::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_ICG_HP_APB_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_ICG_HP_APB to value 0xffff_ffff"]
+impl crate::Resettable for HP_SLEEP_ICG_HP_APB_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_icg_hp_func.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_icg_hp_func.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_ICG_HP_FUNC` reader"]
+pub type R = crate::R<HP_SLEEP_ICG_HP_FUNC_SPEC>;
+#[doc = "Register `HP_SLEEP_ICG_HP_FUNC` writer"]
+pub type W = crate::W<HP_SLEEP_ICG_HP_FUNC_SPEC>;
+#[doc = "Field `HP_SLEEP_DIG_ICG_FUNC_EN` reader - need_des"]
+pub type HP_SLEEP_DIG_ICG_FUNC_EN_R = crate::FieldReader<u32>;
+#[doc = "Field `HP_SLEEP_DIG_ICG_FUNC_EN` writer - need_des"]
+pub type HP_SLEEP_DIG_ICG_FUNC_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_icg_func_en(&self) -> HP_SLEEP_DIG_ICG_FUNC_EN_R {
+        HP_SLEEP_DIG_ICG_FUNC_EN_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_ICG_HP_FUNC")
+            .field(
+                "hp_sleep_dig_icg_func_en",
+                &format_args!("{}", self.hp_sleep_dig_icg_func_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_ICG_HP_FUNC_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_icg_func_en(
+        &mut self,
+    ) -> HP_SLEEP_DIG_ICG_FUNC_EN_W<HP_SLEEP_ICG_HP_FUNC_SPEC> {
+        HP_SLEEP_DIG_ICG_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_hp_func::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_hp_func::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_ICG_HP_FUNC_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_ICG_HP_FUNC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_icg_hp_func::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_ICG_HP_FUNC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_icg_hp_func::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_ICG_HP_FUNC_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_ICG_HP_FUNC to value 0xffff_ffff"]
+impl crate::Resettable for HP_SLEEP_ICG_HP_FUNC_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_icg_modem.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_icg_modem.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_ICG_MODEM` reader"]
+pub type R = crate::R<HP_SLEEP_ICG_MODEM_SPEC>;
+#[doc = "Register `HP_SLEEP_ICG_MODEM` writer"]
+pub type W = crate::W<HP_SLEEP_ICG_MODEM_SPEC>;
+#[doc = "Field `HP_SLEEP_DIG_ICG_MODEM_CODE` reader - need_des"]
+pub type HP_SLEEP_DIG_ICG_MODEM_CODE_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_DIG_ICG_MODEM_CODE` writer - need_des"]
+pub type HP_SLEEP_DIG_ICG_MODEM_CODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_icg_modem_code(&self) -> HP_SLEEP_DIG_ICG_MODEM_CODE_R {
+        HP_SLEEP_DIG_ICG_MODEM_CODE_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_ICG_MODEM")
+            .field(
+                "hp_sleep_dig_icg_modem_code",
+                &format_args!("{}", self.hp_sleep_dig_icg_modem_code().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_ICG_MODEM_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_icg_modem_code(
+        &mut self,
+    ) -> HP_SLEEP_DIG_ICG_MODEM_CODE_W<HP_SLEEP_ICG_MODEM_SPEC> {
+        HP_SLEEP_DIG_ICG_MODEM_CODE_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_icg_modem::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_icg_modem::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_ICG_MODEM_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_ICG_MODEM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_icg_modem::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_ICG_MODEM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_icg_modem::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_ICG_MODEM_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_ICG_MODEM to value 0"]
+impl crate::Resettable for HP_SLEEP_ICG_MODEM_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_lp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_lp_ck_power.rs
@@ -1,0 +1,114 @@
+#[doc = "Register `HP_SLEEP_LP_CK_POWER` reader"]
+pub type R = crate::R<HP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "Register `HP_SLEEP_LP_CK_POWER` writer"]
+pub type W = crate::W<HP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "Field `HP_SLEEP_XPD_XTAL32K` reader - need_des"]
+pub type HP_SLEEP_XPD_XTAL32K_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_XTAL32K` writer - need_des"]
+pub type HP_SLEEP_XPD_XTAL32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_XPD_RC32K` reader - need_des"]
+pub type HP_SLEEP_XPD_RC32K_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_RC32K` writer - need_des"]
+pub type HP_SLEEP_XPD_RC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_XPD_FOSC_CLK` reader - need_des"]
+pub type HP_SLEEP_XPD_FOSC_CLK_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_FOSC_CLK` writer - need_des"]
+pub type HP_SLEEP_XPD_FOSC_CLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_OSC_CLK` reader - need_des"]
+pub type HP_SLEEP_PD_OSC_CLK_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_OSC_CLK` writer - need_des"]
+pub type HP_SLEEP_PD_OSC_CLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_xtal32k(&self) -> HP_SLEEP_XPD_XTAL32K_R {
+        HP_SLEEP_XPD_XTAL32K_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_rc32k(&self) -> HP_SLEEP_XPD_RC32K_R {
+        HP_SLEEP_XPD_RC32K_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_fosc_clk(&self) -> HP_SLEEP_XPD_FOSC_CLK_R {
+        HP_SLEEP_XPD_FOSC_CLK_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_osc_clk(&self) -> HP_SLEEP_PD_OSC_CLK_R {
+        HP_SLEEP_PD_OSC_CLK_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_LP_CK_POWER")
+            .field(
+                "hp_sleep_xpd_xtal32k",
+                &format_args!("{}", self.hp_sleep_xpd_xtal32k().bit()),
+            )
+            .field(
+                "hp_sleep_xpd_rc32k",
+                &format_args!("{}", self.hp_sleep_xpd_rc32k().bit()),
+            )
+            .field(
+                "hp_sleep_xpd_fosc_clk",
+                &format_args!("{}", self.hp_sleep_xpd_fosc_clk().bit()),
+            )
+            .field(
+                "hp_sleep_pd_osc_clk",
+                &format_args!("{}", self.hp_sleep_pd_osc_clk().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_LP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_xtal32k(&mut self) -> HP_SLEEP_XPD_XTAL32K_W<HP_SLEEP_LP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_XTAL32K_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_rc32k(&mut self) -> HP_SLEEP_XPD_RC32K_W<HP_SLEEP_LP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_RC32K_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_fosc_clk(&mut self) -> HP_SLEEP_XPD_FOSC_CLK_W<HP_SLEEP_LP_CK_POWER_SPEC> {
+        HP_SLEEP_XPD_FOSC_CLK_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_osc_clk(&mut self) -> HP_SLEEP_PD_OSC_CLK_W<HP_SLEEP_LP_CK_POWER_SPEC> {
+        HP_SLEEP_PD_OSC_CLK_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_LP_CK_POWER_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_LP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_lp_ck_power::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_LP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_lp_ck_power::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_LP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_LP_CK_POWER to value 0x4000_0000"]
+impl crate::Resettable for HP_SLEEP_LP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0x4000_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_lp_dcdc_reserve.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_lp_dcdc_reserve.rs
@@ -1,0 +1,35 @@
+#[doc = "Register `HP_SLEEP_LP_DCDC_RESERVE` writer"]
+pub type W = crate::W<HP_SLEEP_LP_DCDC_RESERVE_SPEC>;
+#[doc = "Field `HP_SLEEP_LP_DCDC_RESERVE` writer - need_des"]
+pub type HP_SLEEP_LP_DCDC_RESERVE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_LP_DCDC_RESERVE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_dcdc_reserve(
+        &mut self,
+    ) -> HP_SLEEP_LP_DCDC_RESERVE_W<HP_SLEEP_LP_DCDC_RESERVE_SPEC> {
+        HP_SLEEP_LP_DCDC_RESERVE_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_dcdc_reserve::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_LP_DCDC_RESERVE_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_LP_DCDC_RESERVE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_lp_dcdc_reserve::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_LP_DCDC_RESERVE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_LP_DCDC_RESERVE to value 0"]
+impl crate::Resettable for HP_SLEEP_LP_DCDC_RESERVE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_lp_dig_power.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_lp_dig_power.rs
@@ -1,0 +1,78 @@
+#[doc = "Register `HP_SLEEP_LP_DIG_POWER` reader"]
+pub type R = crate::R<HP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "Register `HP_SLEEP_LP_DIG_POWER` writer"]
+pub type W = crate::W<HP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "Field `HP_SLEEP_LP_MEM_DSLP` reader - need_des"]
+pub type HP_SLEEP_LP_MEM_DSLP_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_LP_MEM_DSLP` writer - need_des"]
+pub type HP_SLEEP_LP_MEM_DSLP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_PD_LP_PERI_PD_EN` reader - need_des"]
+pub type HP_SLEEP_PD_LP_PERI_PD_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_PD_LP_PERI_PD_EN` writer - need_des"]
+pub type HP_SLEEP_PD_LP_PERI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_mem_dslp(&self) -> HP_SLEEP_LP_MEM_DSLP_R {
+        HP_SLEEP_LP_MEM_DSLP_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_pd_lp_peri_pd_en(&self) -> HP_SLEEP_PD_LP_PERI_PD_EN_R {
+        HP_SLEEP_PD_LP_PERI_PD_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_LP_DIG_POWER")
+            .field(
+                "hp_sleep_lp_mem_dslp",
+                &format_args!("{}", self.hp_sleep_lp_mem_dslp().bit()),
+            )
+            .field(
+                "hp_sleep_pd_lp_peri_pd_en",
+                &format_args!("{}", self.hp_sleep_pd_lp_peri_pd_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_LP_DIG_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_mem_dslp(&mut self) -> HP_SLEEP_LP_MEM_DSLP_W<HP_SLEEP_LP_DIG_POWER_SPEC> {
+        HP_SLEEP_LP_MEM_DSLP_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_pd_lp_peri_pd_en(
+        &mut self,
+    ) -> HP_SLEEP_PD_LP_PERI_PD_EN_W<HP_SLEEP_LP_DIG_POWER_SPEC> {
+        HP_SLEEP_PD_LP_PERI_PD_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_dig_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_dig_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_LP_DIG_POWER_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_LP_DIG_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_lp_dig_power::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_LP_DIG_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_lp_dig_power::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_LP_DIG_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_LP_DIG_POWER to value 0"]
+impl crate::Resettable for HP_SLEEP_LP_DIG_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_lp_regulator0.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_lp_regulator0.rs
@@ -1,0 +1,122 @@
+#[doc = "Register `HP_SLEEP_LP_REGULATOR0` reader"]
+pub type R = crate::R<HP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "Register `HP_SLEEP_LP_REGULATOR0` writer"]
+pub type W = crate::W<HP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_SLP_XPD` reader - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_SLP_XPD_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_SLP_XPD` writer - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_SLP_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_XPD` reader - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_XPD_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_XPD` writer - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_SLP_DBIAS` reader - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_SLP_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_SLP_DBIAS` writer - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_SLP_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_DBIAS` reader - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_DBIAS_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_DBIAS` writer - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_regulator_slp_xpd(&self) -> HP_SLEEP_LP_REGULATOR_SLP_XPD_R {
+        HP_SLEEP_LP_REGULATOR_SLP_XPD_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_regulator_xpd(&self) -> HP_SLEEP_LP_REGULATOR_XPD_R {
+        HP_SLEEP_LP_REGULATOR_XPD_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_regulator_slp_dbias(&self) -> HP_SLEEP_LP_REGULATOR_SLP_DBIAS_R {
+        HP_SLEEP_LP_REGULATOR_SLP_DBIAS_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_regulator_dbias(&self) -> HP_SLEEP_LP_REGULATOR_DBIAS_R {
+        HP_SLEEP_LP_REGULATOR_DBIAS_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_LP_REGULATOR0")
+            .field(
+                "hp_sleep_lp_regulator_slp_xpd",
+                &format_args!("{}", self.hp_sleep_lp_regulator_slp_xpd().bit()),
+            )
+            .field(
+                "hp_sleep_lp_regulator_xpd",
+                &format_args!("{}", self.hp_sleep_lp_regulator_xpd().bit()),
+            )
+            .field(
+                "hp_sleep_lp_regulator_slp_dbias",
+                &format_args!("{}", self.hp_sleep_lp_regulator_slp_dbias().bits()),
+            )
+            .field(
+                "hp_sleep_lp_regulator_dbias",
+                &format_args!("{}", self.hp_sleep_lp_regulator_dbias().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_LP_REGULATOR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_regulator_slp_xpd(
+        &mut self,
+    ) -> HP_SLEEP_LP_REGULATOR_SLP_XPD_W<HP_SLEEP_LP_REGULATOR0_SPEC> {
+        HP_SLEEP_LP_REGULATOR_SLP_XPD_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_regulator_xpd(
+        &mut self,
+    ) -> HP_SLEEP_LP_REGULATOR_XPD_W<HP_SLEEP_LP_REGULATOR0_SPEC> {
+        HP_SLEEP_LP_REGULATOR_XPD_W::new(self, 22)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_regulator_slp_dbias(
+        &mut self,
+    ) -> HP_SLEEP_LP_REGULATOR_SLP_DBIAS_W<HP_SLEEP_LP_REGULATOR0_SPEC> {
+        HP_SLEEP_LP_REGULATOR_SLP_DBIAS_W::new(self, 23)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_regulator_dbias(
+        &mut self,
+    ) -> HP_SLEEP_LP_REGULATOR_DBIAS_W<HP_SLEEP_LP_REGULATOR0_SPEC> {
+        HP_SLEEP_LP_REGULATOR_DBIAS_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_regulator0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_regulator0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_LP_REGULATOR0_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_LP_REGULATOR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_lp_regulator0::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_LP_REGULATOR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_lp_regulator0::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_LP_REGULATOR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_LP_REGULATOR0 to value 0xc660_0000"]
+impl crate::Resettable for HP_SLEEP_LP_REGULATOR0_SPEC {
+    const RESET_VALUE: u32 = 0xc660_0000;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_lp_regulator1.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_lp_regulator1.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `HP_SLEEP_LP_REGULATOR1` reader"]
+pub type R = crate::R<HP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "Register `HP_SLEEP_LP_REGULATOR1` writer"]
+pub type W = crate::W<HP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_DRV_B` reader - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_DRV_B_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_LP_REGULATOR_DRV_B` writer - need_des"]
+pub type HP_SLEEP_LP_REGULATOR_DRV_B_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_lp_regulator_drv_b(&self) -> HP_SLEEP_LP_REGULATOR_DRV_B_R {
+        HP_SLEEP_LP_REGULATOR_DRV_B_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_LP_REGULATOR1")
+            .field(
+                "hp_sleep_lp_regulator_drv_b",
+                &format_args!("{}", self.hp_sleep_lp_regulator_drv_b().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_LP_REGULATOR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_lp_regulator_drv_b(
+        &mut self,
+    ) -> HP_SLEEP_LP_REGULATOR_DRV_B_W<HP_SLEEP_LP_REGULATOR1_SPEC> {
+        HP_SLEEP_LP_REGULATOR_DRV_B_W::new(self, 28)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_lp_regulator1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_lp_regulator1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_LP_REGULATOR1_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_LP_REGULATOR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_lp_regulator1::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_LP_REGULATOR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_lp_regulator1::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_LP_REGULATOR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_LP_REGULATOR1 to value 0"]
+impl crate::Resettable for HP_SLEEP_LP_REGULATOR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_sysclk.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_sysclk.rs
@@ -1,0 +1,137 @@
+#[doc = "Register `HP_SLEEP_SYSCLK` reader"]
+pub type R = crate::R<HP_SLEEP_SYSCLK_SPEC>;
+#[doc = "Register `HP_SLEEP_SYSCLK` writer"]
+pub type W = crate::W<HP_SLEEP_SYSCLK_SPEC>;
+#[doc = "Field `HP_SLEEP_DIG_SYS_CLK_NO_DIV` reader - need_des"]
+pub type HP_SLEEP_DIG_SYS_CLK_NO_DIV_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_DIG_SYS_CLK_NO_DIV` writer - need_des"]
+pub type HP_SLEEP_DIG_SYS_CLK_NO_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_ICG_SYS_CLOCK_EN` reader - need_des"]
+pub type HP_SLEEP_ICG_SYS_CLOCK_EN_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_ICG_SYS_CLOCK_EN` writer - need_des"]
+pub type HP_SLEEP_ICG_SYS_CLOCK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_SYS_CLK_SLP_SEL` reader - need_des"]
+pub type HP_SLEEP_SYS_CLK_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_SYS_CLK_SLP_SEL` writer - need_des"]
+pub type HP_SLEEP_SYS_CLK_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_ICG_SLP_SEL` reader - need_des"]
+pub type HP_SLEEP_ICG_SLP_SEL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_ICG_SLP_SEL` writer - need_des"]
+pub type HP_SLEEP_ICG_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SLEEP_DIG_SYS_CLK_SEL` reader - need_des"]
+pub type HP_SLEEP_DIG_SYS_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `HP_SLEEP_DIG_SYS_CLK_SEL` writer - need_des"]
+pub type HP_SLEEP_DIG_SYS_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_sys_clk_no_div(&self) -> HP_SLEEP_DIG_SYS_CLK_NO_DIV_R {
+        HP_SLEEP_DIG_SYS_CLK_NO_DIV_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_icg_sys_clock_en(&self) -> HP_SLEEP_ICG_SYS_CLOCK_EN_R {
+        HP_SLEEP_ICG_SYS_CLOCK_EN_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_sys_clk_slp_sel(&self) -> HP_SLEEP_SYS_CLK_SLP_SEL_R {
+        HP_SLEEP_SYS_CLK_SLP_SEL_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_icg_slp_sel(&self) -> HP_SLEEP_ICG_SLP_SEL_R {
+        HP_SLEEP_ICG_SLP_SEL_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_dig_sys_clk_sel(&self) -> HP_SLEEP_DIG_SYS_CLK_SEL_R {
+        HP_SLEEP_DIG_SYS_CLK_SEL_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_SYSCLK")
+            .field(
+                "hp_sleep_dig_sys_clk_no_div",
+                &format_args!("{}", self.hp_sleep_dig_sys_clk_no_div().bit()),
+            )
+            .field(
+                "hp_sleep_icg_sys_clock_en",
+                &format_args!("{}", self.hp_sleep_icg_sys_clock_en().bit()),
+            )
+            .field(
+                "hp_sleep_sys_clk_slp_sel",
+                &format_args!("{}", self.hp_sleep_sys_clk_slp_sel().bit()),
+            )
+            .field(
+                "hp_sleep_icg_slp_sel",
+                &format_args!("{}", self.hp_sleep_icg_slp_sel().bit()),
+            )
+            .field(
+                "hp_sleep_dig_sys_clk_sel",
+                &format_args!("{}", self.hp_sleep_dig_sys_clk_sel().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_SYSCLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_sys_clk_no_div(
+        &mut self,
+    ) -> HP_SLEEP_DIG_SYS_CLK_NO_DIV_W<HP_SLEEP_SYSCLK_SPEC> {
+        HP_SLEEP_DIG_SYS_CLK_NO_DIV_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_icg_sys_clock_en(
+        &mut self,
+    ) -> HP_SLEEP_ICG_SYS_CLOCK_EN_W<HP_SLEEP_SYSCLK_SPEC> {
+        HP_SLEEP_ICG_SYS_CLOCK_EN_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_sys_clk_slp_sel(&mut self) -> HP_SLEEP_SYS_CLK_SLP_SEL_W<HP_SLEEP_SYSCLK_SPEC> {
+        HP_SLEEP_SYS_CLK_SLP_SEL_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_icg_slp_sel(&mut self) -> HP_SLEEP_ICG_SLP_SEL_W<HP_SLEEP_SYSCLK_SPEC> {
+        HP_SLEEP_ICG_SLP_SEL_W::new(self, 29)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_dig_sys_clk_sel(&mut self) -> HP_SLEEP_DIG_SYS_CLK_SEL_W<HP_SLEEP_SYSCLK_SPEC> {
+        HP_SLEEP_DIG_SYS_CLK_SEL_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_sysclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_sysclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_SYSCLK_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_SYSCLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_sysclk::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_SYSCLK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_sysclk::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_SYSCLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_SYSCLK to value 0"]
+impl crate::Resettable for HP_SLEEP_SYSCLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/hp_sleep_xtal.rs
+++ b/esp32c6-lp/src/pmu/hp_sleep_xtal.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `HP_SLEEP_XTAL` reader"]
+pub type R = crate::R<HP_SLEEP_XTAL_SPEC>;
+#[doc = "Register `HP_SLEEP_XTAL` writer"]
+pub type W = crate::W<HP_SLEEP_XTAL_SPEC>;
+#[doc = "Field `HP_SLEEP_XPD_XTAL` reader - need_des"]
+pub type HP_SLEEP_XPD_XTAL_R = crate::BitReader;
+#[doc = "Field `HP_SLEEP_XPD_XTAL` writer - need_des"]
+pub type HP_SLEEP_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sleep_xpd_xtal(&self) -> HP_SLEEP_XPD_XTAL_R {
+        HP_SLEEP_XPD_XTAL_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HP_SLEEP_XTAL")
+            .field(
+                "hp_sleep_xpd_xtal",
+                &format_args!("{}", self.hp_sleep_xpd_xtal().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<HP_SLEEP_XTAL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sleep_xpd_xtal(&mut self) -> HP_SLEEP_XPD_XTAL_W<HP_SLEEP_XTAL_SPEC> {
+        HP_SLEEP_XPD_XTAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hp_sleep_xtal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hp_sleep_xtal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HP_SLEEP_XTAL_SPEC;
+impl crate::RegisterSpec for HP_SLEEP_XTAL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hp_sleep_xtal::R`](R) reader structure"]
+impl crate::Readable for HP_SLEEP_XTAL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hp_sleep_xtal::W`](W) writer structure"]
+impl crate::Writable for HP_SLEEP_XTAL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets HP_SLEEP_XTAL to value 0x8000_0000"]
+impl crate::Resettable for HP_SLEEP_XTAL_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/imm_hp_apb_icg.rs
+++ b/esp32c6-lp/src/pmu/imm_hp_apb_icg.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `IMM_HP_APB_ICG` writer"]
+pub type W = crate::W<IMM_HP_APB_ICG_SPEC>;
+#[doc = "Field `UPDATE_DIG_ICG_APB_EN` writer - need_des"]
+pub type UPDATE_DIG_ICG_APB_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_HP_APB_ICG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn update_dig_icg_apb_en(&mut self) -> UPDATE_DIG_ICG_APB_EN_W<IMM_HP_APB_ICG_SPEC> {
+        UPDATE_DIG_ICG_APB_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_apb_icg::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_HP_APB_ICG_SPEC;
+impl crate::RegisterSpec for IMM_HP_APB_ICG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_hp_apb_icg::W`](W) writer structure"]
+impl crate::Writable for IMM_HP_APB_ICG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_HP_APB_ICG to value 0"]
+impl crate::Resettable for IMM_HP_APB_ICG_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_hp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/imm_hp_ck_power.rs
@@ -1,0 +1,149 @@
+#[doc = "Register `IMM_HP_CK_POWER` reader"]
+pub type R = crate::R<IMM_HP_CK_POWER_SPEC>;
+#[doc = "Register `IMM_HP_CK_POWER` writer"]
+pub type W = crate::W<IMM_HP_CK_POWER_SPEC>;
+#[doc = "Field `TIE_LOW_GLOBAL_BBPLL_ICG` writer - need_des"]
+pub type TIE_LOW_GLOBAL_BBPLL_ICG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_GLOBAL_XTAL_ICG` writer - need_des"]
+pub type TIE_LOW_GLOBAL_XTAL_ICG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_I2C_RETENTION` writer - need_des"]
+pub type TIE_LOW_I2C_RETENTION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_XPD_BB_I2C` writer - need_des"]
+pub type TIE_LOW_XPD_BB_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_XPD_BBPLL_I2C` writer - need_des"]
+pub type TIE_LOW_XPD_BBPLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_XPD_BBPLL` writer - need_des"]
+pub type TIE_LOW_XPD_BBPLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_XPD_XTAL` writer - need_des"]
+pub type TIE_LOW_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_GLOBAL_BBPLL_ICG` writer - need_des"]
+pub type TIE_HIGH_GLOBAL_BBPLL_ICG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_GLOBAL_XTAL_ICG` writer - need_des"]
+pub type TIE_HIGH_GLOBAL_XTAL_ICG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_I2C_RETENTION` writer - need_des"]
+pub type TIE_HIGH_I2C_RETENTION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_XPD_BB_I2C` writer - need_des"]
+pub type TIE_HIGH_XPD_BB_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_XPD_BBPLL_I2C` writer - need_des"]
+pub type TIE_HIGH_XPD_BBPLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_XPD_BBPLL` writer - need_des"]
+pub type TIE_HIGH_XPD_BBPLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_XPD_XTAL` writer - need_des"]
+pub type TIE_HIGH_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IMM_HP_CK_POWER").finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_HP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_global_bbpll_icg(&mut self) -> TIE_LOW_GLOBAL_BBPLL_ICG_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_GLOBAL_BBPLL_ICG_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_global_xtal_icg(&mut self) -> TIE_LOW_GLOBAL_XTAL_ICG_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_GLOBAL_XTAL_ICG_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_i2c_retention(&mut self) -> TIE_LOW_I2C_RETENTION_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_I2C_RETENTION_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_xpd_bb_i2c(&mut self) -> TIE_LOW_XPD_BB_I2C_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_XPD_BB_I2C_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_xpd_bbpll_i2c(&mut self) -> TIE_LOW_XPD_BBPLL_I2C_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_XPD_BBPLL_I2C_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_xpd_bbpll(&mut self) -> TIE_LOW_XPD_BBPLL_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_XPD_BBPLL_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_xpd_xtal(&mut self) -> TIE_LOW_XPD_XTAL_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_LOW_XPD_XTAL_W::new(self, 6)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_global_bbpll_icg(
+        &mut self,
+    ) -> TIE_HIGH_GLOBAL_BBPLL_ICG_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_GLOBAL_BBPLL_ICG_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_global_xtal_icg(&mut self) -> TIE_HIGH_GLOBAL_XTAL_ICG_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_GLOBAL_XTAL_ICG_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_i2c_retention(&mut self) -> TIE_HIGH_I2C_RETENTION_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_I2C_RETENTION_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_xpd_bb_i2c(&mut self) -> TIE_HIGH_XPD_BB_I2C_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_XPD_BB_I2C_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_xpd_bbpll_i2c(&mut self) -> TIE_HIGH_XPD_BBPLL_I2C_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_XPD_BBPLL_I2C_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_xpd_bbpll(&mut self) -> TIE_HIGH_XPD_BBPLL_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_XPD_BBPLL_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_xpd_xtal(&mut self) -> TIE_HIGH_XPD_XTAL_W<IMM_HP_CK_POWER_SPEC> {
+        TIE_HIGH_XPD_XTAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`imm_hp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_HP_CK_POWER_SPEC;
+impl crate::RegisterSpec for IMM_HP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`imm_hp_ck_power::R`](R) reader structure"]
+impl crate::Readable for IMM_HP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`imm_hp_ck_power::W`](W) writer structure"]
+impl crate::Writable for IMM_HP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_HP_CK_POWER to value 0"]
+impl crate::Resettable for IMM_HP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_hp_func_icg.rs
+++ b/esp32c6-lp/src/pmu/imm_hp_func_icg.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `IMM_HP_FUNC_ICG` writer"]
+pub type W = crate::W<IMM_HP_FUNC_ICG_SPEC>;
+#[doc = "Field `UPDATE_DIG_ICG_FUNC_EN` writer - need_des"]
+pub type UPDATE_DIG_ICG_FUNC_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_HP_FUNC_ICG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn update_dig_icg_func_en(&mut self) -> UPDATE_DIG_ICG_FUNC_EN_W<IMM_HP_FUNC_ICG_SPEC> {
+        UPDATE_DIG_ICG_FUNC_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_hp_func_icg::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_HP_FUNC_ICG_SPEC;
+impl crate::RegisterSpec for IMM_HP_FUNC_ICG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_hp_func_icg::W`](W) writer structure"]
+impl crate::Writable for IMM_HP_FUNC_ICG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_HP_FUNC_ICG to value 0"]
+impl crate::Resettable for IMM_HP_FUNC_ICG_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_i2c_iso.rs
+++ b/esp32c6-lp/src/pmu/imm_i2c_iso.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `IMM_I2C_ISO` writer"]
+pub type W = crate::W<IMM_I2C_ISO_SPEC>;
+#[doc = "Field `TIE_HIGH_I2C_ISO_EN` writer - need_des"]
+pub type TIE_HIGH_I2C_ISO_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_I2C_ISO_EN` writer - need_des"]
+pub type TIE_LOW_I2C_ISO_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_I2C_ISO_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_i2c_iso_en(&mut self) -> TIE_HIGH_I2C_ISO_EN_W<IMM_I2C_ISO_SPEC> {
+        TIE_HIGH_I2C_ISO_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_i2c_iso_en(&mut self) -> TIE_LOW_I2C_ISO_EN_W<IMM_I2C_ISO_SPEC> {
+        TIE_LOW_I2C_ISO_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_i2c_iso::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_I2C_ISO_SPEC;
+impl crate::RegisterSpec for IMM_I2C_ISO_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_i2c_iso::W`](W) writer structure"]
+impl crate::Writable for IMM_I2C_ISO_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_I2C_ISO to value 0"]
+impl crate::Resettable for IMM_I2C_ISO_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_lp_icg.rs
+++ b/esp32c6-lp/src/pmu/imm_lp_icg.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `IMM_LP_ICG` writer"]
+pub type W = crate::W<IMM_LP_ICG_SPEC>;
+#[doc = "Field `TIE_LOW_LP_ROOTCLK_SEL` writer - need_des"]
+pub type TIE_LOW_LP_ROOTCLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_LP_ROOTCLK_SEL` writer - need_des"]
+pub type TIE_HIGH_LP_ROOTCLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_LP_ICG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_lp_rootclk_sel(&mut self) -> TIE_LOW_LP_ROOTCLK_SEL_W<IMM_LP_ICG_SPEC> {
+        TIE_LOW_LP_ROOTCLK_SEL_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_lp_rootclk_sel(&mut self) -> TIE_HIGH_LP_ROOTCLK_SEL_W<IMM_LP_ICG_SPEC> {
+        TIE_HIGH_LP_ROOTCLK_SEL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_lp_icg::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_LP_ICG_SPEC;
+impl crate::RegisterSpec for IMM_LP_ICG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_lp_icg::W`](W) writer structure"]
+impl crate::Writable for IMM_LP_ICG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_LP_ICG to value 0"]
+impl crate::Resettable for IMM_LP_ICG_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_modem_icg.rs
+++ b/esp32c6-lp/src/pmu/imm_modem_icg.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `IMM_MODEM_ICG` writer"]
+pub type W = crate::W<IMM_MODEM_ICG_SPEC>;
+#[doc = "Field `UPDATE_DIG_ICG_MODEM_EN` writer - need_des"]
+pub type UPDATE_DIG_ICG_MODEM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_MODEM_ICG_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn update_dig_icg_modem_en(&mut self) -> UPDATE_DIG_ICG_MODEM_EN_W<IMM_MODEM_ICG_SPEC> {
+        UPDATE_DIG_ICG_MODEM_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_modem_icg::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_MODEM_ICG_SPEC;
+impl crate::RegisterSpec for IMM_MODEM_ICG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_modem_icg::W`](W) writer structure"]
+impl crate::Writable for IMM_MODEM_ICG_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_MODEM_ICG to value 0"]
+impl crate::Resettable for IMM_MODEM_ICG_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_pad_hold_all.rs
+++ b/esp32c6-lp/src/pmu/imm_pad_hold_all.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `IMM_PAD_HOLD_ALL` writer"]
+pub type W = crate::W<IMM_PAD_HOLD_ALL_SPEC>;
+#[doc = "Field `TIE_HIGH_LP_PAD_HOLD_ALL` writer - need_des"]
+pub type TIE_HIGH_LP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_LP_PAD_HOLD_ALL` writer - need_des"]
+pub type TIE_LOW_LP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_HP_PAD_HOLD_ALL` writer - need_des"]
+pub type TIE_HIGH_HP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_HP_PAD_HOLD_ALL` writer - need_des"]
+pub type TIE_LOW_HP_PAD_HOLD_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_PAD_HOLD_ALL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_lp_pad_hold_all(
+        &mut self,
+    ) -> TIE_HIGH_LP_PAD_HOLD_ALL_W<IMM_PAD_HOLD_ALL_SPEC> {
+        TIE_HIGH_LP_PAD_HOLD_ALL_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_lp_pad_hold_all(&mut self) -> TIE_LOW_LP_PAD_HOLD_ALL_W<IMM_PAD_HOLD_ALL_SPEC> {
+        TIE_LOW_LP_PAD_HOLD_ALL_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_hp_pad_hold_all(
+        &mut self,
+    ) -> TIE_HIGH_HP_PAD_HOLD_ALL_W<IMM_PAD_HOLD_ALL_SPEC> {
+        TIE_HIGH_HP_PAD_HOLD_ALL_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_hp_pad_hold_all(&mut self) -> TIE_LOW_HP_PAD_HOLD_ALL_W<IMM_PAD_HOLD_ALL_SPEC> {
+        TIE_LOW_HP_PAD_HOLD_ALL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_pad_hold_all::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_PAD_HOLD_ALL_SPEC;
+impl crate::RegisterSpec for IMM_PAD_HOLD_ALL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_pad_hold_all::W`](W) writer structure"]
+impl crate::Writable for IMM_PAD_HOLD_ALL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_PAD_HOLD_ALL to value 0"]
+impl crate::Resettable for IMM_PAD_HOLD_ALL_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/imm_sleep_sysclk.rs
+++ b/esp32c6-lp/src/pmu/imm_sleep_sysclk.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `IMM_SLEEP_SYSCLK` writer"]
+pub type W = crate::W<IMM_SLEEP_SYSCLK_SPEC>;
+#[doc = "Field `UPDATE_DIG_ICG_SWITCH` writer - need_des"]
+pub type UPDATE_DIG_ICG_SWITCH_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_LOW_ICG_SLP_SEL` writer - need_des"]
+pub type TIE_LOW_ICG_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TIE_HIGH_ICG_SLP_SEL` writer - need_des"]
+pub type TIE_HIGH_ICG_SLP_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `UPDATE_DIG_SYS_CLK_SEL` writer - need_des"]
+pub type UPDATE_DIG_SYS_CLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<IMM_SLEEP_SYSCLK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn update_dig_icg_switch(&mut self) -> UPDATE_DIG_ICG_SWITCH_W<IMM_SLEEP_SYSCLK_SPEC> {
+        UPDATE_DIG_ICG_SWITCH_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_low_icg_slp_sel(&mut self) -> TIE_LOW_ICG_SLP_SEL_W<IMM_SLEEP_SYSCLK_SPEC> {
+        TIE_LOW_ICG_SLP_SEL_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tie_high_icg_slp_sel(&mut self) -> TIE_HIGH_ICG_SLP_SEL_W<IMM_SLEEP_SYSCLK_SPEC> {
+        TIE_HIGH_ICG_SLP_SEL_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn update_dig_sys_clk_sel(&mut self) -> UPDATE_DIG_SYS_CLK_SEL_W<IMM_SLEEP_SYSCLK_SPEC> {
+        UPDATE_DIG_SYS_CLK_SEL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`imm_sleep_sysclk::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IMM_SLEEP_SYSCLK_SPEC;
+impl crate::RegisterSpec for IMM_SLEEP_SYSCLK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`imm_sleep_sysclk::W`](W) writer structure"]
+impl crate::Writable for IMM_SLEEP_SYSCLK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets IMM_SLEEP_SYSCLK to value 0"]
+impl crate::Resettable for IMM_SLEEP_SYSCLK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/int_clr.rs
+++ b/esp32c6-lp/src/pmu/int_clr.rs
@@ -1,0 +1,65 @@
+#[doc = "Register `INT_CLR` writer"]
+pub type W = crate::W<INT_CLR_SPEC>;
+#[doc = "Field `LP_CPU_EXC` writer - need_des"]
+pub type LP_CPU_EXC_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SDIO_IDLE` writer - need_des"]
+pub type SDIO_IDLE_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SW` writer - need_des"]
+pub type SW_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SOC_SLEEP_REJECT` writer - need_des"]
+pub type SOC_SLEEP_REJECT_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SOC_WAKEUP` writer - need_des"]
+pub type SOC_WAKEUP_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<INT_CLR_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_exc(&mut self) -> LP_CPU_EXC_W<INT_CLR_SPEC> {
+        LP_CPU_EXC_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sdio_idle(&mut self) -> SDIO_IDLE_W<INT_CLR_SPEC> {
+        SDIO_IDLE_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sw(&mut self) -> SW_W<INT_CLR_SPEC> {
+        SW_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_sleep_reject(&mut self) -> SOC_SLEEP_REJECT_W<INT_CLR_SPEC> {
+        SOC_SLEEP_REJECT_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_wakeup(&mut self) -> SOC_WAKEUP_W<INT_CLR_SPEC> {
+        SOC_WAKEUP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_clr::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_CLR_SPEC;
+impl crate::RegisterSpec for INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`int_clr::W`](W) writer structure"]
+impl crate::Writable for INT_CLR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0xf800_0000;
+}
+#[doc = "`reset()` method sets INT_CLR to value 0"]
+impl crate::Resettable for INT_CLR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/int_ena.rs
+++ b/esp32c6-lp/src/pmu/int_ena.rs
@@ -1,0 +1,121 @@
+#[doc = "Register `INT_ENA` reader"]
+pub type R = crate::R<INT_ENA_SPEC>;
+#[doc = "Register `INT_ENA` writer"]
+pub type W = crate::W<INT_ENA_SPEC>;
+#[doc = "Field `LP_CPU_EXC` reader - need_des"]
+pub type LP_CPU_EXC_R = crate::BitReader;
+#[doc = "Field `LP_CPU_EXC` writer - need_des"]
+pub type LP_CPU_EXC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SDIO_IDLE` reader - need_des"]
+pub type SDIO_IDLE_R = crate::BitReader;
+#[doc = "Field `SDIO_IDLE` writer - need_des"]
+pub type SDIO_IDLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SW` reader - need_des"]
+pub type SW_R = crate::BitReader;
+#[doc = "Field `SW` writer - need_des"]
+pub type SW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SOC_SLEEP_REJECT` reader - need_des"]
+pub type SOC_SLEEP_REJECT_R = crate::BitReader;
+#[doc = "Field `SOC_SLEEP_REJECT` writer - need_des"]
+pub type SOC_SLEEP_REJECT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SOC_WAKEUP` reader - need_des"]
+pub type SOC_WAKEUP_R = crate::BitReader;
+#[doc = "Field `SOC_WAKEUP` writer - need_des"]
+pub type SOC_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_exc(&self) -> LP_CPU_EXC_R {
+        LP_CPU_EXC_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sdio_idle(&self) -> SDIO_IDLE_R {
+        SDIO_IDLE_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn sw(&self) -> SW_R {
+        SW_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn soc_sleep_reject(&self) -> SOC_SLEEP_REJECT_R {
+        SOC_SLEEP_REJECT_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn soc_wakeup(&self) -> SOC_WAKEUP_R {
+        SOC_WAKEUP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("INT_ENA")
+            .field("lp_cpu_exc", &format_args!("{}", self.lp_cpu_exc().bit()))
+            .field("sdio_idle", &format_args!("{}", self.sdio_idle().bit()))
+            .field("sw", &format_args!("{}", self.sw().bit()))
+            .field(
+                "soc_sleep_reject",
+                &format_args!("{}", self.soc_sleep_reject().bit()),
+            )
+            .field("soc_wakeup", &format_args!("{}", self.soc_wakeup().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<INT_ENA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_exc(&mut self) -> LP_CPU_EXC_W<INT_ENA_SPEC> {
+        LP_CPU_EXC_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sdio_idle(&mut self) -> SDIO_IDLE_W<INT_ENA_SPEC> {
+        SDIO_IDLE_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sw(&mut self) -> SW_W<INT_ENA_SPEC> {
+        SW_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_sleep_reject(&mut self) -> SOC_SLEEP_REJECT_W<INT_ENA_SPEC> {
+        SOC_SLEEP_REJECT_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_wakeup(&mut self) -> SOC_WAKEUP_W<INT_ENA_SPEC> {
+        SOC_WAKEUP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_ena::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_ena::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_ENA_SPEC;
+impl crate::RegisterSpec for INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`int_ena::R`](R) reader structure"]
+impl crate::Readable for INT_ENA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`int_ena::W`](W) writer structure"]
+impl crate::Writable for INT_ENA_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets INT_ENA to value 0"]
+impl crate::Resettable for INT_ENA_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/int_raw.rs
+++ b/esp32c6-lp/src/pmu/int_raw.rs
@@ -1,0 +1,121 @@
+#[doc = "Register `INT_RAW` reader"]
+pub type R = crate::R<INT_RAW_SPEC>;
+#[doc = "Register `INT_RAW` writer"]
+pub type W = crate::W<INT_RAW_SPEC>;
+#[doc = "Field `LP_CPU_EXC` reader - need_des"]
+pub type LP_CPU_EXC_R = crate::BitReader;
+#[doc = "Field `LP_CPU_EXC` writer - need_des"]
+pub type LP_CPU_EXC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SDIO_IDLE` reader - need_des"]
+pub type SDIO_IDLE_R = crate::BitReader;
+#[doc = "Field `SDIO_IDLE` writer - need_des"]
+pub type SDIO_IDLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SW` reader - need_des"]
+pub type SW_R = crate::BitReader;
+#[doc = "Field `SW` writer - need_des"]
+pub type SW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SOC_SLEEP_REJECT` reader - need_des"]
+pub type SOC_SLEEP_REJECT_R = crate::BitReader;
+#[doc = "Field `SOC_SLEEP_REJECT` writer - need_des"]
+pub type SOC_SLEEP_REJECT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SOC_WAKEUP` reader - need_des"]
+pub type SOC_WAKEUP_R = crate::BitReader;
+#[doc = "Field `SOC_WAKEUP` writer - need_des"]
+pub type SOC_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_exc(&self) -> LP_CPU_EXC_R {
+        LP_CPU_EXC_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sdio_idle(&self) -> SDIO_IDLE_R {
+        SDIO_IDLE_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn sw(&self) -> SW_R {
+        SW_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn soc_sleep_reject(&self) -> SOC_SLEEP_REJECT_R {
+        SOC_SLEEP_REJECT_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn soc_wakeup(&self) -> SOC_WAKEUP_R {
+        SOC_WAKEUP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("INT_RAW")
+            .field("lp_cpu_exc", &format_args!("{}", self.lp_cpu_exc().bit()))
+            .field("sdio_idle", &format_args!("{}", self.sdio_idle().bit()))
+            .field("sw", &format_args!("{}", self.sw().bit()))
+            .field(
+                "soc_sleep_reject",
+                &format_args!("{}", self.soc_sleep_reject().bit()),
+            )
+            .field("soc_wakeup", &format_args!("{}", self.soc_wakeup().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<INT_RAW_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_exc(&mut self) -> LP_CPU_EXC_W<INT_RAW_SPEC> {
+        LP_CPU_EXC_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sdio_idle(&mut self) -> SDIO_IDLE_W<INT_RAW_SPEC> {
+        SDIO_IDLE_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sw(&mut self) -> SW_W<INT_RAW_SPEC> {
+        SW_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_sleep_reject(&mut self) -> SOC_SLEEP_REJECT_W<INT_RAW_SPEC> {
+        SOC_SLEEP_REJECT_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_wakeup(&mut self) -> SOC_WAKEUP_W<INT_RAW_SPEC> {
+        SOC_WAKEUP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_raw::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_raw::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_RAW_SPEC;
+impl crate::RegisterSpec for INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`int_raw::R`](R) reader structure"]
+impl crate::Readable for INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`int_raw::W`](W) writer structure"]
+impl crate::Writable for INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets INT_RAW to value 0"]
+impl crate::Resettable for INT_RAW_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/int_st.rs
+++ b/esp32c6-lp/src/pmu/int_st.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `INT_ST` reader"]
+pub type R = crate::R<INT_ST_SPEC>;
+#[doc = "Field `LP_CPU_EXC` reader - need_des"]
+pub type LP_CPU_EXC_R = crate::BitReader;
+#[doc = "Field `SDIO_IDLE` reader - need_des"]
+pub type SDIO_IDLE_R = crate::BitReader;
+#[doc = "Field `SW` reader - need_des"]
+pub type SW_R = crate::BitReader;
+#[doc = "Field `SOC_SLEEP_REJECT` reader - need_des"]
+pub type SOC_SLEEP_REJECT_R = crate::BitReader;
+#[doc = "Field `SOC_WAKEUP` reader - need_des"]
+pub type SOC_WAKEUP_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_exc(&self) -> LP_CPU_EXC_R {
+        LP_CPU_EXC_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sdio_idle(&self) -> SDIO_IDLE_R {
+        SDIO_IDLE_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn sw(&self) -> SW_R {
+        SW_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn soc_sleep_reject(&self) -> SOC_SLEEP_REJECT_R {
+        SOC_SLEEP_REJECT_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn soc_wakeup(&self) -> SOC_WAKEUP_R {
+        SOC_WAKEUP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("INT_ST")
+            .field("lp_cpu_exc", &format_args!("{}", self.lp_cpu_exc().bit()))
+            .field("sdio_idle", &format_args!("{}", self.sdio_idle().bit()))
+            .field("sw", &format_args!("{}", self.sw().bit()))
+            .field(
+                "soc_sleep_reject",
+                &format_args!("{}", self.soc_sleep_reject().bit()),
+            )
+            .field("soc_wakeup", &format_args!("{}", self.soc_wakeup().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<INT_ST_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_st::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_ST_SPEC;
+impl crate::RegisterSpec for INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`int_st::R`](R) reader structure"]
+impl crate::Readable for INT_ST_SPEC {}
+#[doc = "`reset()` method sets INT_ST to value 0"]
+impl crate::Resettable for INT_ST_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_cpu_pwr0.rs
+++ b/esp32c6-lp/src/pmu/lp_cpu_pwr0.rs
@@ -1,0 +1,193 @@
+#[doc = "Register `LP_CPU_PWR0` reader"]
+pub type R = crate::R<LP_CPU_PWR0_SPEC>;
+#[doc = "Register `LP_CPU_PWR0` writer"]
+pub type W = crate::W<LP_CPU_PWR0_SPEC>;
+#[doc = "Field `LP_CPU_WAITI_RDY` reader - need_des"]
+pub type LP_CPU_WAITI_RDY_R = crate::BitReader;
+#[doc = "Field `LP_CPU_STALL_RDY` reader - need_des"]
+pub type LP_CPU_STALL_RDY_R = crate::BitReader;
+#[doc = "Field `LP_CPU_FORCE_STALL` reader - need_des"]
+pub type LP_CPU_FORCE_STALL_R = crate::BitReader;
+#[doc = "Field `LP_CPU_FORCE_STALL` writer - need_des"]
+pub type LP_CPU_FORCE_STALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_CPU_SLP_WAITI_FLAG_EN` reader - need_des"]
+pub type LP_CPU_SLP_WAITI_FLAG_EN_R = crate::BitReader;
+#[doc = "Field `LP_CPU_SLP_WAITI_FLAG_EN` writer - need_des"]
+pub type LP_CPU_SLP_WAITI_FLAG_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_CPU_SLP_STALL_FLAG_EN` reader - need_des"]
+pub type LP_CPU_SLP_STALL_FLAG_EN_R = crate::BitReader;
+#[doc = "Field `LP_CPU_SLP_STALL_FLAG_EN` writer - need_des"]
+pub type LP_CPU_SLP_STALL_FLAG_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_CPU_SLP_STALL_WAIT` reader - need_des"]
+pub type LP_CPU_SLP_STALL_WAIT_R = crate::FieldReader;
+#[doc = "Field `LP_CPU_SLP_STALL_WAIT` writer - need_des"]
+pub type LP_CPU_SLP_STALL_WAIT_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `LP_CPU_SLP_STALL_EN` reader - need_des"]
+pub type LP_CPU_SLP_STALL_EN_R = crate::BitReader;
+#[doc = "Field `LP_CPU_SLP_STALL_EN` writer - need_des"]
+pub type LP_CPU_SLP_STALL_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_CPU_SLP_RESET_EN` reader - need_des"]
+pub type LP_CPU_SLP_RESET_EN_R = crate::BitReader;
+#[doc = "Field `LP_CPU_SLP_RESET_EN` writer - need_des"]
+pub type LP_CPU_SLP_RESET_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_CPU_SLP_BYPASS_INTR_EN` reader - need_des"]
+pub type LP_CPU_SLP_BYPASS_INTR_EN_R = crate::BitReader;
+#[doc = "Field `LP_CPU_SLP_BYPASS_INTR_EN` writer - need_des"]
+pub type LP_CPU_SLP_BYPASS_INTR_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_waiti_rdy(&self) -> LP_CPU_WAITI_RDY_R {
+        LP_CPU_WAITI_RDY_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_stall_rdy(&self) -> LP_CPU_STALL_RDY_R {
+        LP_CPU_STALL_RDY_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_force_stall(&self) -> LP_CPU_FORCE_STALL_R {
+        LP_CPU_FORCE_STALL_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_waiti_flag_en(&self) -> LP_CPU_SLP_WAITI_FLAG_EN_R {
+        LP_CPU_SLP_WAITI_FLAG_EN_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_stall_flag_en(&self) -> LP_CPU_SLP_STALL_FLAG_EN_R {
+        LP_CPU_SLP_STALL_FLAG_EN_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bits 21:28 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_stall_wait(&self) -> LP_CPU_SLP_STALL_WAIT_R {
+        LP_CPU_SLP_STALL_WAIT_R::new(((self.bits >> 21) & 0xff) as u8)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_stall_en(&self) -> LP_CPU_SLP_STALL_EN_R {
+        LP_CPU_SLP_STALL_EN_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_reset_en(&self) -> LP_CPU_SLP_RESET_EN_R {
+        LP_CPU_SLP_RESET_EN_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_slp_bypass_intr_en(&self) -> LP_CPU_SLP_BYPASS_INTR_EN_R {
+        LP_CPU_SLP_BYPASS_INTR_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_CPU_PWR0")
+            .field(
+                "lp_cpu_waiti_rdy",
+                &format_args!("{}", self.lp_cpu_waiti_rdy().bit()),
+            )
+            .field(
+                "lp_cpu_stall_rdy",
+                &format_args!("{}", self.lp_cpu_stall_rdy().bit()),
+            )
+            .field(
+                "lp_cpu_force_stall",
+                &format_args!("{}", self.lp_cpu_force_stall().bit()),
+            )
+            .field(
+                "lp_cpu_slp_waiti_flag_en",
+                &format_args!("{}", self.lp_cpu_slp_waiti_flag_en().bit()),
+            )
+            .field(
+                "lp_cpu_slp_stall_flag_en",
+                &format_args!("{}", self.lp_cpu_slp_stall_flag_en().bit()),
+            )
+            .field(
+                "lp_cpu_slp_stall_wait",
+                &format_args!("{}", self.lp_cpu_slp_stall_wait().bits()),
+            )
+            .field(
+                "lp_cpu_slp_stall_en",
+                &format_args!("{}", self.lp_cpu_slp_stall_en().bit()),
+            )
+            .field(
+                "lp_cpu_slp_reset_en",
+                &format_args!("{}", self.lp_cpu_slp_reset_en().bit()),
+            )
+            .field(
+                "lp_cpu_slp_bypass_intr_en",
+                &format_args!("{}", self.lp_cpu_slp_bypass_intr_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_CPU_PWR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 18 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_force_stall(&mut self) -> LP_CPU_FORCE_STALL_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_FORCE_STALL_W::new(self, 18)
+    }
+    #[doc = "Bit 19 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_waiti_flag_en(&mut self) -> LP_CPU_SLP_WAITI_FLAG_EN_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_WAITI_FLAG_EN_W::new(self, 19)
+    }
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_stall_flag_en(&mut self) -> LP_CPU_SLP_STALL_FLAG_EN_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_STALL_FLAG_EN_W::new(self, 20)
+    }
+    #[doc = "Bits 21:28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_stall_wait(&mut self) -> LP_CPU_SLP_STALL_WAIT_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_STALL_WAIT_W::new(self, 21)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_stall_en(&mut self) -> LP_CPU_SLP_STALL_EN_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_STALL_EN_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_reset_en(&mut self) -> LP_CPU_SLP_RESET_EN_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_RESET_EN_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_slp_bypass_intr_en(&mut self) -> LP_CPU_SLP_BYPASS_INTR_EN_W<LP_CPU_PWR0_SPEC> {
+        LP_CPU_SLP_BYPASS_INTR_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_cpu_pwr0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_cpu_pwr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_CPU_PWR0_SPEC;
+impl crate::RegisterSpec for LP_CPU_PWR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_cpu_pwr0::R`](R) reader structure"]
+impl crate::Readable for LP_CPU_PWR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_cpu_pwr0::W`](W) writer structure"]
+impl crate::Writable for LP_CPU_PWR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_CPU_PWR0 to value 0x1ff0_0000"]
+impl crate::Resettable for LP_CPU_PWR0_SPEC {
+    const RESET_VALUE: u32 = 0x1ff0_0000;
+}

--- a/esp32c6-lp/src/pmu/lp_cpu_pwr1.rs
+++ b/esp32c6-lp/src/pmu/lp_cpu_pwr1.rs
@@ -1,0 +1,65 @@
+#[doc = "Register `LP_CPU_PWR1` reader"]
+pub type R = crate::R<LP_CPU_PWR1_SPEC>;
+#[doc = "Register `LP_CPU_PWR1` writer"]
+pub type W = crate::W<LP_CPU_PWR1_SPEC>;
+#[doc = "Field `LP_CPU_WAKEUP_EN` reader - need_des"]
+pub type LP_CPU_WAKEUP_EN_R = crate::FieldReader<u16>;
+#[doc = "Field `LP_CPU_WAKEUP_EN` writer - need_des"]
+pub type LP_CPU_WAKEUP_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `LP_CPU_SLEEP_REQ` writer - need_des"]
+pub type LP_CPU_SLEEP_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 0:15 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_wakeup_en(&self) -> LP_CPU_WAKEUP_EN_R {
+        LP_CPU_WAKEUP_EN_R::new((self.bits & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_CPU_PWR1")
+            .field(
+                "lp_cpu_wakeup_en",
+                &format_args!("{}", self.lp_cpu_wakeup_en().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_CPU_PWR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_wakeup_en(&mut self) -> LP_CPU_WAKEUP_EN_W<LP_CPU_PWR1_SPEC> {
+        LP_CPU_WAKEUP_EN_W::new(self, 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_sleep_req(&mut self) -> LP_CPU_SLEEP_REQ_W<LP_CPU_PWR1_SPEC> {
+        LP_CPU_SLEEP_REQ_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_cpu_pwr1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_cpu_pwr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_CPU_PWR1_SPEC;
+impl crate::RegisterSpec for LP_CPU_PWR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_cpu_pwr1::R`](R) reader structure"]
+impl crate::Readable for LP_CPU_PWR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_cpu_pwr1::W`](W) writer structure"]
+impl crate::Writable for LP_CPU_PWR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_CPU_PWR1 to value 0"]
+impl crate::Resettable for LP_CPU_PWR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_int_clr.rs
+++ b/esp32c6-lp/src/pmu/lp_int_clr.rs
@@ -1,0 +1,121 @@
+#[doc = "Register `LP_INT_CLR` writer"]
+pub type W = crate::W<LP_INT_CLR_SPEC>;
+#[doc = "Field `LP_CPU_WAKEUP` writer - need_des"]
+pub type LP_CPU_WAKEUP_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `HP_SW_TRIGGER` writer - need_des"]
+pub type HP_SW_TRIGGER_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_INT_CLR_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_wakeup(&mut self) -> LP_CPU_WAKEUP_W<LP_INT_CLR_SPEC> {
+        LP_CPU_WAKEUP_W::new(self, 20)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_end(&mut self) -> MODEM_SWITCH_ACTIVE_END_W<LP_INT_CLR_SPEC> {
+        MODEM_SWITCH_ACTIVE_END_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_end(&mut self) -> SLEEP_SWITCH_ACTIVE_END_W<LP_INT_CLR_SPEC> {
+        SLEEP_SWITCH_ACTIVE_END_W::new(self, 22)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_end(&mut self) -> SLEEP_SWITCH_MODEM_END_W<LP_INT_CLR_SPEC> {
+        SLEEP_SWITCH_MODEM_END_W::new(self, 23)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_end(&mut self) -> MODEM_SWITCH_SLEEP_END_W<LP_INT_CLR_SPEC> {
+        MODEM_SWITCH_SLEEP_END_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_end(&mut self) -> ACTIVE_SWITCH_SLEEP_END_W<LP_INT_CLR_SPEC> {
+        ACTIVE_SWITCH_SLEEP_END_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_start(&mut self) -> MODEM_SWITCH_ACTIVE_START_W<LP_INT_CLR_SPEC> {
+        MODEM_SWITCH_ACTIVE_START_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_start(&mut self) -> SLEEP_SWITCH_ACTIVE_START_W<LP_INT_CLR_SPEC> {
+        SLEEP_SWITCH_ACTIVE_START_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_start(&mut self) -> SLEEP_SWITCH_MODEM_START_W<LP_INT_CLR_SPEC> {
+        SLEEP_SWITCH_MODEM_START_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_start(&mut self) -> MODEM_SWITCH_SLEEP_START_W<LP_INT_CLR_SPEC> {
+        MODEM_SWITCH_SLEEP_START_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_start(&mut self) -> ACTIVE_SWITCH_SLEEP_START_W<LP_INT_CLR_SPEC> {
+        ACTIVE_SWITCH_SLEEP_START_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sw_trigger(&mut self) -> HP_SW_TRIGGER_W<LP_INT_CLR_SPEC> {
+        HP_SW_TRIGGER_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_clr::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_INT_CLR_SPEC;
+impl crate::RegisterSpec for LP_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`lp_int_clr::W`](W) writer structure"]
+impl crate::Writable for LP_INT_CLR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0xfff0_0000;
+}
+#[doc = "`reset()` method sets LP_INT_CLR to value 0"]
+impl crate::Resettable for LP_INT_CLR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_int_ena.rs
+++ b/esp32c6-lp/src/pmu/lp_int_ena.rs
@@ -1,0 +1,266 @@
+#[doc = "Register `LP_INT_ENA` reader"]
+pub type R = crate::R<LP_INT_ENA_SPEC>;
+#[doc = "Register `LP_INT_ENA` writer"]
+pub type W = crate::W<LP_INT_ENA_SPEC>;
+#[doc = "Field `LP_CPU_WAKEUP` reader - need_des"]
+pub type LP_CPU_WAKEUP_R = crate::BitReader;
+#[doc = "Field `LP_CPU_WAKEUP` writer - need_des"]
+pub type LP_CPU_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SW_TRIGGER` reader - need_des"]
+pub type HP_SW_TRIGGER_R = crate::BitReader;
+#[doc = "Field `HP_SW_TRIGGER` writer - need_des"]
+pub type HP_SW_TRIGGER_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_wakeup(&self) -> LP_CPU_WAKEUP_R {
+        LP_CPU_WAKEUP_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_end(&self) -> MODEM_SWITCH_ACTIVE_END_R {
+        MODEM_SWITCH_ACTIVE_END_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_end(&self) -> SLEEP_SWITCH_ACTIVE_END_R {
+        SLEEP_SWITCH_ACTIVE_END_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_end(&self) -> SLEEP_SWITCH_MODEM_END_R {
+        SLEEP_SWITCH_MODEM_END_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_end(&self) -> MODEM_SWITCH_SLEEP_END_R {
+        MODEM_SWITCH_SLEEP_END_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_end(&self) -> ACTIVE_SWITCH_SLEEP_END_R {
+        ACTIVE_SWITCH_SLEEP_END_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_start(&self) -> MODEM_SWITCH_ACTIVE_START_R {
+        MODEM_SWITCH_ACTIVE_START_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_start(&self) -> SLEEP_SWITCH_ACTIVE_START_R {
+        SLEEP_SWITCH_ACTIVE_START_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_start(&self) -> SLEEP_SWITCH_MODEM_START_R {
+        SLEEP_SWITCH_MODEM_START_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_start(&self) -> MODEM_SWITCH_SLEEP_START_R {
+        MODEM_SWITCH_SLEEP_START_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_start(&self) -> ACTIVE_SWITCH_SLEEP_START_R {
+        ACTIVE_SWITCH_SLEEP_START_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sw_trigger(&self) -> HP_SW_TRIGGER_R {
+        HP_SW_TRIGGER_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_INT_ENA")
+            .field(
+                "lp_cpu_wakeup",
+                &format_args!("{}", self.lp_cpu_wakeup().bit()),
+            )
+            .field(
+                "modem_switch_active_end",
+                &format_args!("{}", self.modem_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_active_end",
+                &format_args!("{}", self.sleep_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_modem_end",
+                &format_args!("{}", self.sleep_switch_modem_end().bit()),
+            )
+            .field(
+                "modem_switch_sleep_end",
+                &format_args!("{}", self.modem_switch_sleep_end().bit()),
+            )
+            .field(
+                "active_switch_sleep_end",
+                &format_args!("{}", self.active_switch_sleep_end().bit()),
+            )
+            .field(
+                "modem_switch_active_start",
+                &format_args!("{}", self.modem_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_active_start",
+                &format_args!("{}", self.sleep_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_modem_start",
+                &format_args!("{}", self.sleep_switch_modem_start().bit()),
+            )
+            .field(
+                "modem_switch_sleep_start",
+                &format_args!("{}", self.modem_switch_sleep_start().bit()),
+            )
+            .field(
+                "active_switch_sleep_start",
+                &format_args!("{}", self.active_switch_sleep_start().bit()),
+            )
+            .field(
+                "hp_sw_trigger",
+                &format_args!("{}", self.hp_sw_trigger().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_INT_ENA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_wakeup(&mut self) -> LP_CPU_WAKEUP_W<LP_INT_ENA_SPEC> {
+        LP_CPU_WAKEUP_W::new(self, 20)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_end(&mut self) -> MODEM_SWITCH_ACTIVE_END_W<LP_INT_ENA_SPEC> {
+        MODEM_SWITCH_ACTIVE_END_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_end(&mut self) -> SLEEP_SWITCH_ACTIVE_END_W<LP_INT_ENA_SPEC> {
+        SLEEP_SWITCH_ACTIVE_END_W::new(self, 22)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_end(&mut self) -> SLEEP_SWITCH_MODEM_END_W<LP_INT_ENA_SPEC> {
+        SLEEP_SWITCH_MODEM_END_W::new(self, 23)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_end(&mut self) -> MODEM_SWITCH_SLEEP_END_W<LP_INT_ENA_SPEC> {
+        MODEM_SWITCH_SLEEP_END_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_end(&mut self) -> ACTIVE_SWITCH_SLEEP_END_W<LP_INT_ENA_SPEC> {
+        ACTIVE_SWITCH_SLEEP_END_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_start(&mut self) -> MODEM_SWITCH_ACTIVE_START_W<LP_INT_ENA_SPEC> {
+        MODEM_SWITCH_ACTIVE_START_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_start(&mut self) -> SLEEP_SWITCH_ACTIVE_START_W<LP_INT_ENA_SPEC> {
+        SLEEP_SWITCH_ACTIVE_START_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_start(&mut self) -> SLEEP_SWITCH_MODEM_START_W<LP_INT_ENA_SPEC> {
+        SLEEP_SWITCH_MODEM_START_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_start(&mut self) -> MODEM_SWITCH_SLEEP_START_W<LP_INT_ENA_SPEC> {
+        MODEM_SWITCH_SLEEP_START_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_start(&mut self) -> ACTIVE_SWITCH_SLEEP_START_W<LP_INT_ENA_SPEC> {
+        ACTIVE_SWITCH_SLEEP_START_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sw_trigger(&mut self) -> HP_SW_TRIGGER_W<LP_INT_ENA_SPEC> {
+        HP_SW_TRIGGER_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_ena::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_ena::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_INT_ENA_SPEC;
+impl crate::RegisterSpec for LP_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_int_ena::R`](R) reader structure"]
+impl crate::Readable for LP_INT_ENA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_int_ena::W`](W) writer structure"]
+impl crate::Writable for LP_INT_ENA_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_INT_ENA to value 0"]
+impl crate::Resettable for LP_INT_ENA_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_int_raw.rs
+++ b/esp32c6-lp/src/pmu/lp_int_raw.rs
@@ -1,0 +1,266 @@
+#[doc = "Register `LP_INT_RAW` reader"]
+pub type R = crate::R<LP_INT_RAW_SPEC>;
+#[doc = "Register `LP_INT_RAW` writer"]
+pub type W = crate::W<LP_INT_RAW_SPEC>;
+#[doc = "Field `LP_CPU_WAKEUP` reader - need_des"]
+pub type LP_CPU_WAKEUP_R = crate::BitReader;
+#[doc = "Field `LP_CPU_WAKEUP` writer - need_des"]
+pub type LP_CPU_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` writer - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` writer - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` writer - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` writer - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` writer - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `HP_SW_TRIGGER` reader - need_des"]
+pub type HP_SW_TRIGGER_R = crate::BitReader;
+#[doc = "Field `HP_SW_TRIGGER` writer - need_des"]
+pub type HP_SW_TRIGGER_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_wakeup(&self) -> LP_CPU_WAKEUP_R {
+        LP_CPU_WAKEUP_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_end(&self) -> MODEM_SWITCH_ACTIVE_END_R {
+        MODEM_SWITCH_ACTIVE_END_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_end(&self) -> SLEEP_SWITCH_ACTIVE_END_R {
+        SLEEP_SWITCH_ACTIVE_END_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_end(&self) -> SLEEP_SWITCH_MODEM_END_R {
+        SLEEP_SWITCH_MODEM_END_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_end(&self) -> MODEM_SWITCH_SLEEP_END_R {
+        MODEM_SWITCH_SLEEP_END_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_end(&self) -> ACTIVE_SWITCH_SLEEP_END_R {
+        ACTIVE_SWITCH_SLEEP_END_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_start(&self) -> MODEM_SWITCH_ACTIVE_START_R {
+        MODEM_SWITCH_ACTIVE_START_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_start(&self) -> SLEEP_SWITCH_ACTIVE_START_R {
+        SLEEP_SWITCH_ACTIVE_START_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_start(&self) -> SLEEP_SWITCH_MODEM_START_R {
+        SLEEP_SWITCH_MODEM_START_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_start(&self) -> MODEM_SWITCH_SLEEP_START_R {
+        MODEM_SWITCH_SLEEP_START_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_start(&self) -> ACTIVE_SWITCH_SLEEP_START_R {
+        ACTIVE_SWITCH_SLEEP_START_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sw_trigger(&self) -> HP_SW_TRIGGER_R {
+        HP_SW_TRIGGER_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_INT_RAW")
+            .field(
+                "lp_cpu_wakeup",
+                &format_args!("{}", self.lp_cpu_wakeup().bit()),
+            )
+            .field(
+                "modem_switch_active_end",
+                &format_args!("{}", self.modem_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_active_end",
+                &format_args!("{}", self.sleep_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_modem_end",
+                &format_args!("{}", self.sleep_switch_modem_end().bit()),
+            )
+            .field(
+                "modem_switch_sleep_end",
+                &format_args!("{}", self.modem_switch_sleep_end().bit()),
+            )
+            .field(
+                "active_switch_sleep_end",
+                &format_args!("{}", self.active_switch_sleep_end().bit()),
+            )
+            .field(
+                "modem_switch_active_start",
+                &format_args!("{}", self.modem_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_active_start",
+                &format_args!("{}", self.sleep_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_modem_start",
+                &format_args!("{}", self.sleep_switch_modem_start().bit()),
+            )
+            .field(
+                "modem_switch_sleep_start",
+                &format_args!("{}", self.modem_switch_sleep_start().bit()),
+            )
+            .field(
+                "active_switch_sleep_start",
+                &format_args!("{}", self.active_switch_sleep_start().bit()),
+            )
+            .field(
+                "hp_sw_trigger",
+                &format_args!("{}", self.hp_sw_trigger().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_INT_RAW_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_cpu_wakeup(&mut self) -> LP_CPU_WAKEUP_W<LP_INT_RAW_SPEC> {
+        LP_CPU_WAKEUP_W::new(self, 20)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_end(&mut self) -> MODEM_SWITCH_ACTIVE_END_W<LP_INT_RAW_SPEC> {
+        MODEM_SWITCH_ACTIVE_END_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_end(&mut self) -> SLEEP_SWITCH_ACTIVE_END_W<LP_INT_RAW_SPEC> {
+        SLEEP_SWITCH_ACTIVE_END_W::new(self, 22)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_end(&mut self) -> SLEEP_SWITCH_MODEM_END_W<LP_INT_RAW_SPEC> {
+        SLEEP_SWITCH_MODEM_END_W::new(self, 23)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_end(&mut self) -> MODEM_SWITCH_SLEEP_END_W<LP_INT_RAW_SPEC> {
+        MODEM_SWITCH_SLEEP_END_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_end(&mut self) -> ACTIVE_SWITCH_SLEEP_END_W<LP_INT_RAW_SPEC> {
+        ACTIVE_SWITCH_SLEEP_END_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_active_start(&mut self) -> MODEM_SWITCH_ACTIVE_START_W<LP_INT_RAW_SPEC> {
+        MODEM_SWITCH_ACTIVE_START_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_active_start(&mut self) -> SLEEP_SWITCH_ACTIVE_START_W<LP_INT_RAW_SPEC> {
+        SLEEP_SWITCH_ACTIVE_START_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_switch_modem_start(&mut self) -> SLEEP_SWITCH_MODEM_START_W<LP_INT_RAW_SPEC> {
+        SLEEP_SWITCH_MODEM_START_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_switch_sleep_start(&mut self) -> MODEM_SWITCH_SLEEP_START_W<LP_INT_RAW_SPEC> {
+        MODEM_SWITCH_SLEEP_START_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn active_switch_sleep_start(&mut self) -> ACTIVE_SWITCH_SLEEP_START_W<LP_INT_RAW_SPEC> {
+        ACTIVE_SWITCH_SLEEP_START_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_sw_trigger(&mut self) -> HP_SW_TRIGGER_W<LP_INT_RAW_SPEC> {
+        HP_SW_TRIGGER_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_raw::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_int_raw::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_INT_RAW_SPEC;
+impl crate::RegisterSpec for LP_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_int_raw::R`](R) reader structure"]
+impl crate::Readable for LP_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_int_raw::W`](W) writer structure"]
+impl crate::Writable for LP_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_INT_RAW to value 0"]
+impl crate::Resettable for LP_INT_RAW_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_int_st.rs
+++ b/esp32c6-lp/src/pmu/lp_int_st.rs
@@ -1,0 +1,160 @@
+#[doc = "Register `LP_INT_ST` reader"]
+pub type R = crate::R<LP_INT_ST_SPEC>;
+#[doc = "Field `LP_CPU_WAKEUP` reader - need_des"]
+pub type LP_CPU_WAKEUP_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_END` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_END` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_END_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_END` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_END` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_END` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_END_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_ACTIVE_START` reader - need_des"]
+pub type MODEM_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_ACTIVE_START` reader - need_des"]
+pub type SLEEP_SWITCH_ACTIVE_START_R = crate::BitReader;
+#[doc = "Field `SLEEP_SWITCH_MODEM_START` reader - need_des"]
+pub type SLEEP_SWITCH_MODEM_START_R = crate::BitReader;
+#[doc = "Field `MODEM_SWITCH_SLEEP_START` reader - need_des"]
+pub type MODEM_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `ACTIVE_SWITCH_SLEEP_START` reader - need_des"]
+pub type ACTIVE_SWITCH_SLEEP_START_R = crate::BitReader;
+#[doc = "Field `HP_SW_TRIGGER` reader - need_des"]
+pub type HP_SW_TRIGGER_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - need_des"]
+    #[inline(always)]
+    pub fn lp_cpu_wakeup(&self) -> LP_CPU_WAKEUP_R {
+        LP_CPU_WAKEUP_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_end(&self) -> MODEM_SWITCH_ACTIVE_END_R {
+        MODEM_SWITCH_ACTIVE_END_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_end(&self) -> SLEEP_SWITCH_ACTIVE_END_R {
+        SLEEP_SWITCH_ACTIVE_END_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_end(&self) -> SLEEP_SWITCH_MODEM_END_R {
+        SLEEP_SWITCH_MODEM_END_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_end(&self) -> MODEM_SWITCH_SLEEP_END_R {
+        MODEM_SWITCH_SLEEP_END_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_end(&self) -> ACTIVE_SWITCH_SLEEP_END_R {
+        ACTIVE_SWITCH_SLEEP_END_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_active_start(&self) -> MODEM_SWITCH_ACTIVE_START_R {
+        MODEM_SWITCH_ACTIVE_START_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_active_start(&self) -> SLEEP_SWITCH_ACTIVE_START_R {
+        SLEEP_SWITCH_ACTIVE_START_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn sleep_switch_modem_start(&self) -> SLEEP_SWITCH_MODEM_START_R {
+        SLEEP_SWITCH_MODEM_START_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn modem_switch_sleep_start(&self) -> MODEM_SWITCH_SLEEP_START_R {
+        MODEM_SWITCH_SLEEP_START_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn active_switch_sleep_start(&self) -> ACTIVE_SWITCH_SLEEP_START_R {
+        ACTIVE_SWITCH_SLEEP_START_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn hp_sw_trigger(&self) -> HP_SW_TRIGGER_R {
+        HP_SW_TRIGGER_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_INT_ST")
+            .field(
+                "lp_cpu_wakeup",
+                &format_args!("{}", self.lp_cpu_wakeup().bit()),
+            )
+            .field(
+                "modem_switch_active_end",
+                &format_args!("{}", self.modem_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_active_end",
+                &format_args!("{}", self.sleep_switch_active_end().bit()),
+            )
+            .field(
+                "sleep_switch_modem_end",
+                &format_args!("{}", self.sleep_switch_modem_end().bit()),
+            )
+            .field(
+                "modem_switch_sleep_end",
+                &format_args!("{}", self.modem_switch_sleep_end().bit()),
+            )
+            .field(
+                "active_switch_sleep_end",
+                &format_args!("{}", self.active_switch_sleep_end().bit()),
+            )
+            .field(
+                "modem_switch_active_start",
+                &format_args!("{}", self.modem_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_active_start",
+                &format_args!("{}", self.sleep_switch_active_start().bit()),
+            )
+            .field(
+                "sleep_switch_modem_start",
+                &format_args!("{}", self.sleep_switch_modem_start().bit()),
+            )
+            .field(
+                "modem_switch_sleep_start",
+                &format_args!("{}", self.modem_switch_sleep_start().bit()),
+            )
+            .field(
+                "active_switch_sleep_start",
+                &format_args!("{}", self.active_switch_sleep_start().bit()),
+            )
+            .field(
+                "hp_sw_trigger",
+                &format_args!("{}", self.hp_sw_trigger().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_INT_ST_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_int_st::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_INT_ST_SPEC;
+impl crate::RegisterSpec for LP_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_int_st::R`](R) reader structure"]
+impl crate::Readable for LP_INT_ST_SPEC {}
+#[doc = "`reset()` method sets LP_INT_ST to value 0"]
+impl crate::Resettable for LP_INT_ST_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_bias.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_bias.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `LP_SLEEP_BIAS` reader"]
+pub type R = crate::R<LP_SLEEP_BIAS_SPEC>;
+#[doc = "Register `LP_SLEEP_BIAS` writer"]
+pub type W = crate::W<LP_SLEEP_BIAS_SPEC>;
+#[doc = "Field `LP_SLEEP_XPD_BIAS` reader - need_des"]
+pub type LP_SLEEP_XPD_BIAS_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_XPD_BIAS` writer - need_des"]
+pub type LP_SLEEP_XPD_BIAS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_DBG_ATTEN` reader - need_des"]
+pub type LP_SLEEP_DBG_ATTEN_R = crate::FieldReader;
+#[doc = "Field `LP_SLEEP_DBG_ATTEN` writer - need_des"]
+pub type LP_SLEEP_DBG_ATTEN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `LP_SLEEP_PD_CUR` reader - need_des"]
+pub type LP_SLEEP_PD_CUR_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_PD_CUR` writer - need_des"]
+pub type LP_SLEEP_PD_CUR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLEEP` reader - need_des"]
+pub type SLEEP_R = crate::BitReader;
+#[doc = "Field `SLEEP` writer - need_des"]
+pub type SLEEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_xpd_bias(&self) -> LP_SLEEP_XPD_BIAS_R {
+        LP_SLEEP_XPD_BIAS_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_dbg_atten(&self) -> LP_SLEEP_DBG_ATTEN_R {
+        LP_SLEEP_DBG_ATTEN_R::new(((self.bits >> 26) & 0x0f) as u8)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_pd_cur(&self) -> LP_SLEEP_PD_CUR_R {
+        LP_SLEEP_PD_CUR_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn sleep(&self) -> SLEEP_R {
+        SLEEP_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_BIAS")
+            .field(
+                "lp_sleep_xpd_bias",
+                &format_args!("{}", self.lp_sleep_xpd_bias().bit()),
+            )
+            .field(
+                "lp_sleep_dbg_atten",
+                &format_args!("{}", self.lp_sleep_dbg_atten().bits()),
+            )
+            .field(
+                "lp_sleep_pd_cur",
+                &format_args!("{}", self.lp_sleep_pd_cur().bit()),
+            )
+            .field("sleep", &format_args!("{}", self.sleep().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_BIAS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 25 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_xpd_bias(&mut self) -> LP_SLEEP_XPD_BIAS_W<LP_SLEEP_BIAS_SPEC> {
+        LP_SLEEP_XPD_BIAS_W::new(self, 25)
+    }
+    #[doc = "Bits 26:29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_dbg_atten(&mut self) -> LP_SLEEP_DBG_ATTEN_W<LP_SLEEP_BIAS_SPEC> {
+        LP_SLEEP_DBG_ATTEN_W::new(self, 26)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_pd_cur(&mut self) -> LP_SLEEP_PD_CUR_W<LP_SLEEP_BIAS_SPEC> {
+        LP_SLEEP_PD_CUR_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep(&mut self) -> SLEEP_W<LP_SLEEP_BIAS_SPEC> {
+        SLEEP_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_bias::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_bias::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_BIAS_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_BIAS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_bias::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_BIAS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_bias::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_BIAS_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_BIAS to value 0"]
+impl crate::Resettable for LP_SLEEP_BIAS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_lp_bias_reserve.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_lp_bias_reserve.rs
@@ -1,0 +1,35 @@
+#[doc = "Register `LP_SLEEP_LP_BIAS_RESERVE` writer"]
+pub type W = crate::W<LP_SLEEP_LP_BIAS_RESERVE_SPEC>;
+#[doc = "Field `LP_SLEEP_LP_BIAS_RESERVE` writer - need_des"]
+pub type LP_SLEEP_LP_BIAS_RESERVE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_LP_BIAS_RESERVE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_bias_reserve(
+        &mut self,
+    ) -> LP_SLEEP_LP_BIAS_RESERVE_W<LP_SLEEP_LP_BIAS_RESERVE_SPEC> {
+        LP_SLEEP_LP_BIAS_RESERVE_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_bias_reserve::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_LP_BIAS_RESERVE_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_LP_BIAS_RESERVE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_lp_bias_reserve::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_LP_BIAS_RESERVE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_LP_BIAS_RESERVE to value 0"]
+impl crate::Resettable for LP_SLEEP_LP_BIAS_RESERVE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_lp_ck_power.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_lp_ck_power.rs
@@ -1,0 +1,114 @@
+#[doc = "Register `LP_SLEEP_LP_CK_POWER` reader"]
+pub type R = crate::R<LP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "Register `LP_SLEEP_LP_CK_POWER` writer"]
+pub type W = crate::W<LP_SLEEP_LP_CK_POWER_SPEC>;
+#[doc = "Field `LP_SLEEP_XPD_XTAL32K` reader - need_des"]
+pub type LP_SLEEP_XPD_XTAL32K_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_XPD_XTAL32K` writer - need_des"]
+pub type LP_SLEEP_XPD_XTAL32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_XPD_RC32K` reader - need_des"]
+pub type LP_SLEEP_XPD_RC32K_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_XPD_RC32K` writer - need_des"]
+pub type LP_SLEEP_XPD_RC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_XPD_FOSC_CLK` reader - need_des"]
+pub type LP_SLEEP_XPD_FOSC_CLK_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_XPD_FOSC_CLK` writer - need_des"]
+pub type LP_SLEEP_XPD_FOSC_CLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_PD_OSC_CLK` reader - need_des"]
+pub type LP_SLEEP_PD_OSC_CLK_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_PD_OSC_CLK` writer - need_des"]
+pub type LP_SLEEP_PD_OSC_CLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_xpd_xtal32k(&self) -> LP_SLEEP_XPD_XTAL32K_R {
+        LP_SLEEP_XPD_XTAL32K_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_xpd_rc32k(&self) -> LP_SLEEP_XPD_RC32K_R {
+        LP_SLEEP_XPD_RC32K_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_xpd_fosc_clk(&self) -> LP_SLEEP_XPD_FOSC_CLK_R {
+        LP_SLEEP_XPD_FOSC_CLK_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_pd_osc_clk(&self) -> LP_SLEEP_PD_OSC_CLK_R {
+        LP_SLEEP_PD_OSC_CLK_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_LP_CK_POWER")
+            .field(
+                "lp_sleep_xpd_xtal32k",
+                &format_args!("{}", self.lp_sleep_xpd_xtal32k().bit()),
+            )
+            .field(
+                "lp_sleep_xpd_rc32k",
+                &format_args!("{}", self.lp_sleep_xpd_rc32k().bit()),
+            )
+            .field(
+                "lp_sleep_xpd_fosc_clk",
+                &format_args!("{}", self.lp_sleep_xpd_fosc_clk().bit()),
+            )
+            .field(
+                "lp_sleep_pd_osc_clk",
+                &format_args!("{}", self.lp_sleep_pd_osc_clk().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_LP_CK_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_xpd_xtal32k(&mut self) -> LP_SLEEP_XPD_XTAL32K_W<LP_SLEEP_LP_CK_POWER_SPEC> {
+        LP_SLEEP_XPD_XTAL32K_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_xpd_rc32k(&mut self) -> LP_SLEEP_XPD_RC32K_W<LP_SLEEP_LP_CK_POWER_SPEC> {
+        LP_SLEEP_XPD_RC32K_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_xpd_fosc_clk(&mut self) -> LP_SLEEP_XPD_FOSC_CLK_W<LP_SLEEP_LP_CK_POWER_SPEC> {
+        LP_SLEEP_XPD_FOSC_CLK_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_pd_osc_clk(&mut self) -> LP_SLEEP_PD_OSC_CLK_W<LP_SLEEP_LP_CK_POWER_SPEC> {
+        LP_SLEEP_PD_OSC_CLK_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_ck_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_ck_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_LP_CK_POWER_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_LP_CK_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_lp_ck_power::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_LP_CK_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_lp_ck_power::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_LP_CK_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_LP_CK_POWER to value 0x4000_0000"]
+impl crate::Resettable for LP_SLEEP_LP_CK_POWER_SPEC {
+    const RESET_VALUE: u32 = 0x4000_0000;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_lp_dig_power.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_lp_dig_power.rs
@@ -1,0 +1,78 @@
+#[doc = "Register `LP_SLEEP_LP_DIG_POWER` reader"]
+pub type R = crate::R<LP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "Register `LP_SLEEP_LP_DIG_POWER` writer"]
+pub type W = crate::W<LP_SLEEP_LP_DIG_POWER_SPEC>;
+#[doc = "Field `LP_SLEEP_LP_MEM_DSLP` reader - need_des"]
+pub type LP_SLEEP_LP_MEM_DSLP_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_LP_MEM_DSLP` writer - need_des"]
+pub type LP_SLEEP_LP_MEM_DSLP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_PD_LP_PERI_PD_EN` reader - need_des"]
+pub type LP_SLEEP_PD_LP_PERI_PD_EN_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_PD_LP_PERI_PD_EN` writer - need_des"]
+pub type LP_SLEEP_PD_LP_PERI_PD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_mem_dslp(&self) -> LP_SLEEP_LP_MEM_DSLP_R {
+        LP_SLEEP_LP_MEM_DSLP_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_pd_lp_peri_pd_en(&self) -> LP_SLEEP_PD_LP_PERI_PD_EN_R {
+        LP_SLEEP_PD_LP_PERI_PD_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_LP_DIG_POWER")
+            .field(
+                "lp_sleep_lp_mem_dslp",
+                &format_args!("{}", self.lp_sleep_lp_mem_dslp().bit()),
+            )
+            .field(
+                "lp_sleep_pd_lp_peri_pd_en",
+                &format_args!("{}", self.lp_sleep_pd_lp_peri_pd_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_LP_DIG_POWER_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_mem_dslp(&mut self) -> LP_SLEEP_LP_MEM_DSLP_W<LP_SLEEP_LP_DIG_POWER_SPEC> {
+        LP_SLEEP_LP_MEM_DSLP_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_pd_lp_peri_pd_en(
+        &mut self,
+    ) -> LP_SLEEP_PD_LP_PERI_PD_EN_W<LP_SLEEP_LP_DIG_POWER_SPEC> {
+        LP_SLEEP_PD_LP_PERI_PD_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_dig_power::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_dig_power::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_LP_DIG_POWER_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_LP_DIG_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_lp_dig_power::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_LP_DIG_POWER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_lp_dig_power::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_LP_DIG_POWER_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_LP_DIG_POWER to value 0"]
+impl crate::Resettable for LP_SLEEP_LP_DIG_POWER_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_lp_regulator0.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_lp_regulator0.rs
@@ -1,0 +1,122 @@
+#[doc = "Register `LP_SLEEP_LP_REGULATOR0` reader"]
+pub type R = crate::R<LP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "Register `LP_SLEEP_LP_REGULATOR0` writer"]
+pub type W = crate::W<LP_SLEEP_LP_REGULATOR0_SPEC>;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_SLP_XPD` reader - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_SLP_XPD_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_SLP_XPD` writer - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_SLP_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_XPD` reader - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_XPD_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_XPD` writer - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_XPD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_SLP_DBIAS` reader - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_SLP_DBIAS_R = crate::FieldReader;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_SLP_DBIAS` writer - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_SLP_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_DBIAS` reader - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_DBIAS_R = crate::FieldReader;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_DBIAS` writer - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_DBIAS_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_regulator_slp_xpd(&self) -> LP_SLEEP_LP_REGULATOR_SLP_XPD_R {
+        LP_SLEEP_LP_REGULATOR_SLP_XPD_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_regulator_xpd(&self) -> LP_SLEEP_LP_REGULATOR_XPD_R {
+        LP_SLEEP_LP_REGULATOR_XPD_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_regulator_slp_dbias(&self) -> LP_SLEEP_LP_REGULATOR_SLP_DBIAS_R {
+        LP_SLEEP_LP_REGULATOR_SLP_DBIAS_R::new(((self.bits >> 23) & 0x0f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_regulator_dbias(&self) -> LP_SLEEP_LP_REGULATOR_DBIAS_R {
+        LP_SLEEP_LP_REGULATOR_DBIAS_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_LP_REGULATOR0")
+            .field(
+                "lp_sleep_lp_regulator_slp_xpd",
+                &format_args!("{}", self.lp_sleep_lp_regulator_slp_xpd().bit()),
+            )
+            .field(
+                "lp_sleep_lp_regulator_xpd",
+                &format_args!("{}", self.lp_sleep_lp_regulator_xpd().bit()),
+            )
+            .field(
+                "lp_sleep_lp_regulator_slp_dbias",
+                &format_args!("{}", self.lp_sleep_lp_regulator_slp_dbias().bits()),
+            )
+            .field(
+                "lp_sleep_lp_regulator_dbias",
+                &format_args!("{}", self.lp_sleep_lp_regulator_dbias().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_LP_REGULATOR0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_regulator_slp_xpd(
+        &mut self,
+    ) -> LP_SLEEP_LP_REGULATOR_SLP_XPD_W<LP_SLEEP_LP_REGULATOR0_SPEC> {
+        LP_SLEEP_LP_REGULATOR_SLP_XPD_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_regulator_xpd(
+        &mut self,
+    ) -> LP_SLEEP_LP_REGULATOR_XPD_W<LP_SLEEP_LP_REGULATOR0_SPEC> {
+        LP_SLEEP_LP_REGULATOR_XPD_W::new(self, 22)
+    }
+    #[doc = "Bits 23:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_regulator_slp_dbias(
+        &mut self,
+    ) -> LP_SLEEP_LP_REGULATOR_SLP_DBIAS_W<LP_SLEEP_LP_REGULATOR0_SPEC> {
+        LP_SLEEP_LP_REGULATOR_SLP_DBIAS_W::new(self, 23)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_regulator_dbias(
+        &mut self,
+    ) -> LP_SLEEP_LP_REGULATOR_DBIAS_W<LP_SLEEP_LP_REGULATOR0_SPEC> {
+        LP_SLEEP_LP_REGULATOR_DBIAS_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_regulator0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_regulator0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_LP_REGULATOR0_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_LP_REGULATOR0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_lp_regulator0::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_LP_REGULATOR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_lp_regulator0::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_LP_REGULATOR0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_LP_REGULATOR0 to value 0xc660_0000"]
+impl crate::Resettable for LP_SLEEP_LP_REGULATOR0_SPEC {
+    const RESET_VALUE: u32 = 0xc660_0000;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_lp_regulator1.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_lp_regulator1.rs
@@ -1,0 +1,59 @@
+#[doc = "Register `LP_SLEEP_LP_REGULATOR1` reader"]
+pub type R = crate::R<LP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "Register `LP_SLEEP_LP_REGULATOR1` writer"]
+pub type W = crate::W<LP_SLEEP_LP_REGULATOR1_SPEC>;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_DRV_B` reader - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_DRV_B_R = crate::FieldReader;
+#[doc = "Field `LP_SLEEP_LP_REGULATOR_DRV_B` writer - need_des"]
+pub type LP_SLEEP_LP_REGULATOR_DRV_B_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_lp_regulator_drv_b(&self) -> LP_SLEEP_LP_REGULATOR_DRV_B_R {
+        LP_SLEEP_LP_REGULATOR_DRV_B_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_LP_REGULATOR1")
+            .field(
+                "lp_sleep_lp_regulator_drv_b",
+                &format_args!("{}", self.lp_sleep_lp_regulator_drv_b().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_LP_REGULATOR1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_lp_regulator_drv_b(
+        &mut self,
+    ) -> LP_SLEEP_LP_REGULATOR_DRV_B_W<LP_SLEEP_LP_REGULATOR1_SPEC> {
+        LP_SLEEP_LP_REGULATOR_DRV_B_W::new(self, 28)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_lp_regulator1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_lp_regulator1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_LP_REGULATOR1_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_LP_REGULATOR1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_lp_regulator1::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_LP_REGULATOR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_lp_regulator1::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_LP_REGULATOR1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_LP_REGULATOR1 to value 0"]
+impl crate::Resettable for LP_SLEEP_LP_REGULATOR1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/lp_sleep_xtal.rs
+++ b/esp32c6-lp/src/pmu/lp_sleep_xtal.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `LP_SLEEP_XTAL` reader"]
+pub type R = crate::R<LP_SLEEP_XTAL_SPEC>;
+#[doc = "Register `LP_SLEEP_XTAL` writer"]
+pub type W = crate::W<LP_SLEEP_XTAL_SPEC>;
+#[doc = "Field `LP_SLEEP_XPD_XTAL` reader - need_des"]
+pub type LP_SLEEP_XPD_XTAL_R = crate::BitReader;
+#[doc = "Field `LP_SLEEP_XPD_XTAL` writer - need_des"]
+pub type LP_SLEEP_XPD_XTAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn lp_sleep_xpd_xtal(&self) -> LP_SLEEP_XPD_XTAL_R {
+        LP_SLEEP_XPD_XTAL_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_SLEEP_XTAL")
+            .field(
+                "lp_sleep_xpd_xtal",
+                &format_args!("{}", self.lp_sleep_xpd_xtal().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<LP_SLEEP_XTAL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_sleep_xpd_xtal(&mut self) -> LP_SLEEP_XPD_XTAL_W<LP_SLEEP_XTAL_SPEC> {
+        LP_SLEEP_XPD_XTAL_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_sleep_xtal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_sleep_xtal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_SLEEP_XTAL_SPEC;
+impl crate::RegisterSpec for LP_SLEEP_XTAL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_sleep_xtal::R`](R) reader structure"]
+impl crate::Readable for LP_SLEEP_XTAL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_sleep_xtal::W`](W) writer structure"]
+impl crate::Writable for LP_SLEEP_XTAL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets LP_SLEEP_XTAL to value 0x8000_0000"]
+impl crate::Resettable for LP_SLEEP_XTAL_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/main_state.rs
+++ b/esp32c6-lp/src/pmu/main_state.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `MAIN_STATE` reader"]
+pub type R = crate::R<MAIN_STATE_SPEC>;
+#[doc = "Field `MAIN_LAST_ST_STATE` reader - need_des"]
+pub type MAIN_LAST_ST_STATE_R = crate::FieldReader;
+#[doc = "Field `MAIN_TAR_ST_STATE` reader - need_des"]
+pub type MAIN_TAR_ST_STATE_R = crate::FieldReader;
+#[doc = "Field `MAIN_CUR_ST_STATE` reader - need_des"]
+pub type MAIN_CUR_ST_STATE_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 11:17 - need_des"]
+    #[inline(always)]
+    pub fn main_last_st_state(&self) -> MAIN_LAST_ST_STATE_R {
+        MAIN_LAST_ST_STATE_R::new(((self.bits >> 11) & 0x7f) as u8)
+    }
+    #[doc = "Bits 18:24 - need_des"]
+    #[inline(always)]
+    pub fn main_tar_st_state(&self) -> MAIN_TAR_ST_STATE_R {
+        MAIN_TAR_ST_STATE_R::new(((self.bits >> 18) & 0x7f) as u8)
+    }
+    #[doc = "Bits 25:31 - need_des"]
+    #[inline(always)]
+    pub fn main_cur_st_state(&self) -> MAIN_CUR_ST_STATE_R {
+        MAIN_CUR_ST_STATE_R::new(((self.bits >> 25) & 0x7f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MAIN_STATE")
+            .field(
+                "main_last_st_state",
+                &format_args!("{}", self.main_last_st_state().bits()),
+            )
+            .field(
+                "main_tar_st_state",
+                &format_args!("{}", self.main_tar_st_state().bits()),
+            )
+            .field(
+                "main_cur_st_state",
+                &format_args!("{}", self.main_cur_st_state().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<MAIN_STATE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`main_state::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MAIN_STATE_SPEC;
+impl crate::RegisterSpec for MAIN_STATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`main_state::R`](R) reader structure"]
+impl crate::Readable for MAIN_STATE_SPEC {}
+#[doc = "`reset()` method sets MAIN_STATE to value 0x0810_0800"]
+impl crate::Resettable for MAIN_STATE_SPEC {
+    const RESET_VALUE: u32 = 0x0810_0800;
+}

--- a/esp32c6-lp/src/pmu/por_status.rs
+++ b/esp32c6-lp/src/pmu/por_status.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `POR_STATUS` reader"]
+pub type R = crate::R<POR_STATUS_SPEC>;
+#[doc = "Field `POR_DONE` reader - need_des"]
+pub type POR_DONE_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn por_done(&self) -> POR_DONE_R {
+        POR_DONE_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POR_STATUS")
+            .field("por_done", &format_args!("{}", self.por_done().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POR_STATUS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`por_status::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POR_STATUS_SPEC;
+impl crate::RegisterSpec for POR_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`por_status::R`](R) reader structure"]
+impl crate::Readable for POR_STATUS_SPEC {}
+#[doc = "`reset()` method sets POR_STATUS to value 0x8000_0000"]
+impl crate::Resettable for POR_STATUS_SPEC {
+    const RESET_VALUE: u32 = 0x8000_0000;
+}

--- a/esp32c6-lp/src/pmu/power_ck_wait_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_ck_wait_cntl.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `POWER_CK_WAIT_CNTL` reader"]
+pub type R = crate::R<POWER_CK_WAIT_CNTL_SPEC>;
+#[doc = "Register `POWER_CK_WAIT_CNTL` writer"]
+pub type W = crate::W<POWER_CK_WAIT_CNTL_SPEC>;
+#[doc = "Field `WAIT_XTL_STABLE` reader - need_des"]
+pub type WAIT_XTL_STABLE_R = crate::FieldReader<u16>;
+#[doc = "Field `WAIT_XTL_STABLE` writer - need_des"]
+pub type WAIT_XTL_STABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `WAIT_PLL_STABLE` reader - need_des"]
+pub type WAIT_PLL_STABLE_R = crate::FieldReader<u16>;
+#[doc = "Field `WAIT_PLL_STABLE` writer - need_des"]
+pub type WAIT_PLL_STABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - need_des"]
+    #[inline(always)]
+    pub fn wait_xtl_stable(&self) -> WAIT_XTL_STABLE_R {
+        WAIT_XTL_STABLE_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - need_des"]
+    #[inline(always)]
+    pub fn wait_pll_stable(&self) -> WAIT_PLL_STABLE_R {
+        WAIT_PLL_STABLE_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_CK_WAIT_CNTL")
+            .field(
+                "wait_xtl_stable",
+                &format_args!("{}", self.wait_xtl_stable().bits()),
+            )
+            .field(
+                "wait_pll_stable",
+                &format_args!("{}", self.wait_pll_stable().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_CK_WAIT_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn wait_xtl_stable(&mut self) -> WAIT_XTL_STABLE_W<POWER_CK_WAIT_CNTL_SPEC> {
+        WAIT_XTL_STABLE_W::new(self, 0)
+    }
+    #[doc = "Bits 16:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn wait_pll_stable(&mut self) -> WAIT_PLL_STABLE_W<POWER_CK_WAIT_CNTL_SPEC> {
+        WAIT_PLL_STABLE_W::new(self, 16)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_ck_wait_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_ck_wait_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_CK_WAIT_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_CK_WAIT_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_ck_wait_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_CK_WAIT_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_ck_wait_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_CK_WAIT_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_CK_WAIT_CNTL to value 0x0100_0100"]
+impl crate::Resettable for POWER_CK_WAIT_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x0100_0100;
+}

--- a/esp32c6-lp/src/pmu/power_hp_pad.rs
+++ b/esp32c6-lp/src/pmu/power_hp_pad.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `POWER_HP_PAD` reader"]
+pub type R = crate::R<POWER_HP_PAD_SPEC>;
+#[doc = "Register `POWER_HP_PAD` writer"]
+pub type W = crate::W<POWER_HP_PAD_SPEC>;
+#[doc = "Field `FORCE_HP_PAD_NO_ISO_ALL` reader - need_des"]
+pub type FORCE_HP_PAD_NO_ISO_ALL_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_PAD_NO_ISO_ALL` writer - need_des"]
+pub type FORCE_HP_PAD_NO_ISO_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_PAD_ISO_ALL` reader - need_des"]
+pub type FORCE_HP_PAD_ISO_ALL_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_PAD_ISO_ALL` writer - need_des"]
+pub type FORCE_HP_PAD_ISO_ALL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_pad_no_iso_all(&self) -> FORCE_HP_PAD_NO_ISO_ALL_R {
+        FORCE_HP_PAD_NO_ISO_ALL_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_pad_iso_all(&self) -> FORCE_HP_PAD_ISO_ALL_R {
+        FORCE_HP_PAD_ISO_ALL_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_HP_PAD")
+            .field(
+                "force_hp_pad_no_iso_all",
+                &format_args!("{}", self.force_hp_pad_no_iso_all().bit()),
+            )
+            .field(
+                "force_hp_pad_iso_all",
+                &format_args!("{}", self.force_hp_pad_iso_all().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_HP_PAD_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_pad_no_iso_all(&mut self) -> FORCE_HP_PAD_NO_ISO_ALL_W<POWER_HP_PAD_SPEC> {
+        FORCE_HP_PAD_NO_ISO_ALL_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_pad_iso_all(&mut self) -> FORCE_HP_PAD_ISO_ALL_W<POWER_HP_PAD_SPEC> {
+        FORCE_HP_PAD_ISO_ALL_W::new(self, 1)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_hp_pad::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_hp_pad::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_HP_PAD_SPEC;
+impl crate::RegisterSpec for POWER_HP_PAD_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_hp_pad::R`](R) reader structure"]
+impl crate::Readable for POWER_HP_PAD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_hp_pad::W`](W) writer structure"]
+impl crate::Writable for POWER_HP_PAD_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_HP_PAD to value 0"]
+impl crate::Resettable for POWER_HP_PAD_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/power_pd_hpaon_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_hpaon_cntl.rs
@@ -1,0 +1,190 @@
+#[doc = "Register `POWER_PD_HPAON_CNTL` reader"]
+pub type R = crate::R<POWER_PD_HPAON_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_HPAON_CNTL` writer"]
+pub type W = crate::W<POWER_PD_HPAON_CNTL_SPEC>;
+#[doc = "Field `FORCE_HP_AON_RESET` reader - need_des"]
+pub type FORCE_HP_AON_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_RESET` writer - need_des"]
+pub type FORCE_HP_AON_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_AON_ISO` reader - need_des"]
+pub type FORCE_HP_AON_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_ISO` writer - need_des"]
+pub type FORCE_HP_AON_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_AON_PU` reader - need_des"]
+pub type FORCE_HP_AON_PU_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_PU` writer - need_des"]
+pub type FORCE_HP_AON_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_AON_NO_RESET` reader - need_des"]
+pub type FORCE_HP_AON_NO_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_NO_RESET` writer - need_des"]
+pub type FORCE_HP_AON_NO_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_AON_NO_ISO` reader - need_des"]
+pub type FORCE_HP_AON_NO_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_NO_ISO` writer - need_des"]
+pub type FORCE_HP_AON_NO_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_AON_PD` reader - need_des"]
+pub type FORCE_HP_AON_PD_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_AON_PD` writer - need_des"]
+pub type FORCE_HP_AON_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PD_HP_AON_MASK` reader - need_des"]
+pub type PD_HP_AON_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_AON_MASK` writer - need_des"]
+pub type PD_HP_AON_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_AON_PD_MASK` reader - need_des"]
+pub type PD_HP_AON_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_AON_PD_MASK` writer - need_des"]
+pub type PD_HP_AON_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_reset(&self) -> FORCE_HP_AON_RESET_R {
+        FORCE_HP_AON_RESET_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_iso(&self) -> FORCE_HP_AON_ISO_R {
+        FORCE_HP_AON_ISO_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_pu(&self) -> FORCE_HP_AON_PU_R {
+        FORCE_HP_AON_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_no_reset(&self) -> FORCE_HP_AON_NO_RESET_R {
+        FORCE_HP_AON_NO_RESET_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_no_iso(&self) -> FORCE_HP_AON_NO_ISO_R {
+        FORCE_HP_AON_NO_ISO_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_aon_pd(&self) -> FORCE_HP_AON_PD_R {
+        FORCE_HP_AON_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_aon_mask(&self) -> PD_HP_AON_MASK_R {
+        PD_HP_AON_MASK_R::new(((self.bits >> 6) & 0x1f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_aon_pd_mask(&self) -> PD_HP_AON_PD_MASK_R {
+        PD_HP_AON_PD_MASK_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_HPAON_CNTL")
+            .field(
+                "force_hp_aon_reset",
+                &format_args!("{}", self.force_hp_aon_reset().bit()),
+            )
+            .field(
+                "force_hp_aon_iso",
+                &format_args!("{}", self.force_hp_aon_iso().bit()),
+            )
+            .field(
+                "force_hp_aon_pu",
+                &format_args!("{}", self.force_hp_aon_pu().bit()),
+            )
+            .field(
+                "force_hp_aon_no_reset",
+                &format_args!("{}", self.force_hp_aon_no_reset().bit()),
+            )
+            .field(
+                "force_hp_aon_no_iso",
+                &format_args!("{}", self.force_hp_aon_no_iso().bit()),
+            )
+            .field(
+                "force_hp_aon_pd",
+                &format_args!("{}", self.force_hp_aon_pd().bit()),
+            )
+            .field(
+                "pd_hp_aon_mask",
+                &format_args!("{}", self.pd_hp_aon_mask().bits()),
+            )
+            .field(
+                "pd_hp_aon_pd_mask",
+                &format_args!("{}", self.pd_hp_aon_pd_mask().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_HPAON_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_reset(&mut self) -> FORCE_HP_AON_RESET_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_RESET_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_iso(&mut self) -> FORCE_HP_AON_ISO_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_ISO_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_pu(&mut self) -> FORCE_HP_AON_PU_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_PU_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_no_reset(&mut self) -> FORCE_HP_AON_NO_RESET_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_NO_RESET_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_no_iso(&mut self) -> FORCE_HP_AON_NO_ISO_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_NO_ISO_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_aon_pd(&mut self) -> FORCE_HP_AON_PD_W<POWER_PD_HPAON_CNTL_SPEC> {
+        FORCE_HP_AON_PD_W::new(self, 5)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_aon_mask(&mut self) -> PD_HP_AON_MASK_W<POWER_PD_HPAON_CNTL_SPEC> {
+        PD_HP_AON_MASK_W::new(self, 6)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_aon_pd_mask(&mut self) -> PD_HP_AON_PD_MASK_W<POWER_PD_HPAON_CNTL_SPEC> {
+        PD_HP_AON_PD_MASK_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpaon_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpaon_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_HPAON_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_HPAON_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_hpaon_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_HPAON_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_hpaon_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_HPAON_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_HPAON_CNTL to value 0x1c"]
+impl crate::Resettable for POWER_PD_HPAON_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x1c;
+}

--- a/esp32c6-lp/src/pmu/power_pd_hpcpu_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_hpcpu_cntl.rs
@@ -1,0 +1,190 @@
+#[doc = "Register `POWER_PD_HPCPU_CNTL` reader"]
+pub type R = crate::R<POWER_PD_HPCPU_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_HPCPU_CNTL` writer"]
+pub type W = crate::W<POWER_PD_HPCPU_CNTL_SPEC>;
+#[doc = "Field `FORCE_HP_CPU_RESET` reader - need_des"]
+pub type FORCE_HP_CPU_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_RESET` writer - need_des"]
+pub type FORCE_HP_CPU_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_CPU_ISO` reader - need_des"]
+pub type FORCE_HP_CPU_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_ISO` writer - need_des"]
+pub type FORCE_HP_CPU_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_CPU_PU` reader - need_des"]
+pub type FORCE_HP_CPU_PU_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_PU` writer - need_des"]
+pub type FORCE_HP_CPU_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_CPU_NO_RESET` reader - need_des"]
+pub type FORCE_HP_CPU_NO_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_NO_RESET` writer - need_des"]
+pub type FORCE_HP_CPU_NO_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_CPU_NO_ISO` reader - need_des"]
+pub type FORCE_HP_CPU_NO_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_NO_ISO` writer - need_des"]
+pub type FORCE_HP_CPU_NO_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_CPU_PD` reader - need_des"]
+pub type FORCE_HP_CPU_PD_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_CPU_PD` writer - need_des"]
+pub type FORCE_HP_CPU_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PD_HP_CPU_MASK` reader - need_des"]
+pub type PD_HP_CPU_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_CPU_MASK` writer - need_des"]
+pub type PD_HP_CPU_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_CPU_PD_MASK` reader - need_des"]
+pub type PD_HP_CPU_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_CPU_PD_MASK` writer - need_des"]
+pub type PD_HP_CPU_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_reset(&self) -> FORCE_HP_CPU_RESET_R {
+        FORCE_HP_CPU_RESET_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_iso(&self) -> FORCE_HP_CPU_ISO_R {
+        FORCE_HP_CPU_ISO_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_pu(&self) -> FORCE_HP_CPU_PU_R {
+        FORCE_HP_CPU_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_no_reset(&self) -> FORCE_HP_CPU_NO_RESET_R {
+        FORCE_HP_CPU_NO_RESET_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_no_iso(&self) -> FORCE_HP_CPU_NO_ISO_R {
+        FORCE_HP_CPU_NO_ISO_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_cpu_pd(&self) -> FORCE_HP_CPU_PD_R {
+        FORCE_HP_CPU_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_cpu_mask(&self) -> PD_HP_CPU_MASK_R {
+        PD_HP_CPU_MASK_R::new(((self.bits >> 6) & 0x1f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_cpu_pd_mask(&self) -> PD_HP_CPU_PD_MASK_R {
+        PD_HP_CPU_PD_MASK_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_HPCPU_CNTL")
+            .field(
+                "force_hp_cpu_reset",
+                &format_args!("{}", self.force_hp_cpu_reset().bit()),
+            )
+            .field(
+                "force_hp_cpu_iso",
+                &format_args!("{}", self.force_hp_cpu_iso().bit()),
+            )
+            .field(
+                "force_hp_cpu_pu",
+                &format_args!("{}", self.force_hp_cpu_pu().bit()),
+            )
+            .field(
+                "force_hp_cpu_no_reset",
+                &format_args!("{}", self.force_hp_cpu_no_reset().bit()),
+            )
+            .field(
+                "force_hp_cpu_no_iso",
+                &format_args!("{}", self.force_hp_cpu_no_iso().bit()),
+            )
+            .field(
+                "force_hp_cpu_pd",
+                &format_args!("{}", self.force_hp_cpu_pd().bit()),
+            )
+            .field(
+                "pd_hp_cpu_mask",
+                &format_args!("{}", self.pd_hp_cpu_mask().bits()),
+            )
+            .field(
+                "pd_hp_cpu_pd_mask",
+                &format_args!("{}", self.pd_hp_cpu_pd_mask().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_HPCPU_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_reset(&mut self) -> FORCE_HP_CPU_RESET_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_RESET_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_iso(&mut self) -> FORCE_HP_CPU_ISO_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_ISO_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_pu(&mut self) -> FORCE_HP_CPU_PU_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_PU_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_no_reset(&mut self) -> FORCE_HP_CPU_NO_RESET_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_NO_RESET_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_no_iso(&mut self) -> FORCE_HP_CPU_NO_ISO_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_NO_ISO_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_cpu_pd(&mut self) -> FORCE_HP_CPU_PD_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        FORCE_HP_CPU_PD_W::new(self, 5)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_cpu_mask(&mut self) -> PD_HP_CPU_MASK_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        PD_HP_CPU_MASK_W::new(self, 6)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_cpu_pd_mask(&mut self) -> PD_HP_CPU_PD_MASK_W<POWER_PD_HPCPU_CNTL_SPEC> {
+        PD_HP_CPU_PD_MASK_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpcpu_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpcpu_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_HPCPU_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_HPCPU_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_hpcpu_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_HPCPU_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_hpcpu_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_HPCPU_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_HPCPU_CNTL to value 0x1c"]
+impl crate::Resettable for POWER_PD_HPCPU_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x1c;
+}

--- a/esp32c6-lp/src/pmu/power_pd_hpperi_reserve.rs
+++ b/esp32c6-lp/src/pmu/power_pd_hpperi_reserve.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `POWER_PD_HPPERI_RESERVE` writer"]
+pub type W = crate::W<POWER_PD_HPPERI_RESERVE_SPEC>;
+#[doc = "Field `HP_PERI_RESERVE` writer - need_des"]
+pub type HP_PERI_RESERVE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_HPPERI_RESERVE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_peri_reserve(&mut self) -> HP_PERI_RESERVE_W<POWER_PD_HPPERI_RESERVE_SPEC> {
+        HP_PERI_RESERVE_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpperi_reserve::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_HPPERI_RESERVE_SPEC;
+impl crate::RegisterSpec for POWER_PD_HPPERI_RESERVE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`power_pd_hpperi_reserve::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_HPPERI_RESERVE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_HPPERI_RESERVE to value 0"]
+impl crate::Resettable for POWER_PD_HPPERI_RESERVE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/power_pd_hpwifi_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_hpwifi_cntl.rs
@@ -1,0 +1,192 @@
+#[doc = "Register `POWER_PD_HPWIFI_CNTL` reader"]
+pub type R = crate::R<POWER_PD_HPWIFI_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_HPWIFI_CNTL` writer"]
+pub type W = crate::W<POWER_PD_HPWIFI_CNTL_SPEC>;
+#[doc = "Field `FORCE_HP_WIFI_RESET` reader - need_des"]
+pub type FORCE_HP_WIFI_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_RESET` writer - need_des"]
+pub type FORCE_HP_WIFI_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_WIFI_ISO` reader - need_des"]
+pub type FORCE_HP_WIFI_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_ISO` writer - need_des"]
+pub type FORCE_HP_WIFI_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_WIFI_PU` reader - need_des"]
+pub type FORCE_HP_WIFI_PU_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_PU` writer - need_des"]
+pub type FORCE_HP_WIFI_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_WIFI_NO_RESET` reader - need_des"]
+pub type FORCE_HP_WIFI_NO_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_NO_RESET` writer - need_des"]
+pub type FORCE_HP_WIFI_NO_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_WIFI_NO_ISO` reader - need_des"]
+pub type FORCE_HP_WIFI_NO_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_NO_ISO` writer - need_des"]
+pub type FORCE_HP_WIFI_NO_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_HP_WIFI_PD` reader - need_des"]
+pub type FORCE_HP_WIFI_PD_R = crate::BitReader;
+#[doc = "Field `FORCE_HP_WIFI_PD` writer - need_des"]
+pub type FORCE_HP_WIFI_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PD_HP_WIFI_MASK` reader - need_des"]
+pub type PD_HP_WIFI_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_WIFI_MASK` writer - need_des"]
+pub type PD_HP_WIFI_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_WIFI_PD_MASK` reader - need_des"]
+pub type PD_HP_WIFI_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_WIFI_PD_MASK` writer - need_des"]
+pub type PD_HP_WIFI_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_reset(&self) -> FORCE_HP_WIFI_RESET_R {
+        FORCE_HP_WIFI_RESET_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_iso(&self) -> FORCE_HP_WIFI_ISO_R {
+        FORCE_HP_WIFI_ISO_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_pu(&self) -> FORCE_HP_WIFI_PU_R {
+        FORCE_HP_WIFI_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_no_reset(&self) -> FORCE_HP_WIFI_NO_RESET_R {
+        FORCE_HP_WIFI_NO_RESET_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_no_iso(&self) -> FORCE_HP_WIFI_NO_ISO_R {
+        FORCE_HP_WIFI_NO_ISO_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_wifi_pd(&self) -> FORCE_HP_WIFI_PD_R {
+        FORCE_HP_WIFI_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_wifi_mask(&self) -> PD_HP_WIFI_MASK_R {
+        PD_HP_WIFI_MASK_R::new(((self.bits >> 6) & 0x1f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_wifi_pd_mask(&self) -> PD_HP_WIFI_PD_MASK_R {
+        PD_HP_WIFI_PD_MASK_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_HPWIFI_CNTL")
+            .field(
+                "force_hp_wifi_reset",
+                &format_args!("{}", self.force_hp_wifi_reset().bit()),
+            )
+            .field(
+                "force_hp_wifi_iso",
+                &format_args!("{}", self.force_hp_wifi_iso().bit()),
+            )
+            .field(
+                "force_hp_wifi_pu",
+                &format_args!("{}", self.force_hp_wifi_pu().bit()),
+            )
+            .field(
+                "force_hp_wifi_no_reset",
+                &format_args!("{}", self.force_hp_wifi_no_reset().bit()),
+            )
+            .field(
+                "force_hp_wifi_no_iso",
+                &format_args!("{}", self.force_hp_wifi_no_iso().bit()),
+            )
+            .field(
+                "force_hp_wifi_pd",
+                &format_args!("{}", self.force_hp_wifi_pd().bit()),
+            )
+            .field(
+                "pd_hp_wifi_mask",
+                &format_args!("{}", self.pd_hp_wifi_mask().bits()),
+            )
+            .field(
+                "pd_hp_wifi_pd_mask",
+                &format_args!("{}", self.pd_hp_wifi_pd_mask().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_HPWIFI_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_reset(&mut self) -> FORCE_HP_WIFI_RESET_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_RESET_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_iso(&mut self) -> FORCE_HP_WIFI_ISO_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_ISO_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_pu(&mut self) -> FORCE_HP_WIFI_PU_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_PU_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_no_reset(
+        &mut self,
+    ) -> FORCE_HP_WIFI_NO_RESET_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_NO_RESET_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_no_iso(&mut self) -> FORCE_HP_WIFI_NO_ISO_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_NO_ISO_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_wifi_pd(&mut self) -> FORCE_HP_WIFI_PD_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        FORCE_HP_WIFI_PD_W::new(self, 5)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_wifi_mask(&mut self) -> PD_HP_WIFI_MASK_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        PD_HP_WIFI_MASK_W::new(self, 6)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_wifi_pd_mask(&mut self) -> PD_HP_WIFI_PD_MASK_W<POWER_PD_HPWIFI_CNTL_SPEC> {
+        PD_HP_WIFI_PD_MASK_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_hpwifi_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_hpwifi_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_HPWIFI_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_HPWIFI_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_hpwifi_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_HPWIFI_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_hpwifi_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_HPWIFI_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_HPWIFI_CNTL to value 0x1c"]
+impl crate::Resettable for POWER_PD_HPWIFI_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x1c;
+}

--- a/esp32c6-lp/src/pmu/power_pd_lpperi_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_lpperi_cntl.rs
@@ -1,0 +1,154 @@
+#[doc = "Register `POWER_PD_LPPERI_CNTL` reader"]
+pub type R = crate::R<POWER_PD_LPPERI_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_LPPERI_CNTL` writer"]
+pub type W = crate::W<POWER_PD_LPPERI_CNTL_SPEC>;
+#[doc = "Field `FORCE_LP_PERI_RESET` reader - need_des"]
+pub type FORCE_LP_PERI_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_RESET` writer - need_des"]
+pub type FORCE_LP_PERI_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_LP_PERI_ISO` reader - need_des"]
+pub type FORCE_LP_PERI_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_ISO` writer - need_des"]
+pub type FORCE_LP_PERI_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_LP_PERI_PU` reader - need_des"]
+pub type FORCE_LP_PERI_PU_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_PU` writer - need_des"]
+pub type FORCE_LP_PERI_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_LP_PERI_NO_RESET` reader - need_des"]
+pub type FORCE_LP_PERI_NO_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_NO_RESET` writer - need_des"]
+pub type FORCE_LP_PERI_NO_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_LP_PERI_NO_ISO` reader - need_des"]
+pub type FORCE_LP_PERI_NO_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_NO_ISO` writer - need_des"]
+pub type FORCE_LP_PERI_NO_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_LP_PERI_PD` reader - need_des"]
+pub type FORCE_LP_PERI_PD_R = crate::BitReader;
+#[doc = "Field `FORCE_LP_PERI_PD` writer - need_des"]
+pub type FORCE_LP_PERI_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_reset(&self) -> FORCE_LP_PERI_RESET_R {
+        FORCE_LP_PERI_RESET_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_iso(&self) -> FORCE_LP_PERI_ISO_R {
+        FORCE_LP_PERI_ISO_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_pu(&self) -> FORCE_LP_PERI_PU_R {
+        FORCE_LP_PERI_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_no_reset(&self) -> FORCE_LP_PERI_NO_RESET_R {
+        FORCE_LP_PERI_NO_RESET_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_no_iso(&self) -> FORCE_LP_PERI_NO_ISO_R {
+        FORCE_LP_PERI_NO_ISO_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    pub fn force_lp_peri_pd(&self) -> FORCE_LP_PERI_PD_R {
+        FORCE_LP_PERI_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_LPPERI_CNTL")
+            .field(
+                "force_lp_peri_reset",
+                &format_args!("{}", self.force_lp_peri_reset().bit()),
+            )
+            .field(
+                "force_lp_peri_iso",
+                &format_args!("{}", self.force_lp_peri_iso().bit()),
+            )
+            .field(
+                "force_lp_peri_pu",
+                &format_args!("{}", self.force_lp_peri_pu().bit()),
+            )
+            .field(
+                "force_lp_peri_no_reset",
+                &format_args!("{}", self.force_lp_peri_no_reset().bit()),
+            )
+            .field(
+                "force_lp_peri_no_iso",
+                &format_args!("{}", self.force_lp_peri_no_iso().bit()),
+            )
+            .field(
+                "force_lp_peri_pd",
+                &format_args!("{}", self.force_lp_peri_pd().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_LPPERI_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_reset(&mut self) -> FORCE_LP_PERI_RESET_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_RESET_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_iso(&mut self) -> FORCE_LP_PERI_ISO_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_ISO_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_pu(&mut self) -> FORCE_LP_PERI_PU_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_PU_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_no_reset(
+        &mut self,
+    ) -> FORCE_LP_PERI_NO_RESET_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_NO_RESET_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_no_iso(&mut self) -> FORCE_LP_PERI_NO_ISO_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_NO_ISO_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_lp_peri_pd(&mut self) -> FORCE_LP_PERI_PD_W<POWER_PD_LPPERI_CNTL_SPEC> {
+        FORCE_LP_PERI_PD_W::new(self, 5)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_lpperi_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_lpperi_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_LPPERI_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_LPPERI_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_lpperi_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_LPPERI_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_lpperi_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_LPPERI_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_LPPERI_CNTL to value 0x1c"]
+impl crate::Resettable for POWER_PD_LPPERI_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x1c;
+}

--- a/esp32c6-lp/src/pmu/power_pd_mem_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_mem_cntl.rs
@@ -1,0 +1,114 @@
+#[doc = "Register `POWER_PD_MEM_CNTL` reader"]
+pub type R = crate::R<POWER_PD_MEM_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_MEM_CNTL` writer"]
+pub type W = crate::W<POWER_PD_MEM_CNTL_SPEC>;
+#[doc = "Field `FORCE_HP_MEM_ISO` reader - need_des"]
+pub type FORCE_HP_MEM_ISO_R = crate::FieldReader;
+#[doc = "Field `FORCE_HP_MEM_ISO` writer - need_des"]
+pub type FORCE_HP_MEM_ISO_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `FORCE_HP_MEM_PD` reader - need_des"]
+pub type FORCE_HP_MEM_PD_R = crate::FieldReader;
+#[doc = "Field `FORCE_HP_MEM_PD` writer - need_des"]
+pub type FORCE_HP_MEM_PD_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `FORCE_HP_MEM_NO_ISO` reader - need_des"]
+pub type FORCE_HP_MEM_NO_ISO_R = crate::FieldReader;
+#[doc = "Field `FORCE_HP_MEM_NO_ISO` writer - need_des"]
+pub type FORCE_HP_MEM_NO_ISO_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `FORCE_HP_MEM_PU` reader - need_des"]
+pub type FORCE_HP_MEM_PU_R = crate::FieldReader;
+#[doc = "Field `FORCE_HP_MEM_PU` writer - need_des"]
+pub type FORCE_HP_MEM_PU_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 0:3 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_mem_iso(&self) -> FORCE_HP_MEM_ISO_R {
+        FORCE_HP_MEM_ISO_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_mem_pd(&self) -> FORCE_HP_MEM_PD_R {
+        FORCE_HP_MEM_PD_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+    #[doc = "Bits 24:27 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_mem_no_iso(&self) -> FORCE_HP_MEM_NO_ISO_R {
+        FORCE_HP_MEM_NO_ISO_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    pub fn force_hp_mem_pu(&self) -> FORCE_HP_MEM_PU_R {
+        FORCE_HP_MEM_PU_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_MEM_CNTL")
+            .field(
+                "force_hp_mem_iso",
+                &format_args!("{}", self.force_hp_mem_iso().bits()),
+            )
+            .field(
+                "force_hp_mem_pd",
+                &format_args!("{}", self.force_hp_mem_pd().bits()),
+            )
+            .field(
+                "force_hp_mem_no_iso",
+                &format_args!("{}", self.force_hp_mem_no_iso().bits()),
+            )
+            .field(
+                "force_hp_mem_pu",
+                &format_args!("{}", self.force_hp_mem_pu().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_MEM_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_mem_iso(&mut self) -> FORCE_HP_MEM_ISO_W<POWER_PD_MEM_CNTL_SPEC> {
+        FORCE_HP_MEM_ISO_W::new(self, 0)
+    }
+    #[doc = "Bits 4:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_mem_pd(&mut self) -> FORCE_HP_MEM_PD_W<POWER_PD_MEM_CNTL_SPEC> {
+        FORCE_HP_MEM_PD_W::new(self, 4)
+    }
+    #[doc = "Bits 24:27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_mem_no_iso(&mut self) -> FORCE_HP_MEM_NO_ISO_W<POWER_PD_MEM_CNTL_SPEC> {
+        FORCE_HP_MEM_NO_ISO_W::new(self, 24)
+    }
+    #[doc = "Bits 28:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_hp_mem_pu(&mut self) -> FORCE_HP_MEM_PU_W<POWER_PD_MEM_CNTL_SPEC> {
+        FORCE_HP_MEM_PU_W::new(self, 28)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_mem_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_mem_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_MEM_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_MEM_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_mem_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_MEM_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_mem_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_MEM_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_MEM_CNTL to value 0xff00_0000"]
+impl crate::Resettable for POWER_PD_MEM_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0xff00_0000;
+}

--- a/esp32c6-lp/src/pmu/power_pd_mem_mask.rs
+++ b/esp32c6-lp/src/pmu/power_pd_mem_mask.rs
@@ -1,0 +1,152 @@
+#[doc = "Register `POWER_PD_MEM_MASK` reader"]
+pub type R = crate::R<POWER_PD_MEM_MASK_SPEC>;
+#[doc = "Register `POWER_PD_MEM_MASK` writer"]
+pub type W = crate::W<POWER_PD_MEM_MASK_SPEC>;
+#[doc = "Field `PD_HP_MEM2_PD_MASK` reader - need_des"]
+pub type PD_HP_MEM2_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM2_PD_MASK` writer - need_des"]
+pub type PD_HP_MEM2_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_MEM1_PD_MASK` reader - need_des"]
+pub type PD_HP_MEM1_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM1_PD_MASK` writer - need_des"]
+pub type PD_HP_MEM1_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_MEM0_PD_MASK` reader - need_des"]
+pub type PD_HP_MEM0_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM0_PD_MASK` writer - need_des"]
+pub type PD_HP_MEM0_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_MEM2_MASK` reader - need_des"]
+pub type PD_HP_MEM2_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM2_MASK` writer - need_des"]
+pub type PD_HP_MEM2_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_MEM1_MASK` reader - need_des"]
+pub type PD_HP_MEM1_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM1_MASK` writer - need_des"]
+pub type PD_HP_MEM1_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_HP_MEM0_MASK` reader - need_des"]
+pub type PD_HP_MEM0_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_HP_MEM0_MASK` writer - need_des"]
+pub type PD_HP_MEM0_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bits 0:4 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem2_pd_mask(&self) -> PD_HP_MEM2_PD_MASK_R {
+        PD_HP_MEM2_PD_MASK_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:9 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem1_pd_mask(&self) -> PD_HP_MEM1_PD_MASK_R {
+        PD_HP_MEM1_PD_MASK_R::new(((self.bits >> 5) & 0x1f) as u8)
+    }
+    #[doc = "Bits 10:14 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem0_pd_mask(&self) -> PD_HP_MEM0_PD_MASK_R {
+        PD_HP_MEM0_PD_MASK_R::new(((self.bits >> 10) & 0x1f) as u8)
+    }
+    #[doc = "Bits 17:21 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem2_mask(&self) -> PD_HP_MEM2_MASK_R {
+        PD_HP_MEM2_MASK_R::new(((self.bits >> 17) & 0x1f) as u8)
+    }
+    #[doc = "Bits 22:26 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem1_mask(&self) -> PD_HP_MEM1_MASK_R {
+        PD_HP_MEM1_MASK_R::new(((self.bits >> 22) & 0x1f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn pd_hp_mem0_mask(&self) -> PD_HP_MEM0_MASK_R {
+        PD_HP_MEM0_MASK_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_MEM_MASK")
+            .field(
+                "pd_hp_mem2_pd_mask",
+                &format_args!("{}", self.pd_hp_mem2_pd_mask().bits()),
+            )
+            .field(
+                "pd_hp_mem1_pd_mask",
+                &format_args!("{}", self.pd_hp_mem1_pd_mask().bits()),
+            )
+            .field(
+                "pd_hp_mem0_pd_mask",
+                &format_args!("{}", self.pd_hp_mem0_pd_mask().bits()),
+            )
+            .field(
+                "pd_hp_mem2_mask",
+                &format_args!("{}", self.pd_hp_mem2_mask().bits()),
+            )
+            .field(
+                "pd_hp_mem1_mask",
+                &format_args!("{}", self.pd_hp_mem1_mask().bits()),
+            )
+            .field(
+                "pd_hp_mem0_mask",
+                &format_args!("{}", self.pd_hp_mem0_mask().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_MEM_MASK_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem2_pd_mask(&mut self) -> PD_HP_MEM2_PD_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM2_PD_MASK_W::new(self, 0)
+    }
+    #[doc = "Bits 5:9 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem1_pd_mask(&mut self) -> PD_HP_MEM1_PD_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM1_PD_MASK_W::new(self, 5)
+    }
+    #[doc = "Bits 10:14 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem0_pd_mask(&mut self) -> PD_HP_MEM0_PD_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM0_PD_MASK_W::new(self, 10)
+    }
+    #[doc = "Bits 17:21 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem2_mask(&mut self) -> PD_HP_MEM2_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM2_MASK_W::new(self, 17)
+    }
+    #[doc = "Bits 22:26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem1_mask(&mut self) -> PD_HP_MEM1_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM1_MASK_W::new(self, 22)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_hp_mem0_mask(&mut self) -> PD_HP_MEM0_MASK_W<POWER_PD_MEM_MASK_SPEC> {
+        PD_HP_MEM0_MASK_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_mem_mask::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_mem_mask::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_MEM_MASK_SPEC;
+impl crate::RegisterSpec for POWER_PD_MEM_MASK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_mem_mask::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_MEM_MASK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_mem_mask::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_MEM_MASK_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_MEM_MASK to value 0"]
+impl crate::Resettable for POWER_PD_MEM_MASK_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/power_pd_top_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_pd_top_cntl.rs
@@ -1,0 +1,190 @@
+#[doc = "Register `POWER_PD_TOP_CNTL` reader"]
+pub type R = crate::R<POWER_PD_TOP_CNTL_SPEC>;
+#[doc = "Register `POWER_PD_TOP_CNTL` writer"]
+pub type W = crate::W<POWER_PD_TOP_CNTL_SPEC>;
+#[doc = "Field `FORCE_TOP_RESET` reader - need_des"]
+pub type FORCE_TOP_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_RESET` writer - need_des"]
+pub type FORCE_TOP_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_TOP_ISO` reader - need_des"]
+pub type FORCE_TOP_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_ISO` writer - need_des"]
+pub type FORCE_TOP_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_TOP_PU` reader - need_des"]
+pub type FORCE_TOP_PU_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_PU` writer - need_des"]
+pub type FORCE_TOP_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_TOP_NO_RESET` reader - need_des"]
+pub type FORCE_TOP_NO_RESET_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_NO_RESET` writer - need_des"]
+pub type FORCE_TOP_NO_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_TOP_NO_ISO` reader - need_des"]
+pub type FORCE_TOP_NO_ISO_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_NO_ISO` writer - need_des"]
+pub type FORCE_TOP_NO_ISO_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `FORCE_TOP_PD` reader - need_des"]
+pub type FORCE_TOP_PD_R = crate::BitReader;
+#[doc = "Field `FORCE_TOP_PD` writer - need_des"]
+pub type FORCE_TOP_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PD_TOP_MASK` reader - need_des"]
+pub type PD_TOP_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_TOP_MASK` writer - need_des"]
+pub type PD_TOP_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `PD_TOP_PD_MASK` reader - need_des"]
+pub type PD_TOP_PD_MASK_R = crate::FieldReader;
+#[doc = "Field `PD_TOP_PD_MASK` writer - need_des"]
+pub type PD_TOP_PD_MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+impl R {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    pub fn force_top_reset(&self) -> FORCE_TOP_RESET_R {
+        FORCE_TOP_RESET_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    pub fn force_top_iso(&self) -> FORCE_TOP_ISO_R {
+        FORCE_TOP_ISO_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    pub fn force_top_pu(&self) -> FORCE_TOP_PU_R {
+        FORCE_TOP_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    pub fn force_top_no_reset(&self) -> FORCE_TOP_NO_RESET_R {
+        FORCE_TOP_NO_RESET_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    pub fn force_top_no_iso(&self) -> FORCE_TOP_NO_ISO_R {
+        FORCE_TOP_NO_ISO_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    pub fn force_top_pd(&self) -> FORCE_TOP_PD_R {
+        FORCE_TOP_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    pub fn pd_top_mask(&self) -> PD_TOP_MASK_R {
+        PD_TOP_MASK_R::new(((self.bits >> 6) & 0x1f) as u8)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    pub fn pd_top_pd_mask(&self) -> PD_TOP_PD_MASK_R {
+        PD_TOP_PD_MASK_R::new(((self.bits >> 27) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_PD_TOP_CNTL")
+            .field(
+                "force_top_reset",
+                &format_args!("{}", self.force_top_reset().bit()),
+            )
+            .field(
+                "force_top_iso",
+                &format_args!("{}", self.force_top_iso().bit()),
+            )
+            .field(
+                "force_top_pu",
+                &format_args!("{}", self.force_top_pu().bit()),
+            )
+            .field(
+                "force_top_no_reset",
+                &format_args!("{}", self.force_top_no_reset().bit()),
+            )
+            .field(
+                "force_top_no_iso",
+                &format_args!("{}", self.force_top_no_iso().bit()),
+            )
+            .field(
+                "force_top_pd",
+                &format_args!("{}", self.force_top_pd().bit()),
+            )
+            .field(
+                "pd_top_mask",
+                &format_args!("{}", self.pd_top_mask().bits()),
+            )
+            .field(
+                "pd_top_pd_mask",
+                &format_args!("{}", self.pd_top_pd_mask().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_PD_TOP_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_reset(&mut self) -> FORCE_TOP_RESET_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_RESET_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_iso(&mut self) -> FORCE_TOP_ISO_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_ISO_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_pu(&mut self) -> FORCE_TOP_PU_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_PU_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_no_reset(&mut self) -> FORCE_TOP_NO_RESET_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_NO_RESET_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_no_iso(&mut self) -> FORCE_TOP_NO_ISO_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_NO_ISO_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn force_top_pd(&mut self) -> FORCE_TOP_PD_W<POWER_PD_TOP_CNTL_SPEC> {
+        FORCE_TOP_PD_W::new(self, 5)
+    }
+    #[doc = "Bits 6:10 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_top_mask(&mut self) -> PD_TOP_MASK_W<POWER_PD_TOP_CNTL_SPEC> {
+        PD_TOP_MASK_W::new(self, 6)
+    }
+    #[doc = "Bits 27:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd_top_pd_mask(&mut self) -> PD_TOP_PD_MASK_W<POWER_PD_TOP_CNTL_SPEC> {
+        PD_TOP_PD_MASK_W::new(self, 27)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_pd_top_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_pd_top_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_PD_TOP_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_PD_TOP_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_pd_top_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_PD_TOP_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_pd_top_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_PD_TOP_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_PD_TOP_CNTL to value 0x1c"]
+impl crate::Resettable for POWER_PD_TOP_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x1c;
+}

--- a/esp32c6-lp/src/pmu/power_vdd_spi_cntl.rs
+++ b/esp32c6-lp/src/pmu/power_vdd_spi_cntl.rs
@@ -1,0 +1,95 @@
+#[doc = "Register `POWER_VDD_SPI_CNTL` reader"]
+pub type R = crate::R<POWER_VDD_SPI_CNTL_SPEC>;
+#[doc = "Register `POWER_VDD_SPI_CNTL` writer"]
+pub type W = crate::W<POWER_VDD_SPI_CNTL_SPEC>;
+#[doc = "Field `VDD_SPI_PWR_WAIT` reader - need_des"]
+pub type VDD_SPI_PWR_WAIT_R = crate::FieldReader<u16>;
+#[doc = "Field `VDD_SPI_PWR_WAIT` writer - need_des"]
+pub type VDD_SPI_PWR_WAIT_W<'a, REG> = crate::FieldWriter<'a, REG, 11, u16>;
+#[doc = "Field `VDD_SPI_PWR_SW` reader - need_des"]
+pub type VDD_SPI_PWR_SW_R = crate::FieldReader;
+#[doc = "Field `VDD_SPI_PWR_SW` writer - need_des"]
+pub type VDD_SPI_PWR_SW_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `VDD_SPI_PWR_SEL_SW` reader - need_des"]
+pub type VDD_SPI_PWR_SEL_SW_R = crate::BitReader;
+#[doc = "Field `VDD_SPI_PWR_SEL_SW` writer - need_des"]
+pub type VDD_SPI_PWR_SEL_SW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 18:28 - need_des"]
+    #[inline(always)]
+    pub fn vdd_spi_pwr_wait(&self) -> VDD_SPI_PWR_WAIT_R {
+        VDD_SPI_PWR_WAIT_R::new(((self.bits >> 18) & 0x07ff) as u16)
+    }
+    #[doc = "Bits 29:30 - need_des"]
+    #[inline(always)]
+    pub fn vdd_spi_pwr_sw(&self) -> VDD_SPI_PWR_SW_R {
+        VDD_SPI_PWR_SW_R::new(((self.bits >> 29) & 3) as u8)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn vdd_spi_pwr_sel_sw(&self) -> VDD_SPI_PWR_SEL_SW_R {
+        VDD_SPI_PWR_SEL_SW_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_VDD_SPI_CNTL")
+            .field(
+                "vdd_spi_pwr_wait",
+                &format_args!("{}", self.vdd_spi_pwr_wait().bits()),
+            )
+            .field(
+                "vdd_spi_pwr_sw",
+                &format_args!("{}", self.vdd_spi_pwr_sw().bits()),
+            )
+            .field(
+                "vdd_spi_pwr_sel_sw",
+                &format_args!("{}", self.vdd_spi_pwr_sel_sw().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_VDD_SPI_CNTL_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 18:28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdd_spi_pwr_wait(&mut self) -> VDD_SPI_PWR_WAIT_W<POWER_VDD_SPI_CNTL_SPEC> {
+        VDD_SPI_PWR_WAIT_W::new(self, 18)
+    }
+    #[doc = "Bits 29:30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdd_spi_pwr_sw(&mut self) -> VDD_SPI_PWR_SW_W<POWER_VDD_SPI_CNTL_SPEC> {
+        VDD_SPI_PWR_SW_W::new(self, 29)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdd_spi_pwr_sel_sw(&mut self) -> VDD_SPI_PWR_SEL_SW_W<POWER_VDD_SPI_CNTL_SPEC> {
+        VDD_SPI_PWR_SEL_SW_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_vdd_spi_cntl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_vdd_spi_cntl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_VDD_SPI_CNTL_SPEC;
+impl crate::RegisterSpec for POWER_VDD_SPI_CNTL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_vdd_spi_cntl::R`](R) reader structure"]
+impl crate::Readable for POWER_VDD_SPI_CNTL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_vdd_spi_cntl::W`](W) writer structure"]
+impl crate::Writable for POWER_VDD_SPI_CNTL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_VDD_SPI_CNTL to value 0x63fc_0000"]
+impl crate::Resettable for POWER_VDD_SPI_CNTL_SPEC {
+    const RESET_VALUE: u32 = 0x63fc_0000;
+}

--- a/esp32c6-lp/src/pmu/power_wait_timer0.rs
+++ b/esp32c6-lp/src/pmu/power_wait_timer0.rs
@@ -1,0 +1,95 @@
+#[doc = "Register `POWER_WAIT_TIMER0` reader"]
+pub type R = crate::R<POWER_WAIT_TIMER0_SPEC>;
+#[doc = "Register `POWER_WAIT_TIMER0` writer"]
+pub type W = crate::W<POWER_WAIT_TIMER0_SPEC>;
+#[doc = "Field `DG_HP_POWERDOWN_TIMER` reader - need_des"]
+pub type DG_HP_POWERDOWN_TIMER_R = crate::FieldReader<u16>;
+#[doc = "Field `DG_HP_POWERDOWN_TIMER` writer - need_des"]
+pub type DG_HP_POWERDOWN_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `DG_HP_POWERUP_TIMER` reader - need_des"]
+pub type DG_HP_POWERUP_TIMER_R = crate::FieldReader<u16>;
+#[doc = "Field `DG_HP_POWERUP_TIMER` writer - need_des"]
+pub type DG_HP_POWERUP_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `DG_HP_WAIT_TIMER` reader - need_des"]
+pub type DG_HP_WAIT_TIMER_R = crate::FieldReader<u16>;
+#[doc = "Field `DG_HP_WAIT_TIMER` writer - need_des"]
+pub type DG_HP_WAIT_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+impl R {
+    #[doc = "Bits 5:13 - need_des"]
+    #[inline(always)]
+    pub fn dg_hp_powerdown_timer(&self) -> DG_HP_POWERDOWN_TIMER_R {
+        DG_HP_POWERDOWN_TIMER_R::new(((self.bits >> 5) & 0x01ff) as u16)
+    }
+    #[doc = "Bits 14:22 - need_des"]
+    #[inline(always)]
+    pub fn dg_hp_powerup_timer(&self) -> DG_HP_POWERUP_TIMER_R {
+        DG_HP_POWERUP_TIMER_R::new(((self.bits >> 14) & 0x01ff) as u16)
+    }
+    #[doc = "Bits 23:31 - need_des"]
+    #[inline(always)]
+    pub fn dg_hp_wait_timer(&self) -> DG_HP_WAIT_TIMER_R {
+        DG_HP_WAIT_TIMER_R::new(((self.bits >> 23) & 0x01ff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_WAIT_TIMER0")
+            .field(
+                "dg_hp_powerdown_timer",
+                &format_args!("{}", self.dg_hp_powerdown_timer().bits()),
+            )
+            .field(
+                "dg_hp_powerup_timer",
+                &format_args!("{}", self.dg_hp_powerup_timer().bits()),
+            )
+            .field(
+                "dg_hp_wait_timer",
+                &format_args!("{}", self.dg_hp_wait_timer().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_WAIT_TIMER0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 5:13 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_hp_powerdown_timer(&mut self) -> DG_HP_POWERDOWN_TIMER_W<POWER_WAIT_TIMER0_SPEC> {
+        DG_HP_POWERDOWN_TIMER_W::new(self, 5)
+    }
+    #[doc = "Bits 14:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_hp_powerup_timer(&mut self) -> DG_HP_POWERUP_TIMER_W<POWER_WAIT_TIMER0_SPEC> {
+        DG_HP_POWERUP_TIMER_W::new(self, 14)
+    }
+    #[doc = "Bits 23:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_hp_wait_timer(&mut self) -> DG_HP_WAIT_TIMER_W<POWER_WAIT_TIMER0_SPEC> {
+        DG_HP_WAIT_TIMER_W::new(self, 23)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_wait_timer0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_wait_timer0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_WAIT_TIMER0_SPEC;
+impl crate::RegisterSpec for POWER_WAIT_TIMER0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_wait_timer0::R`](R) reader structure"]
+impl crate::Readable for POWER_WAIT_TIMER0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_wait_timer0::W`](W) writer structure"]
+impl crate::Writable for POWER_WAIT_TIMER0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_WAIT_TIMER0 to value 0x7fbf_dfe0"]
+impl crate::Resettable for POWER_WAIT_TIMER0_SPEC {
+    const RESET_VALUE: u32 = 0x7fbf_dfe0;
+}

--- a/esp32c6-lp/src/pmu/power_wait_timer1.rs
+++ b/esp32c6-lp/src/pmu/power_wait_timer1.rs
@@ -1,0 +1,95 @@
+#[doc = "Register `POWER_WAIT_TIMER1` reader"]
+pub type R = crate::R<POWER_WAIT_TIMER1_SPEC>;
+#[doc = "Register `POWER_WAIT_TIMER1` writer"]
+pub type W = crate::W<POWER_WAIT_TIMER1_SPEC>;
+#[doc = "Field `DG_LP_POWERDOWN_TIMER` reader - need_des"]
+pub type DG_LP_POWERDOWN_TIMER_R = crate::FieldReader;
+#[doc = "Field `DG_LP_POWERDOWN_TIMER` writer - need_des"]
+pub type DG_LP_POWERDOWN_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `DG_LP_POWERUP_TIMER` reader - need_des"]
+pub type DG_LP_POWERUP_TIMER_R = crate::FieldReader;
+#[doc = "Field `DG_LP_POWERUP_TIMER` writer - need_des"]
+pub type DG_LP_POWERUP_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `DG_LP_WAIT_TIMER` reader - need_des"]
+pub type DG_LP_WAIT_TIMER_R = crate::FieldReader<u16>;
+#[doc = "Field `DG_LP_WAIT_TIMER` writer - need_des"]
+pub type DG_LP_WAIT_TIMER_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+impl R {
+    #[doc = "Bits 9:15 - need_des"]
+    #[inline(always)]
+    pub fn dg_lp_powerdown_timer(&self) -> DG_LP_POWERDOWN_TIMER_R {
+        DG_LP_POWERDOWN_TIMER_R::new(((self.bits >> 9) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - need_des"]
+    #[inline(always)]
+    pub fn dg_lp_powerup_timer(&self) -> DG_LP_POWERUP_TIMER_R {
+        DG_LP_POWERUP_TIMER_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 23:31 - need_des"]
+    #[inline(always)]
+    pub fn dg_lp_wait_timer(&self) -> DG_LP_WAIT_TIMER_R {
+        DG_LP_WAIT_TIMER_R::new(((self.bits >> 23) & 0x01ff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("POWER_WAIT_TIMER1")
+            .field(
+                "dg_lp_powerdown_timer",
+                &format_args!("{}", self.dg_lp_powerdown_timer().bits()),
+            )
+            .field(
+                "dg_lp_powerup_timer",
+                &format_args!("{}", self.dg_lp_powerup_timer().bits()),
+            )
+            .field(
+                "dg_lp_wait_timer",
+                &format_args!("{}", self.dg_lp_wait_timer().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<POWER_WAIT_TIMER1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 9:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_lp_powerdown_timer(&mut self) -> DG_LP_POWERDOWN_TIMER_W<POWER_WAIT_TIMER1_SPEC> {
+        DG_LP_POWERDOWN_TIMER_W::new(self, 9)
+    }
+    #[doc = "Bits 16:22 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_lp_powerup_timer(&mut self) -> DG_LP_POWERUP_TIMER_W<POWER_WAIT_TIMER1_SPEC> {
+        DG_LP_POWERUP_TIMER_W::new(self, 16)
+    }
+    #[doc = "Bits 23:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dg_lp_wait_timer(&mut self) -> DG_LP_WAIT_TIMER_W<POWER_WAIT_TIMER1_SPEC> {
+        DG_LP_WAIT_TIMER_W::new(self, 23)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`power_wait_timer1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`power_wait_timer1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct POWER_WAIT_TIMER1_SPEC;
+impl crate::RegisterSpec for POWER_WAIT_TIMER1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`power_wait_timer1::R`](R) reader structure"]
+impl crate::Readable for POWER_WAIT_TIMER1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`power_wait_timer1::W`](W) writer structure"]
+impl crate::Writable for POWER_WAIT_TIMER1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets POWER_WAIT_TIMER1 to value 0x7fff_fe00"]
+impl crate::Resettable for POWER_WAIT_TIMER1_SPEC {
+    const RESET_VALUE: u32 = 0x7fff_fe00;
+}

--- a/esp32c6-lp/src/pmu/pwr_state.rs
+++ b/esp32c6-lp/src/pmu/pwr_state.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `PWR_STATE` reader"]
+pub type R = crate::R<PWR_STATE_SPEC>;
+#[doc = "Field `BACKUP_ST_STATE` reader - need_des"]
+pub type BACKUP_ST_STATE_R = crate::FieldReader;
+#[doc = "Field `LP_PWR_ST_STATE` reader - need_des"]
+pub type LP_PWR_ST_STATE_R = crate::FieldReader;
+#[doc = "Field `HP_PWR_ST_STATE` reader - need_des"]
+pub type HP_PWR_ST_STATE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 13:17 - need_des"]
+    #[inline(always)]
+    pub fn backup_st_state(&self) -> BACKUP_ST_STATE_R {
+        BACKUP_ST_STATE_R::new(((self.bits >> 13) & 0x1f) as u8)
+    }
+    #[doc = "Bits 18:22 - need_des"]
+    #[inline(always)]
+    pub fn lp_pwr_st_state(&self) -> LP_PWR_ST_STATE_R {
+        LP_PWR_ST_STATE_R::new(((self.bits >> 18) & 0x1f) as u8)
+    }
+    #[doc = "Bits 23:31 - need_des"]
+    #[inline(always)]
+    pub fn hp_pwr_st_state(&self) -> HP_PWR_ST_STATE_R {
+        HP_PWR_ST_STATE_R::new(((self.bits >> 23) & 0x01ff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PWR_STATE")
+            .field(
+                "backup_st_state",
+                &format_args!("{}", self.backup_st_state().bits()),
+            )
+            .field(
+                "lp_pwr_st_state",
+                &format_args!("{}", self.lp_pwr_st_state().bits()),
+            )
+            .field(
+                "hp_pwr_st_state",
+                &format_args!("{}", self.hp_pwr_st_state().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<PWR_STATE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pwr_state::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PWR_STATE_SPEC;
+impl crate::RegisterSpec for PWR_STATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pwr_state::R`](R) reader structure"]
+impl crate::Readable for PWR_STATE_SPEC {}
+#[doc = "`reset()` method sets PWR_STATE to value 0x0080_2000"]
+impl crate::Resettable for PWR_STATE_SPEC {
+    const RESET_VALUE: u32 = 0x0080_2000;
+}

--- a/esp32c6-lp/src/pmu/rf_pwc.rs
+++ b/esp32c6-lp/src/pmu/rf_pwc.rs
@@ -1,0 +1,149 @@
+#[doc = "Register `RF_PWC` reader"]
+pub type R = crate::R<RF_PWC_SPEC>;
+#[doc = "Register `RF_PWC` writer"]
+pub type W = crate::W<RF_PWC_SPEC>;
+#[doc = "Field `PERIF_I2C_RSTB` reader - need_des"]
+pub type PERIF_I2C_RSTB_R = crate::BitReader;
+#[doc = "Field `PERIF_I2C_RSTB` writer - need_des"]
+pub type PERIF_I2C_RSTB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `XPD_PERIF_I2C` reader - need_des"]
+pub type XPD_PERIF_I2C_R = crate::BitReader;
+#[doc = "Field `XPD_PERIF_I2C` writer - need_des"]
+pub type XPD_PERIF_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `XPD_TXRF_I2C` reader - need_des"]
+pub type XPD_TXRF_I2C_R = crate::BitReader;
+#[doc = "Field `XPD_TXRF_I2C` writer - need_des"]
+pub type XPD_TXRF_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `XPD_RFRX_PBUS` reader - need_des"]
+pub type XPD_RFRX_PBUS_R = crate::BitReader;
+#[doc = "Field `XPD_RFRX_PBUS` writer - need_des"]
+pub type XPD_RFRX_PBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `XPD_CKGEN_I2C` reader - need_des"]
+pub type XPD_CKGEN_I2C_R = crate::BitReader;
+#[doc = "Field `XPD_CKGEN_I2C` writer - need_des"]
+pub type XPD_CKGEN_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `XPD_PLL_I2C` reader - need_des"]
+pub type XPD_PLL_I2C_R = crate::BitReader;
+#[doc = "Field `XPD_PLL_I2C` writer - need_des"]
+pub type XPD_PLL_I2C_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    pub fn perif_i2c_rstb(&self) -> PERIF_I2C_RSTB_R {
+        PERIF_I2C_RSTB_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    pub fn xpd_perif_i2c(&self) -> XPD_PERIF_I2C_R {
+        XPD_PERIF_I2C_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    pub fn xpd_txrf_i2c(&self) -> XPD_TXRF_I2C_R {
+        XPD_TXRF_I2C_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    pub fn xpd_rfrx_pbus(&self) -> XPD_RFRX_PBUS_R {
+        XPD_RFRX_PBUS_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    pub fn xpd_ckgen_i2c(&self) -> XPD_CKGEN_I2C_R {
+        XPD_CKGEN_I2C_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn xpd_pll_i2c(&self) -> XPD_PLL_I2C_R {
+        XPD_PLL_I2C_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RF_PWC")
+            .field(
+                "perif_i2c_rstb",
+                &format_args!("{}", self.perif_i2c_rstb().bit()),
+            )
+            .field(
+                "xpd_perif_i2c",
+                &format_args!("{}", self.xpd_perif_i2c().bit()),
+            )
+            .field(
+                "xpd_txrf_i2c",
+                &format_args!("{}", self.xpd_txrf_i2c().bit()),
+            )
+            .field(
+                "xpd_rfrx_pbus",
+                &format_args!("{}", self.xpd_rfrx_pbus().bit()),
+            )
+            .field(
+                "xpd_ckgen_i2c",
+                &format_args!("{}", self.xpd_ckgen_i2c().bit()),
+            )
+            .field("xpd_pll_i2c", &format_args!("{}", self.xpd_pll_i2c().bit()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<RF_PWC_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bit 26 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn perif_i2c_rstb(&mut self) -> PERIF_I2C_RSTB_W<RF_PWC_SPEC> {
+        PERIF_I2C_RSTB_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn xpd_perif_i2c(&mut self) -> XPD_PERIF_I2C_W<RF_PWC_SPEC> {
+        XPD_PERIF_I2C_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn xpd_txrf_i2c(&mut self) -> XPD_TXRF_I2C_W<RF_PWC_SPEC> {
+        XPD_TXRF_I2C_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn xpd_rfrx_pbus(&mut self) -> XPD_RFRX_PBUS_W<RF_PWC_SPEC> {
+        XPD_RFRX_PBUS_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn xpd_ckgen_i2c(&mut self) -> XPD_CKGEN_I2C_W<RF_PWC_SPEC> {
+        XPD_CKGEN_I2C_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn xpd_pll_i2c(&mut self) -> XPD_PLL_I2C_W<RF_PWC_SPEC> {
+        XPD_PLL_I2C_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rf_pwc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rf_pwc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RF_PWC_SPEC;
+impl crate::RegisterSpec for RF_PWC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rf_pwc::R`](R) reader structure"]
+impl crate::Readable for RF_PWC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rf_pwc::W`](W) writer structure"]
+impl crate::Writable for RF_PWC_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets RF_PWC to value 0x0800_0000"]
+impl crate::Resettable for RF_PWC_SPEC {
+    const RESET_VALUE: u32 = 0x0800_0000;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl0.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `SLP_WAKEUP_CNTL0` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL0_SPEC>;
+#[doc = "Field `SLEEP_REQ` writer - need_des"]
+pub type SLEEP_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_req(&mut self) -> SLEEP_REQ_W<SLP_WAKEUP_CNTL0_SPEC> {
+        SLEEP_REQ_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl0::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL0_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl0::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL0_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL0 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_CNTL0_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl1.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl1.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `SLP_WAKEUP_CNTL1` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL1_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL1` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL1_SPEC>;
+#[doc = "Field `SLEEP_REJECT_ENA` reader - need_des"]
+pub type SLEEP_REJECT_ENA_R = crate::FieldReader<u32>;
+#[doc = "Field `SLEEP_REJECT_ENA` writer - need_des"]
+pub type SLEEP_REJECT_ENA_W<'a, REG> = crate::FieldWriter<'a, REG, 31, u32>;
+#[doc = "Field `SLP_REJECT_EN` reader - need_des"]
+pub type SLP_REJECT_EN_R = crate::BitReader;
+#[doc = "Field `SLP_REJECT_EN` writer - need_des"]
+pub type SLP_REJECT_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 0:30 - need_des"]
+    #[inline(always)]
+    pub fn sleep_reject_ena(&self) -> SLEEP_REJECT_ENA_R {
+        SLEEP_REJECT_ENA_R::new(self.bits & 0x7fff_ffff)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn slp_reject_en(&self) -> SLP_REJECT_EN_R {
+        SLP_REJECT_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL1")
+            .field(
+                "sleep_reject_ena",
+                &format_args!("{}", self.sleep_reject_ena().bits()),
+            )
+            .field(
+                "slp_reject_en",
+                &format_args!("{}", self.slp_reject_en().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:30 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_reject_ena(&mut self) -> SLEEP_REJECT_ENA_W<SLP_WAKEUP_CNTL1_SPEC> {
+        SLEEP_REJECT_ENA_W::new(self, 0)
+    }
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn slp_reject_en(&mut self) -> SLP_REJECT_EN_W<SLP_WAKEUP_CNTL1_SPEC> {
+        SLP_REJECT_EN_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL1_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl1::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl1::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL1_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL1 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_CNTL1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl2.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl2.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `SLP_WAKEUP_CNTL2` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL2_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL2` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL2_SPEC>;
+#[doc = "Field `WAKEUP_ENA` reader - need_des"]
+pub type WAKEUP_ENA_R = crate::FieldReader<u32>;
+#[doc = "Field `WAKEUP_ENA` writer - need_des"]
+pub type WAKEUP_ENA_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn wakeup_ena(&self) -> WAKEUP_ENA_R {
+        WAKEUP_ENA_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL2")
+            .field("wakeup_ena", &format_args!("{}", self.wakeup_ena().bits()))
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL2_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn wakeup_ena(&mut self) -> WAKEUP_ENA_W<SLP_WAKEUP_CNTL2_SPEC> {
+        WAKEUP_ENA_W::new(self, 0)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL2_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl2::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl2::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL2_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL2 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_CNTL2_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl3.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl3.rs
@@ -1,0 +1,95 @@
+#[doc = "Register `SLP_WAKEUP_CNTL3` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL3_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL3` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL3_SPEC>;
+#[doc = "Field `LP_MIN_SLP_VAL` reader - need_des"]
+pub type LP_MIN_SLP_VAL_R = crate::FieldReader;
+#[doc = "Field `LP_MIN_SLP_VAL` writer - need_des"]
+pub type LP_MIN_SLP_VAL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `HP_MIN_SLP_VAL` reader - need_des"]
+pub type HP_MIN_SLP_VAL_R = crate::FieldReader;
+#[doc = "Field `HP_MIN_SLP_VAL` writer - need_des"]
+pub type HP_MIN_SLP_VAL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `SLEEP_PRT_SEL` reader - need_des"]
+pub type SLEEP_PRT_SEL_R = crate::FieldReader;
+#[doc = "Field `SLEEP_PRT_SEL` writer - need_des"]
+pub type SLEEP_PRT_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    pub fn lp_min_slp_val(&self) -> LP_MIN_SLP_VAL_R {
+        LP_MIN_SLP_VAL_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 8:15 - need_des"]
+    #[inline(always)]
+    pub fn hp_min_slp_val(&self) -> HP_MIN_SLP_VAL_R {
+        HP_MIN_SLP_VAL_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    pub fn sleep_prt_sel(&self) -> SLEEP_PRT_SEL_R {
+        SLEEP_PRT_SEL_R::new(((self.bits >> 16) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL3")
+            .field(
+                "lp_min_slp_val",
+                &format_args!("{}", self.lp_min_slp_val().bits()),
+            )
+            .field(
+                "hp_min_slp_val",
+                &format_args!("{}", self.hp_min_slp_val().bits()),
+            )
+            .field(
+                "sleep_prt_sel",
+                &format_args!("{}", self.sleep_prt_sel().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL3_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_min_slp_val(&mut self) -> LP_MIN_SLP_VAL_W<SLP_WAKEUP_CNTL3_SPEC> {
+        LP_MIN_SLP_VAL_W::new(self, 0)
+    }
+    #[doc = "Bits 8:15 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hp_min_slp_val(&mut self) -> HP_MIN_SLP_VAL_W<SLP_WAKEUP_CNTL3_SPEC> {
+        HP_MIN_SLP_VAL_W::new(self, 8)
+    }
+    #[doc = "Bits 16:17 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sleep_prt_sel(&mut self) -> SLEEP_PRT_SEL_W<SLP_WAKEUP_CNTL3_SPEC> {
+        SLEEP_PRT_SEL_W::new(self, 16)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL3_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL3_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl3::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl3::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL3_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL3 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_CNTL3_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl4.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl4.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `SLP_WAKEUP_CNTL4` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL4_SPEC>;
+#[doc = "Field `SLP_REJECT_CAUSE_CLR` writer - need_des"]
+pub type SLP_REJECT_CAUSE_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL4_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn slp_reject_cause_clr(&mut self) -> SLP_REJECT_CAUSE_CLR_W<SLP_WAKEUP_CNTL4_SPEC> {
+        SLP_REJECT_CAUSE_CLR_W::new(self, 31)
+    }
+}
+#[doc = "need_des\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl4::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL4_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL4_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl4::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL4_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL4 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_CNTL4_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl5.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl5.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `SLP_WAKEUP_CNTL5` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL5_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL5` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL5_SPEC>;
+#[doc = "Field `MODEM_WAIT_TARGET` reader - need_des"]
+pub type MODEM_WAIT_TARGET_R = crate::FieldReader<u32>;
+#[doc = "Field `MODEM_WAIT_TARGET` writer - need_des"]
+pub type MODEM_WAIT_TARGET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `LP_ANA_WAIT_TARGET` reader - need_des"]
+pub type LP_ANA_WAIT_TARGET_R = crate::FieldReader;
+#[doc = "Field `LP_ANA_WAIT_TARGET` writer - need_des"]
+pub type LP_ANA_WAIT_TARGET_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+impl R {
+    #[doc = "Bits 0:19 - need_des"]
+    #[inline(always)]
+    pub fn modem_wait_target(&self) -> MODEM_WAIT_TARGET_R {
+        MODEM_WAIT_TARGET_R::new(self.bits & 0x000f_ffff)
+    }
+    #[doc = "Bits 24:31 - need_des"]
+    #[inline(always)]
+    pub fn lp_ana_wait_target(&self) -> LP_ANA_WAIT_TARGET_R {
+        LP_ANA_WAIT_TARGET_R::new(((self.bits >> 24) & 0xff) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL5")
+            .field(
+                "modem_wait_target",
+                &format_args!("{}", self.modem_wait_target().bits()),
+            )
+            .field(
+                "lp_ana_wait_target",
+                &format_args!("{}", self.lp_ana_wait_target().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL5_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:19 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn modem_wait_target(&mut self) -> MODEM_WAIT_TARGET_W<SLP_WAKEUP_CNTL5_SPEC> {
+        MODEM_WAIT_TARGET_W::new(self, 0)
+    }
+    #[doc = "Bits 24:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_ana_wait_target(&mut self) -> LP_ANA_WAIT_TARGET_W<SLP_WAKEUP_CNTL5_SPEC> {
+        LP_ANA_WAIT_TARGET_W::new(self, 24)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL5_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL5_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl5::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL5_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl5::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL5_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL5 to value 0x0100_0080"]
+impl crate::Resettable for SLP_WAKEUP_CNTL5_SPEC {
+    const RESET_VALUE: u32 = 0x0100_0080;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl6.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl6.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `SLP_WAKEUP_CNTL6` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL6_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL6` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL6_SPEC>;
+#[doc = "Field `SOC_WAKEUP_WAIT` reader - need_des"]
+pub type SOC_WAKEUP_WAIT_R = crate::FieldReader<u32>;
+#[doc = "Field `SOC_WAKEUP_WAIT` writer - need_des"]
+pub type SOC_WAKEUP_WAIT_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `SOC_WAKEUP_WAIT_CFG` reader - need_des"]
+pub type SOC_WAKEUP_WAIT_CFG_R = crate::FieldReader;
+#[doc = "Field `SOC_WAKEUP_WAIT_CFG` writer - need_des"]
+pub type SOC_WAKEUP_WAIT_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 0:19 - need_des"]
+    #[inline(always)]
+    pub fn soc_wakeup_wait(&self) -> SOC_WAKEUP_WAIT_R {
+        SOC_WAKEUP_WAIT_R::new(self.bits & 0x000f_ffff)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    pub fn soc_wakeup_wait_cfg(&self) -> SOC_WAKEUP_WAIT_CFG_R {
+        SOC_WAKEUP_WAIT_CFG_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL6")
+            .field(
+                "soc_wakeup_wait",
+                &format_args!("{}", self.soc_wakeup_wait().bits()),
+            )
+            .field(
+                "soc_wakeup_wait_cfg",
+                &format_args!("{}", self.soc_wakeup_wait_cfg().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL6_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 0:19 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_wakeup_wait(&mut self) -> SOC_WAKEUP_WAIT_W<SLP_WAKEUP_CNTL6_SPEC> {
+        SOC_WAKEUP_WAIT_W::new(self, 0)
+    }
+    #[doc = "Bits 30:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn soc_wakeup_wait_cfg(&mut self) -> SOC_WAKEUP_WAIT_CFG_W<SLP_WAKEUP_CNTL6_SPEC> {
+        SOC_WAKEUP_WAIT_CFG_W::new(self, 30)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl6::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL6_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL6_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl6::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL6_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl6::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL6_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL6 to value 0x80"]
+impl crate::Resettable for SLP_WAKEUP_CNTL6_SPEC {
+    const RESET_VALUE: u32 = 0x80;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_cntl7.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_cntl7.rs
@@ -1,0 +1,57 @@
+#[doc = "Register `SLP_WAKEUP_CNTL7` reader"]
+pub type R = crate::R<SLP_WAKEUP_CNTL7_SPEC>;
+#[doc = "Register `SLP_WAKEUP_CNTL7` writer"]
+pub type W = crate::W<SLP_WAKEUP_CNTL7_SPEC>;
+#[doc = "Field `ANA_WAIT_TARGET` reader - need_des"]
+pub type ANA_WAIT_TARGET_R = crate::FieldReader<u16>;
+#[doc = "Field `ANA_WAIT_TARGET` writer - need_des"]
+pub type ANA_WAIT_TARGET_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+impl R {
+    #[doc = "Bits 16:31 - need_des"]
+    #[inline(always)]
+    pub fn ana_wait_target(&self) -> ANA_WAIT_TARGET_R {
+        ANA_WAIT_TARGET_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_CNTL7")
+            .field(
+                "ana_wait_target",
+                &format_args!("{}", self.ana_wait_target().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_CNTL7_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = "Bits 16:31 - need_des"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ana_wait_target(&mut self) -> ANA_WAIT_TARGET_W<SLP_WAKEUP_CNTL7_SPEC> {
+        ANA_WAIT_TARGET_W::new(self, 16)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_cntl7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`slp_wakeup_cntl7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_CNTL7_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_CNTL7_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_cntl7::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_CNTL7_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`slp_wakeup_cntl7::W`](W) writer structure"]
+impl crate::Writable for SLP_WAKEUP_CNTL7_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets SLP_WAKEUP_CNTL7 to value 0x0001_0000"]
+impl crate::Resettable for SLP_WAKEUP_CNTL7_SPEC {
+    const RESET_VALUE: u32 = 0x0001_0000;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_status0.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_status0.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `SLP_WAKEUP_STATUS0` reader"]
+pub type R = crate::R<SLP_WAKEUP_STATUS0_SPEC>;
+#[doc = "Field `WAKEUP_CAUSE` reader - need_des"]
+pub type WAKEUP_CAUSE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn wakeup_cause(&self) -> WAKEUP_CAUSE_R {
+        WAKEUP_CAUSE_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_STATUS0")
+            .field(
+                "wakeup_cause",
+                &format_args!("{}", self.wakeup_cause().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_STATUS0_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_status0::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_STATUS0_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_STATUS0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_status0::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_STATUS0_SPEC {}
+#[doc = "`reset()` method sets SLP_WAKEUP_STATUS0 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_STATUS0_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/slp_wakeup_status1.rs
+++ b/esp32c6-lp/src/pmu/slp_wakeup_status1.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `SLP_WAKEUP_STATUS1` reader"]
+pub type R = crate::R<SLP_WAKEUP_STATUS1_SPEC>;
+#[doc = "Field `REJECT_CAUSE` reader - need_des"]
+pub type REJECT_CAUSE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - need_des"]
+    #[inline(always)]
+    pub fn reject_cause(&self) -> REJECT_CAUSE_R {
+        REJECT_CAUSE_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SLP_WAKEUP_STATUS1")
+            .field(
+                "reject_cause",
+                &format_args!("{}", self.reject_cause().bits()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<SLP_WAKEUP_STATUS1_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`slp_wakeup_status1::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLP_WAKEUP_STATUS1_SPEC;
+impl crate::RegisterSpec for SLP_WAKEUP_STATUS1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`slp_wakeup_status1::R`](R) reader structure"]
+impl crate::Readable for SLP_WAKEUP_STATUS1_SPEC {}
+#[doc = "`reset()` method sets SLP_WAKEUP_STATUS1 to value 0"]
+impl crate::Resettable for SLP_WAKEUP_STATUS1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/src/pmu/vdd_spi_status.rs
+++ b/esp32c6-lp/src/pmu/vdd_spi_status.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `VDD_SPI_STATUS` reader"]
+pub type R = crate::R<VDD_SPI_STATUS_SPEC>;
+#[doc = "Field `STABLE_VDD_SPI_PWR_DRV` reader - need_des"]
+pub type STABLE_VDD_SPI_PWR_DRV_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 31 - need_des"]
+    #[inline(always)]
+    pub fn stable_vdd_spi_pwr_drv(&self) -> STABLE_VDD_SPI_PWR_DRV_R {
+        STABLE_VDD_SPI_PWR_DRV_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VDD_SPI_STATUS")
+            .field(
+                "stable_vdd_spi_pwr_drv",
+                &format_args!("{}", self.stable_vdd_spi_pwr_drv().bit()),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<VDD_SPI_STATUS_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+#[doc = "need_des\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`vdd_spi_status::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct VDD_SPI_STATUS_SPEC;
+impl crate::RegisterSpec for VDD_SPI_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`vdd_spi_status::R`](R) reader structure"]
+impl crate::Readable for VDD_SPI_STATUS_SPEC {}
+#[doc = "`reset()` method sets VDD_SPI_STATUS to value 0"]
+impl crate::Resettable for VDD_SPI_STATUS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32c6-lp/svd/patches/esp32c6-lp.yaml
+++ b/esp32c6-lp/svd/patches/esp32c6-lp.yaml
@@ -39,3 +39,7 @@ LP_TIMER:
 
 LP_APM:
   _include: ../../../common_patches/hp_apm.yaml
+
+_copy:
+    PMU:
+        from: ../../../esp32c6/svd/esp32c6.svd:PMU


### PR DESCRIPTION
This adds PMU to ESP32C6-LP

It's needed for waking the HP core from the LP core. There are a lot more changes needed to use the latest PAC in `esp-lp-hal` - I prepared those changes locally already and will submit a PR as soon as this gets merged