### PR TITLE
Strip `SARADC_` prefix in `APB_SARADC/CTRL` registers

### DIFF
--- a/esp32c2/svd/patches/esp32c2.yaml
+++ b/esp32c2/svd/patches/esp32c2.yaml
@@ -14,6 +14,10 @@ APB_SARADC:
       name: CTRL_DATE
   CLKM_CONF:
     _strip: REG_
+  CTRL2:
+    _strip: SARADC_
+  CTRL:
+    _strip: SARADC_
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/adc.yaml

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -8,6 +8,10 @@ AES:
   _include: ../../../common_patches/aes.yaml
 
 APB_SARADC:
+  CTRL2:
+    _strip: SARADC_
+  CTRL:
+    _strip: SARADC_
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/adc.yaml

--- a/esp32c6/svd/patches/esp32c6.yaml
+++ b/esp32c6/svd/patches/esp32c6.yaml
@@ -15,6 +15,10 @@ APB_SARADC:
       name: TSENS_SAMPLE
   TSENS_SAMPLE:
     _strip: TSENS_SAMPLE_
+  CTRL2:
+    _strip: SARADC_
+  CTRL:
+    _strip: SARADC_
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/adc.yaml

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -15,6 +15,8 @@ APB_SARADC:
       name: TSENS_SAMPLE
   TSENS_SAMPLE:
     _strip: TSENS_SAMPLE_
+  CTRL2:
+    _strip: SARADC_
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/adc.yaml

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -24,6 +24,10 @@ APB_SARADC:
       name: CTRL_DATE
   CTRL_DATE:
     _strip: APB_CTRL_
+  CTRL2:
+    _strip: SARADC_
+  CTRL:
+    _strip: SARADC_
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/adc.yaml


### PR DESCRIPTION
An inconsistency between a register name and a function name, generated after `svd2rust` in multiple registers was noticed.