### PR TITLE
Fix typo in debug_assist register name

### DIFF
--- a/common_patches/assist_debug.yaml
+++ b/common_patches/assist_debug.yaml
@@ -1,0 +1,3 @@
+_modify:
+  "C0RE_0_DEBUG_MODE":
+    name: "CORE_0_DEBUG_MODE"

--- a/esp32c3/src/assist_debug.rs
+++ b/esp32c3/src/assist_debug.rs
@@ -40,7 +40,7 @@ pub struct RegisterBlock {
     log_mem_writing_addr: LOG_MEM_WRITING_ADDR,
     log_mem_full_flag: LOG_MEM_FULL_FLAG,
     c0re_0_lastpc_before_exception: C0RE_0_LASTPC_BEFORE_EXCEPTION,
-    c0re_0_debug_mode: C0RE_0_DEBUG_MODE,
+    core_0_debug_mode: CORE_0_DEBUG_MODE,
     _reserved39: [u8; 0x0160],
     date: DATE,
 }
@@ -241,8 +241,8 @@ impl RegisterBlock {
     }
     #[doc = "0x98 - ASSIST_DEBUG_C0RE_0_DEBUG_MODE"]
     #[inline(always)]
-    pub const fn c0re_0_debug_mode(&self) -> &C0RE_0_DEBUG_MODE {
-        &self.c0re_0_debug_mode
+    pub const fn core_0_debug_mode(&self) -> &CORE_0_DEBUG_MODE {
+        &self.core_0_debug_mode
     }
     #[doc = "0x1fc - ASSIST_DEBUG_DATE_REG"]
     #[inline(always)]
@@ -415,10 +415,10 @@ pub type C0RE_0_LASTPC_BEFORE_EXCEPTION =
     crate::Reg<c0re_0_lastpc_before_exception::C0RE_0_LASTPC_BEFORE_EXCEPTION_SPEC>;
 #[doc = "ASSIST_DEBUG_C0RE_0_LASTPC_BEFORE_EXCEPTION"]
 pub mod c0re_0_lastpc_before_exception;
-#[doc = "C0RE_0_DEBUG_MODE (r) register accessor: ASSIST_DEBUG_C0RE_0_DEBUG_MODE\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@c0re_0_debug_mode`] module"]
-pub type C0RE_0_DEBUG_MODE = crate::Reg<c0re_0_debug_mode::C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "CORE_0_DEBUG_MODE (r) register accessor: ASSIST_DEBUG_C0RE_0_DEBUG_MODE\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@core_0_debug_mode`] module"]
+pub type CORE_0_DEBUG_MODE = crate::Reg<core_0_debug_mode::CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "ASSIST_DEBUG_C0RE_0_DEBUG_MODE"]
-pub mod c0re_0_debug_mode;
+pub mod core_0_debug_mode;
 #[doc = "DATE (rw) register accessor: ASSIST_DEBUG_DATE_REG\n\nYou can [`read`](crate::Reg::read) this register and get [`date::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`date::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@date`] module"]
 pub type DATE = crate::Reg<date::DATE_SPEC>;
 #[doc = "ASSIST_DEBUG_DATE_REG"]

--- a/esp32c3/src/assist_debug/core_0_debug_mode.rs
+++ b/esp32c3/src/assist_debug/core_0_debug_mode.rs
@@ -1,5 +1,5 @@
-#[doc = "Register `C0RE_0_DEBUG_MODE` reader"]
-pub type R = crate::R<C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "Register `CORE_0_DEBUG_MODE` reader"]
+pub type R = crate::R<CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "Field `CORE_0_DEBUG_MODE` reader - reg_core_0_debug_mode"]
 pub type CORE_0_DEBUG_MODE_R = crate::BitReader;
 #[doc = "Field `CORE_0_DEBUG_MODULE_ACTIVE` reader - reg_core_0_debug_module_active"]
@@ -19,7 +19,7 @@ impl R {
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("C0RE_0_DEBUG_MODE")
+        f.debug_struct("CORE_0_DEBUG_MODE")
             .field("core_0_debug_mode", &self.core_0_debug_mode())
             .field(
                 "core_0_debug_module_active",
@@ -28,14 +28,14 @@ impl core::fmt::Debug for R {
             .finish()
     }
 }
-#[doc = "ASSIST_DEBUG_C0RE_0_DEBUG_MODE\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct C0RE_0_DEBUG_MODE_SPEC;
-impl crate::RegisterSpec for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "ASSIST_DEBUG_C0RE_0_DEBUG_MODE\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CORE_0_DEBUG_MODE_SPEC;
+impl crate::RegisterSpec for CORE_0_DEBUG_MODE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`c0re_0_debug_mode::R`](R) reader structure"]
-impl crate::Readable for C0RE_0_DEBUG_MODE_SPEC {}
-#[doc = "`reset()` method sets C0RE_0_DEBUG_MODE to value 0"]
-impl crate::Resettable for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "`read()` method returns [`core_0_debug_mode::R`](R) reader structure"]
+impl crate::Readable for CORE_0_DEBUG_MODE_SPEC {}
+#[doc = "`reset()` method sets CORE_0_DEBUG_MODE to value 0"]
+impl crate::Resettable for CORE_0_DEBUG_MODE_SPEC {
     const RESET_VALUE: u32 = 0;
 }

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -337,3 +337,7 @@ DMA:
         name: OUT_PRI
       OUT_PERI_SEL_CH?:
         name: OUT_PERI_SEL
+
+ASSIST_DEBUG:
+  _include: ../../../common_patches/assist_debug.yaml
+  

--- a/esp32c6/src/assist_debug.rs
+++ b/esp32c6/src/assist_debug.rs
@@ -31,7 +31,7 @@ pub struct RegisterBlock {
     core_x_iram0_dram0_exception_monitor_0: CORE_X_IRAM0_DRAM0_EXCEPTION_MONITOR_0,
     core_x_iram0_dram0_exception_monitor_1: CORE_X_IRAM0_DRAM0_EXCEPTION_MONITOR_1,
     c0re_0_lastpc_before_exception: C0RE_0_LASTPC_BEFORE_EXCEPTION,
-    c0re_0_debug_mode: C0RE_0_DEBUG_MODE,
+    core_0_debug_mode: CORE_0_DEBUG_MODE,
     clock_gate: CLOCK_GATE,
     _reserved31: [u8; 0x0380],
     date: DATE,
@@ -188,8 +188,8 @@ impl RegisterBlock {
     }
     #[doc = "0x74 - cpu status register"]
     #[inline(always)]
-    pub const fn c0re_0_debug_mode(&self) -> &C0RE_0_DEBUG_MODE {
-        &self.c0re_0_debug_mode
+    pub const fn core_0_debug_mode(&self) -> &CORE_0_DEBUG_MODE {
+        &self.core_0_debug_mode
     }
     #[doc = "0x78 - clock register"]
     #[inline(always)]
@@ -331,10 +331,10 @@ pub type C0RE_0_LASTPC_BEFORE_EXCEPTION =
     crate::Reg<c0re_0_lastpc_before_exception::C0RE_0_LASTPC_BEFORE_EXCEPTION_SPEC>;
 #[doc = "cpu status register"]
 pub mod c0re_0_lastpc_before_exception;
-#[doc = "C0RE_0_DEBUG_MODE (r) register accessor: cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@c0re_0_debug_mode`] module"]
-pub type C0RE_0_DEBUG_MODE = crate::Reg<c0re_0_debug_mode::C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "CORE_0_DEBUG_MODE (r) register accessor: cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@core_0_debug_mode`] module"]
+pub type CORE_0_DEBUG_MODE = crate::Reg<core_0_debug_mode::CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "cpu status register"]
-pub mod c0re_0_debug_mode;
+pub mod core_0_debug_mode;
 #[doc = "CLOCK_GATE (rw) register accessor: clock register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clock_gate`] module"]
 pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
 #[doc = "clock register"]

--- a/esp32c6/src/assist_debug/core_0_debug_mode.rs
+++ b/esp32c6/src/assist_debug/core_0_debug_mode.rs
@@ -1,5 +1,5 @@
-#[doc = "Register `C0RE_0_DEBUG_MODE` reader"]
-pub type R = crate::R<C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "Register `CORE_0_DEBUG_MODE` reader"]
+pub type R = crate::R<CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "Field `CORE_0_DEBUG_MODE` reader - cpu debug mode status, 1 means cpu enter debug mode."]
 pub type CORE_0_DEBUG_MODE_R = crate::BitReader;
 #[doc = "Field `CORE_0_DEBUG_MODULE_ACTIVE` reader - cpu debug_module active status"]
@@ -19,7 +19,7 @@ impl R {
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("C0RE_0_DEBUG_MODE")
+        f.debug_struct("CORE_0_DEBUG_MODE")
             .field("core_0_debug_mode", &self.core_0_debug_mode())
             .field(
                 "core_0_debug_module_active",
@@ -28,14 +28,14 @@ impl core::fmt::Debug for R {
             .finish()
     }
 }
-#[doc = "cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct C0RE_0_DEBUG_MODE_SPEC;
-impl crate::RegisterSpec for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CORE_0_DEBUG_MODE_SPEC;
+impl crate::RegisterSpec for CORE_0_DEBUG_MODE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`c0re_0_debug_mode::R`](R) reader structure"]
-impl crate::Readable for C0RE_0_DEBUG_MODE_SPEC {}
-#[doc = "`reset()` method sets C0RE_0_DEBUG_MODE to value 0"]
-impl crate::Resettable for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "`read()` method returns [`core_0_debug_mode::R`](R) reader structure"]
+impl crate::Readable for CORE_0_DEBUG_MODE_SPEC {}
+#[doc = "`reset()` method sets CORE_0_DEBUG_MODE to value 0"]
+impl crate::Resettable for CORE_0_DEBUG_MODE_SPEC {
     const RESET_VALUE: u32 = 0;
 }

--- a/esp32c6/svd/patches/esp32c6.yaml
+++ b/esp32c6/svd/patches/esp32c6.yaml
@@ -460,3 +460,7 @@ DMA:
         name: OUT_PRI
       OUT_PERI_SEL_CH?:
         name: OUT_PERI_SEL
+
+ASSIST_DEBUG:
+  _include: ../../../common_patches/assist_debug.yaml
+  

--- a/esp32h2/src/assist_debug.rs
+++ b/esp32h2/src/assist_debug.rs
@@ -31,7 +31,7 @@ pub struct RegisterBlock {
     core_x_iram0_dram0_exception_monitor_0: CORE_X_IRAM0_DRAM0_EXCEPTION_MONITOR_0,
     core_x_iram0_dram0_exception_monitor_1: CORE_X_IRAM0_DRAM0_EXCEPTION_MONITOR_1,
     c0re_0_lastpc_before_exception: C0RE_0_LASTPC_BEFORE_EXCEPTION,
-    c0re_0_debug_mode: C0RE_0_DEBUG_MODE,
+    core_0_debug_mode: CORE_0_DEBUG_MODE,
     clock_gate: CLOCK_GATE,
     _reserved31: [u8; 0x0380],
     date: DATE,
@@ -188,8 +188,8 @@ impl RegisterBlock {
     }
     #[doc = "0x74 - cpu status register"]
     #[inline(always)]
-    pub const fn c0re_0_debug_mode(&self) -> &C0RE_0_DEBUG_MODE {
-        &self.c0re_0_debug_mode
+    pub const fn core_0_debug_mode(&self) -> &CORE_0_DEBUG_MODE {
+        &self.core_0_debug_mode
     }
     #[doc = "0x78 - clock register"]
     #[inline(always)]
@@ -331,10 +331,10 @@ pub type C0RE_0_LASTPC_BEFORE_EXCEPTION =
     crate::Reg<c0re_0_lastpc_before_exception::C0RE_0_LASTPC_BEFORE_EXCEPTION_SPEC>;
 #[doc = "cpu status register"]
 pub mod c0re_0_lastpc_before_exception;
-#[doc = "C0RE_0_DEBUG_MODE (r) register accessor: cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@c0re_0_debug_mode`] module"]
-pub type C0RE_0_DEBUG_MODE = crate::Reg<c0re_0_debug_mode::C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "CORE_0_DEBUG_MODE (r) register accessor: cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@core_0_debug_mode`] module"]
+pub type CORE_0_DEBUG_MODE = crate::Reg<core_0_debug_mode::CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "cpu status register"]
-pub mod c0re_0_debug_mode;
+pub mod core_0_debug_mode;
 #[doc = "CLOCK_GATE (rw) register accessor: clock register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clock_gate`] module"]
 pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
 #[doc = "clock register"]

--- a/esp32h2/src/assist_debug/core_0_debug_mode.rs
+++ b/esp32h2/src/assist_debug/core_0_debug_mode.rs
@@ -1,5 +1,5 @@
-#[doc = "Register `C0RE_0_DEBUG_MODE` reader"]
-pub type R = crate::R<C0RE_0_DEBUG_MODE_SPEC>;
+#[doc = "Register `CORE_0_DEBUG_MODE` reader"]
+pub type R = crate::R<CORE_0_DEBUG_MODE_SPEC>;
 #[doc = "Field `CORE_0_DEBUG_MODE` reader - cpu debug mode status, 1 means cpu enter debug mode."]
 pub type CORE_0_DEBUG_MODE_R = crate::BitReader;
 #[doc = "Field `CORE_0_DEBUG_MODULE_ACTIVE` reader - cpu debug_module active status"]
@@ -19,7 +19,7 @@ impl R {
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("C0RE_0_DEBUG_MODE")
+        f.debug_struct("CORE_0_DEBUG_MODE")
             .field("core_0_debug_mode", &self.core_0_debug_mode())
             .field(
                 "core_0_debug_module_active",
@@ -28,14 +28,14 @@ impl core::fmt::Debug for R {
             .finish()
     }
 }
-#[doc = "cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`c0re_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct C0RE_0_DEBUG_MODE_SPEC;
-impl crate::RegisterSpec for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "cpu status register\n\nYou can [`read`](crate::Reg::read) this register and get [`core_0_debug_mode::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CORE_0_DEBUG_MODE_SPEC;
+impl crate::RegisterSpec for CORE_0_DEBUG_MODE_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`c0re_0_debug_mode::R`](R) reader structure"]
-impl crate::Readable for C0RE_0_DEBUG_MODE_SPEC {}
-#[doc = "`reset()` method sets C0RE_0_DEBUG_MODE to value 0"]
-impl crate::Resettable for C0RE_0_DEBUG_MODE_SPEC {
+#[doc = "`read()` method returns [`core_0_debug_mode::R`](R) reader structure"]
+impl crate::Readable for CORE_0_DEBUG_MODE_SPEC {}
+#[doc = "`reset()` method sets CORE_0_DEBUG_MODE to value 0"]
+impl crate::Resettable for CORE_0_DEBUG_MODE_SPEC {
     const RESET_VALUE: u32 = 0;
 }

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -483,3 +483,7 @@ TWAI0:
 _modify:
   IEEE802154:
     baseAddress: 0x600A3000
+
+ASSIST_DEBUG:
+  _include: ../../../common_patches/assist_debug.yaml
+  


### PR DESCRIPTION
As discovered in https://github.com/esp-rs/esp-hal/pull/1961, debug_assist has a typo in a register on C3, C6, and H2. This fixes it.

cc @bugadani 