### PR TITLE
Don't enable xtensa-lx/spin

### DIFF
--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -34,7 +34,7 @@ xtensa-lx = "0.9.0"
 defmt = { version = "0.3.8", optional = true }
 
 [features]
-default = ["xtensa-lx/spin"]
+default = []
 rt = []
 impl-register-debug = []
 defmt = ["dep:defmt"]

--- a/esp32s3/Cargo.toml
+++ b/esp32s3/Cargo.toml
@@ -34,7 +34,7 @@ xtensa-lx = "0.9.0"
 defmt = { version = "0.3.8", optional = true }
 
 [features]
-default = ["xtensa-lx/spin"]
+default = []
 rt = []
 impl-register-debug = []
 defmt = ["dep:defmt"]


### PR DESCRIPTION
Nothing seems to use it and the spinlocking mutex implementation doesn't exactly belong in xtensa-lx so I'm planning to remove it from there.