### PR TITLE
ESP32 I2C: Rename ACK_ERR to NACK

### DIFF
--- a/common_patches/i2c0.yaml
+++ b/common_patches/i2c0.yaml
@@ -33,4 +33,3 @@ COMD%s:
       Stop: [2, STOP opcode]
       End: [4, END opcode]
       Rstart: [6, RSTART opcode]
-      

--- a/esp32/src/i2c0/int_clr.rs
+++ b/esp32/src/i2c0/int_clr.rs
@@ -20,8 +20,8 @@ pub type TRANS_COMPLETE_W<'a, REG> = crate::BitWriter1C<'a, REG>;
 pub type TIME_OUT_W<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `TRANS_START` writer - Set this bit to clear the trans_start_int interrupt."]
 pub type TRANS_START_W<'a, REG> = crate::BitWriter1C<'a, REG>;
-#[doc = "Field `ACK_ERR` writer - Set this bit to clear the ack_err_int interrupt."]
-pub type ACK_ERR_W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `NACK` writer - Set this bit to clear the ack_err_int interrupt."]
+pub type NACK_W<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `RX_REC_FULL` writer - Set this bit to clear the rx_rec_full_int interrupt."]
 pub type RX_REC_FULL_W<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `TX_SEND_EMPTY` writer - Set this bit to clear the tx_send_empty_int interrupt."]
@@ -96,8 +96,8 @@ impl W {
     #[doc = "Bit 10 - Set this bit to clear the ack_err_int interrupt."]
     #[inline(always)]
     #[must_use]
-    pub fn ack_err(&mut self) -> ACK_ERR_W<INT_CLR_SPEC> {
-        ACK_ERR_W::new(self, 10)
+    pub fn nack(&mut self) -> NACK_W<INT_CLR_SPEC> {
+        NACK_W::new(self, 10)
     }
     #[doc = "Bit 11 - Set this bit to clear the rx_rec_full_int interrupt."]
     #[inline(always)]

--- a/esp32/src/i2c0/int_ena.rs
+++ b/esp32/src/i2c0/int_ena.rs
@@ -42,10 +42,10 @@ pub type TIME_OUT_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type TRANS_START_R = crate::BitReader;
 #[doc = "Field `TRANS_START` writer - The enable bit for trans_start_int interrupt."]
 pub type TRANS_START_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `ACK_ERR` reader - The enable bit for ack_err_int interrupt."]
-pub type ACK_ERR_R = crate::BitReader;
-#[doc = "Field `ACK_ERR` writer - The enable bit for ack_err_int interrupt."]
-pub type ACK_ERR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `NACK` reader - The enable bit for ack_err_int interrupt."]
+pub type NACK_R = crate::BitReader;
+#[doc = "Field `NACK` writer - The enable bit for ack_err_int interrupt."]
+pub type NACK_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `RX_REC_FULL` reader - The enable bit for rx_rec_full_int interrupt."]
 pub type RX_REC_FULL_R = crate::BitReader;
 #[doc = "Field `RX_REC_FULL` writer - The enable bit for rx_rec_full_int interrupt."]
@@ -107,8 +107,8 @@ impl R {
     }
     #[doc = "Bit 10 - The enable bit for ack_err_int interrupt."]
     #[inline(always)]
-    pub fn ack_err(&self) -> ACK_ERR_R {
-        ACK_ERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn nack(&self) -> NACK_R {
+        NACK_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - The enable bit for rx_rec_full_int interrupt."]
     #[inline(always)]
@@ -135,7 +135,7 @@ impl core::fmt::Debug for R {
             .field("trans_complete", &self.trans_complete())
             .field("time_out", &self.time_out())
             .field("trans_start", &self.trans_start())
-            .field("ack_err", &self.ack_err())
+            .field("nack", &self.nack())
             .field("rx_rec_full", &self.rx_rec_full())
             .field("tx_send_empty", &self.tx_send_empty())
             .finish()
@@ -205,8 +205,8 @@ impl W {
     #[doc = "Bit 10 - The enable bit for ack_err_int interrupt."]
     #[inline(always)]
     #[must_use]
-    pub fn ack_err(&mut self) -> ACK_ERR_W<INT_ENA_SPEC> {
-        ACK_ERR_W::new(self, 10)
+    pub fn nack(&mut self) -> NACK_W<INT_ENA_SPEC> {
+        NACK_W::new(self, 10)
     }
     #[doc = "Bit 11 - The enable bit for rx_rec_full_int interrupt."]
     #[inline(always)]

--- a/esp32/src/i2c0/int_raw.rs
+++ b/esp32/src/i2c0/int_raw.rs
@@ -20,8 +20,8 @@ pub type TRANS_COMPLETE_R = crate::BitReader;
 pub type TIME_OUT_R = crate::BitReader;
 #[doc = "Field `TRANS_START` reader - The raw interrupt status bit for trans_start_int interrupt. when I2C sends the START bit it will produce trans_start_int interrupt."]
 pub type TRANS_START_R = crate::BitReader;
-#[doc = "Field `ACK_ERR` reader - The raw interrupt status bit for ack_err_int interrupt. when I2C receives a wrong ACK bit it will produce ack_err_int interrupt.."]
-pub type ACK_ERR_R = crate::BitReader;
+#[doc = "Field `NACK` reader - The raw interrupt status bit for ack_err_int interrupt. when I2C receives a wrong ACK bit it will produce ack_err_int interrupt.."]
+pub type NACK_R = crate::BitReader;
 #[doc = "Field `RX_REC_FULL` reader - The raw interrupt status bit for rx_rec_full_int interrupt. when I2C receives more data than nonfifo_rx_thres it will produce rx_rec_full_int interrupt."]
 pub type RX_REC_FULL_R = crate::BitReader;
 #[doc = "Field `TX_SEND_EMPTY` reader - The raw interrupt status bit for tx_send_empty_int interrupt.when I2C sends more data than nonfifo_tx_thres it will produce tx_send_empty_int interrupt.."]
@@ -79,8 +79,8 @@ impl R {
     }
     #[doc = "Bit 10 - The raw interrupt status bit for ack_err_int interrupt. when I2C receives a wrong ACK bit it will produce ack_err_int interrupt.."]
     #[inline(always)]
-    pub fn ack_err(&self) -> ACK_ERR_R {
-        ACK_ERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn nack(&self) -> NACK_R {
+        NACK_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - The raw interrupt status bit for rx_rec_full_int interrupt. when I2C receives more data than nonfifo_rx_thres it will produce rx_rec_full_int interrupt."]
     #[inline(always)]
@@ -107,7 +107,7 @@ impl core::fmt::Debug for R {
             .field("trans_complete", &self.trans_complete())
             .field("time_out", &self.time_out())
             .field("trans_start", &self.trans_start())
-            .field("ack_err", &self.ack_err())
+            .field("nack", &self.nack())
             .field("rx_rec_full", &self.rx_rec_full())
             .field("tx_send_empty", &self.tx_send_empty())
             .finish()

--- a/esp32/src/i2c0/int_st.rs
+++ b/esp32/src/i2c0/int_st.rs
@@ -20,8 +20,8 @@ pub type TRANS_COMPLETE_R = crate::BitReader;
 pub type TIME_OUT_R = crate::BitReader;
 #[doc = "Field `TRANS_START` reader - The masked interrupt status for trans_start_int interrupt."]
 pub type TRANS_START_R = crate::BitReader;
-#[doc = "Field `ACK_ERR` reader - The masked interrupt status for ack_err_int interrupt."]
-pub type ACK_ERR_R = crate::BitReader;
+#[doc = "Field `NACK` reader - The masked interrupt status for ack_err_int interrupt."]
+pub type NACK_R = crate::BitReader;
 #[doc = "Field `RX_REC_FULL` reader - The masked interrupt status for rx_rec_full_int interrupt."]
 pub type RX_REC_FULL_R = crate::BitReader;
 #[doc = "Field `TX_SEND_EMPTY` reader - The masked interrupt status for tx_send_empty_int interrupt."]
@@ -79,8 +79,8 @@ impl R {
     }
     #[doc = "Bit 10 - The masked interrupt status for ack_err_int interrupt."]
     #[inline(always)]
-    pub fn ack_err(&self) -> ACK_ERR_R {
-        ACK_ERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn nack(&self) -> NACK_R {
+        NACK_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - The masked interrupt status for rx_rec_full_int interrupt."]
     #[inline(always)]
@@ -107,7 +107,7 @@ impl core::fmt::Debug for R {
             .field("trans_complete", &self.trans_complete())
             .field("time_out", &self.time_out())
             .field("trans_start", &self.trans_start())
-            .field("ack_err", &self.ack_err())
+            .field("nack", &self.nack())
             .field("rx_rec_full", &self.rx_rec_full())
             .field("tx_send_empty", &self.tx_send_empty())
             .finish()

--- a/esp32/svd/patches/esp32.yaml
+++ b/esp32/svd/patches/esp32.yaml
@@ -4,6 +4,22 @@ I2C0:
   _modify:
     INT_STATUS:
       name: INT_ST
+  INT_ENA:
+    _modify:
+      ACK_ERR_INT_ENA:
+        name: NACK_INT_ENA
+  INT_RAW:
+    _modify:
+      ACK_ERR_INT_RAW:
+        name: NACK_INT_RAW
+  INT_CLR:
+    _modify:
+      ACK_ERR_INT_CLR:
+        name: NACK_INT_CLR
+  INT_ST:
+    _modify:
+      ACK_ERR_INT_ST:
+        name: NACK_INT_ST
   _include:
     - ../../../common_patches/i2c0.yaml
     - ../../../common_patches/i2c_opcode.yaml


### PR DESCRIPTION
Allows cleaning up things like https://github.com/esp-rs/esp-hal/blob/main/esp-hal/src/i2c.rs#L650-L653