### PR TITLE
Remove dependency on xtensa-lx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "linked-hash-map"
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -975,18 +975,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1215,18 +1215,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -30,7 +30,6 @@ test = false
 [dependencies]
 critical-section = { version = "1.1.3", optional = true }
 vcell = "0.1.3"
-xtensa-lx = "0.9.0"
 defmt = { version = "0.3.8", optional = true }
 
 [features]

--- a/esp32s2/Cargo.toml
+++ b/esp32s2/Cargo.toml
@@ -30,7 +30,6 @@ test = false
 [dependencies]
 critical-section = { version = "1.1.3", optional = true }
 vcell = "0.1.3"
-xtensa-lx = "0.9.0"
 defmt = { version = "0.3.8", optional = true }
 
 [features]

--- a/esp32s3/Cargo.toml
+++ b/esp32s3/Cargo.toml
@@ -30,7 +30,6 @@ test = false
 [dependencies]
 critical-section = { version = "1.1.3", optional = true }
 vcell = "0.1.3"
-xtensa-lx = "0.9.0"
 defmt = { version = "0.3.8", optional = true }
 
 [features]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -72,7 +72,7 @@ enum Commands {
 
     /// Generate the specified package(s)
     ///
-    /// Additionally patches the releavant SVD(s) prior to generating the
+    /// Additionally patches the relevant SVD(s) prior to generating the
     /// package(s).
     Generate {
         /// Package(s) to target
@@ -272,22 +272,13 @@ fn build_package(workspace: &Path, chip: &Chip) -> Result<()> {
 
     if target.starts_with("riscv") {
         Command::new("rustup")
-            .args([
-                "target",
-                "add",
-                &target,
-            ])
+            .args(["target", "add", &target])
             .current_dir(&path)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()?;
         Command::new("cargo")
-            .args([
-                &format!("+{channel}"),
-                "build",
-                "--target",
-                &target,
-            ])
+            .args([&format!("+{channel}"), "build", "--target", &target])
             .current_dir(path)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
Draft until https://github.com/rust-embedded/svd2rust/pull/883 is merged and preferably released.