### PR TITLE
Add LP_APM0 for ESP32-H2

### DIFF
--- a/esp32h2/src/lib.rs
+++ b/esp32h2/src/lib.rs
@@ -2939,6 +2939,52 @@ impl core::fmt::Debug for I2C_ANA_MST {
 }
 #[doc = "I2C_ANA_MST Peripheral"]
 pub mod i2c_ana_mst;
+#[doc = "LP_APM0 Peripheral"]
+pub struct LP_APM0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for LP_APM0 {}
+impl LP_APM0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const lp_apm0::RegisterBlock = 0x6009_9800 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const lp_apm0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for LP_APM0 {
+    type Target = lp_apm0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for LP_APM0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LP_APM0").finish()
+    }
+}
+#[doc = "LP_APM0 Peripheral"]
+pub mod lp_apm0;
 #[no_mangle]
 static mut DEVICE_PERIPHERALS: bool = false;
 #[doc = r" All the peripherals."]
@@ -3062,6 +3108,8 @@ pub struct Peripherals {
     pub PLIC_UX: PLIC_UX,
     #[doc = "I2C_ANA_MST"]
     pub I2C_ANA_MST: I2C_ANA_MST,
+    #[doc = "LP_APM0"]
+    pub LP_APM0: LP_APM0,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -3143,6 +3191,7 @@ impl Peripherals {
             PLIC_MX: PLIC_MX::steal(),
             PLIC_UX: PLIC_UX::steal(),
             I2C_ANA_MST: I2C_ANA_MST::steal(),
+            LP_APM0: LP_APM0::steal(),
         }
     }
 }

--- a/esp32h2/src/lp_apm0.rs
+++ b/esp32h2/src/lp_apm0.rs
@@ -1,0 +1,219 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    region_filter_en: REGION_FILTER_EN,
+    region0_addr_start: REGION0_ADDR_START,
+    region0_addr_end: REGION0_ADDR_END,
+    region0_pms_attr: REGION0_PMS_ATTR,
+    region1_addr_start: REGION1_ADDR_START,
+    region1_addr_end: REGION1_ADDR_END,
+    region1_pms_attr: REGION1_PMS_ATTR,
+    region2_addr_start: REGION2_ADDR_START,
+    region2_addr_end: REGION2_ADDR_END,
+    region2_pms_attr: REGION2_PMS_ATTR,
+    region3_addr_start: REGION3_ADDR_START,
+    region3_addr_end: REGION3_ADDR_END,
+    region3_pms_attr: REGION3_PMS_ATTR,
+    _reserved13: [u8; 0x90],
+    func_ctrl: FUNC_CTRL,
+    m0_status: M0_STATUS,
+    m0_status_clr: M0_STATUS_CLR,
+    m0_exception_info0: M0_EXCEPTION_INFO0,
+    m0_exception_info1: M0_EXCEPTION_INFO1,
+    int_en: INT_EN,
+    clock_gate: CLOCK_GATE,
+    _reserved20: [u8; 0x071c],
+    date: DATE,
+}
+impl RegisterBlock {
+    #[doc = "0x00 - Region filter enable register"]
+    #[inline(always)]
+    pub const fn region_filter_en(&self) -> &REGION_FILTER_EN {
+        &self.region_filter_en
+    }
+    #[doc = "0x04 - Region address register"]
+    #[inline(always)]
+    pub const fn region0_addr_start(&self) -> &REGION0_ADDR_START {
+        &self.region0_addr_start
+    }
+    #[doc = "0x08 - Region address register"]
+    #[inline(always)]
+    pub const fn region0_addr_end(&self) -> &REGION0_ADDR_END {
+        &self.region0_addr_end
+    }
+    #[doc = "0x0c - Region access authority attribute register"]
+    #[inline(always)]
+    pub const fn region0_pms_attr(&self) -> &REGION0_PMS_ATTR {
+        &self.region0_pms_attr
+    }
+    #[doc = "0x10 - Region address register"]
+    #[inline(always)]
+    pub const fn region1_addr_start(&self) -> &REGION1_ADDR_START {
+        &self.region1_addr_start
+    }
+    #[doc = "0x14 - Region address register"]
+    #[inline(always)]
+    pub const fn region1_addr_end(&self) -> &REGION1_ADDR_END {
+        &self.region1_addr_end
+    }
+    #[doc = "0x18 - Region access authority attribute register"]
+    #[inline(always)]
+    pub const fn region1_pms_attr(&self) -> &REGION1_PMS_ATTR {
+        &self.region1_pms_attr
+    }
+    #[doc = "0x1c - Region address register"]
+    #[inline(always)]
+    pub const fn region2_addr_start(&self) -> &REGION2_ADDR_START {
+        &self.region2_addr_start
+    }
+    #[doc = "0x20 - Region address register"]
+    #[inline(always)]
+    pub const fn region2_addr_end(&self) -> &REGION2_ADDR_END {
+        &self.region2_addr_end
+    }
+    #[doc = "0x24 - Region access authority attribute register"]
+    #[inline(always)]
+    pub const fn region2_pms_attr(&self) -> &REGION2_PMS_ATTR {
+        &self.region2_pms_attr
+    }
+    #[doc = "0x28 - Region address register"]
+    #[inline(always)]
+    pub const fn region3_addr_start(&self) -> &REGION3_ADDR_START {
+        &self.region3_addr_start
+    }
+    #[doc = "0x2c - Region address register"]
+    #[inline(always)]
+    pub const fn region3_addr_end(&self) -> &REGION3_ADDR_END {
+        &self.region3_addr_end
+    }
+    #[doc = "0x30 - Region access authority attribute register"]
+    #[inline(always)]
+    pub const fn region3_pms_attr(&self) -> &REGION3_PMS_ATTR {
+        &self.region3_pms_attr
+    }
+    #[doc = "0xc4 - PMS function control register"]
+    #[inline(always)]
+    pub const fn func_ctrl(&self) -> &FUNC_CTRL {
+        &self.func_ctrl
+    }
+    #[doc = "0xc8 - M0 status register"]
+    #[inline(always)]
+    pub const fn m0_status(&self) -> &M0_STATUS {
+        &self.m0_status
+    }
+    #[doc = "0xcc - M0 status clear register"]
+    #[inline(always)]
+    pub const fn m0_status_clr(&self) -> &M0_STATUS_CLR {
+        &self.m0_status_clr
+    }
+    #[doc = "0xd0 - M0 exception_info0 register"]
+    #[inline(always)]
+    pub const fn m0_exception_info0(&self) -> &M0_EXCEPTION_INFO0 {
+        &self.m0_exception_info0
+    }
+    #[doc = "0xd4 - M0 exception_info1 register"]
+    #[inline(always)]
+    pub const fn m0_exception_info1(&self) -> &M0_EXCEPTION_INFO1 {
+        &self.m0_exception_info1
+    }
+    #[doc = "0xd8 - APM interrupt enable register"]
+    #[inline(always)]
+    pub const fn int_en(&self) -> &INT_EN {
+        &self.int_en
+    }
+    #[doc = "0xdc - clock gating register"]
+    #[inline(always)]
+    pub const fn clock_gate(&self) -> &CLOCK_GATE {
+        &self.clock_gate
+    }
+    #[doc = "0x7fc - Version register"]
+    #[inline(always)]
+    pub const fn date(&self) -> &DATE {
+        &self.date
+    }
+}
+#[doc = "REGION_FILTER_EN (rw) register accessor: Region filter enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`region_filter_en::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region_filter_en::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region_filter_en`] module"]
+pub type REGION_FILTER_EN = crate::Reg<region_filter_en::REGION_FILTER_EN_SPEC>;
+#[doc = "Region filter enable register"]
+pub mod region_filter_en;
+#[doc = "REGION0_ADDR_START (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_addr_start::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_addr_start::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region0_addr_start`] module"]
+pub type REGION0_ADDR_START = crate::Reg<region0_addr_start::REGION0_ADDR_START_SPEC>;
+#[doc = "Region address register"]
+pub mod region0_addr_start;
+#[doc = "REGION0_ADDR_END (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_addr_end::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_addr_end::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region0_addr_end`] module"]
+pub type REGION0_ADDR_END = crate::Reg<region0_addr_end::REGION0_ADDR_END_SPEC>;
+#[doc = "Region address register"]
+pub mod region0_addr_end;
+#[doc = "REGION0_PMS_ATTR (rw) register accessor: Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_pms_attr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_pms_attr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region0_pms_attr`] module"]
+pub type REGION0_PMS_ATTR = crate::Reg<region0_pms_attr::REGION0_PMS_ATTR_SPEC>;
+#[doc = "Region access authority attribute register"]
+pub mod region0_pms_attr;
+#[doc = "REGION1_ADDR_START (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_addr_start::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_addr_start::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region1_addr_start`] module"]
+pub type REGION1_ADDR_START = crate::Reg<region1_addr_start::REGION1_ADDR_START_SPEC>;
+#[doc = "Region address register"]
+pub mod region1_addr_start;
+#[doc = "REGION1_ADDR_END (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_addr_end::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_addr_end::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region1_addr_end`] module"]
+pub type REGION1_ADDR_END = crate::Reg<region1_addr_end::REGION1_ADDR_END_SPEC>;
+#[doc = "Region address register"]
+pub mod region1_addr_end;
+#[doc = "REGION1_PMS_ATTR (rw) register accessor: Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_pms_attr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_pms_attr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region1_pms_attr`] module"]
+pub type REGION1_PMS_ATTR = crate::Reg<region1_pms_attr::REGION1_PMS_ATTR_SPEC>;
+#[doc = "Region access authority attribute register"]
+pub mod region1_pms_attr;
+#[doc = "REGION2_ADDR_START (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_addr_start::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_addr_start::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region2_addr_start`] module"]
+pub type REGION2_ADDR_START = crate::Reg<region2_addr_start::REGION2_ADDR_START_SPEC>;
+#[doc = "Region address register"]
+pub mod region2_addr_start;
+#[doc = "REGION2_ADDR_END (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_addr_end::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_addr_end::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region2_addr_end`] module"]
+pub type REGION2_ADDR_END = crate::Reg<region2_addr_end::REGION2_ADDR_END_SPEC>;
+#[doc = "Region address register"]
+pub mod region2_addr_end;
+#[doc = "REGION2_PMS_ATTR (rw) register accessor: Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_pms_attr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_pms_attr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region2_pms_attr`] module"]
+pub type REGION2_PMS_ATTR = crate::Reg<region2_pms_attr::REGION2_PMS_ATTR_SPEC>;
+#[doc = "Region access authority attribute register"]
+pub mod region2_pms_attr;
+#[doc = "REGION3_ADDR_START (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_addr_start::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_addr_start::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region3_addr_start`] module"]
+pub type REGION3_ADDR_START = crate::Reg<region3_addr_start::REGION3_ADDR_START_SPEC>;
+#[doc = "Region address register"]
+pub mod region3_addr_start;
+#[doc = "REGION3_ADDR_END (rw) register accessor: Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_addr_end::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_addr_end::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region3_addr_end`] module"]
+pub type REGION3_ADDR_END = crate::Reg<region3_addr_end::REGION3_ADDR_END_SPEC>;
+#[doc = "Region address register"]
+pub mod region3_addr_end;
+#[doc = "REGION3_PMS_ATTR (rw) register accessor: Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_pms_attr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_pms_attr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@region3_pms_attr`] module"]
+pub type REGION3_PMS_ATTR = crate::Reg<region3_pms_attr::REGION3_PMS_ATTR_SPEC>;
+#[doc = "Region access authority attribute register"]
+pub mod region3_pms_attr;
+#[doc = "FUNC_CTRL (rw) register accessor: PMS function control register\n\nYou can [`read`](crate::Reg::read) this register and get [`func_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`func_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@func_ctrl`] module"]
+pub type FUNC_CTRL = crate::Reg<func_ctrl::FUNC_CTRL_SPEC>;
+#[doc = "PMS function control register"]
+pub mod func_ctrl;
+#[doc = "M0_STATUS (r) register accessor: M0 status register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_status::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@m0_status`] module"]
+pub type M0_STATUS = crate::Reg<m0_status::M0_STATUS_SPEC>;
+#[doc = "M0 status register"]
+pub mod m0_status;
+#[doc = "M0_STATUS_CLR (w) register accessor: M0 status clear register\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`m0_status_clr::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@m0_status_clr`] module"]
+pub type M0_STATUS_CLR = crate::Reg<m0_status_clr::M0_STATUS_CLR_SPEC>;
+#[doc = "M0 status clear register"]
+pub mod m0_status_clr;
+#[doc = "M0_EXCEPTION_INFO0 (r) register accessor: M0 exception_info0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_exception_info0::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@m0_exception_info0`] module"]
+pub type M0_EXCEPTION_INFO0 = crate::Reg<m0_exception_info0::M0_EXCEPTION_INFO0_SPEC>;
+#[doc = "M0 exception_info0 register"]
+pub mod m0_exception_info0;
+#[doc = "M0_EXCEPTION_INFO1 (r) register accessor: M0 exception_info1 register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_exception_info1::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@m0_exception_info1`] module"]
+pub type M0_EXCEPTION_INFO1 = crate::Reg<m0_exception_info1::M0_EXCEPTION_INFO1_SPEC>;
+#[doc = "M0 exception_info1 register"]
+pub mod m0_exception_info1;
+#[doc = "INT_EN (rw) register accessor: APM interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`int_en::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`int_en::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@int_en`] module"]
+pub type INT_EN = crate::Reg<int_en::INT_EN_SPEC>;
+#[doc = "APM interrupt enable register"]
+pub mod int_en;
+#[doc = "CLOCK_GATE (rw) register accessor: clock gating register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clock_gate`] module"]
+pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
+#[doc = "clock gating register"]
+pub mod clock_gate;
+#[doc = "DATE (rw) register accessor: Version register\n\nYou can [`read`](crate::Reg::read) this register and get [`date::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`date::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@date`] module"]
+pub type DATE = crate::Reg<date::DATE_SPEC>;
+#[doc = "Version register"]
+pub mod date;

--- a/esp32h2/src/lp_apm0/clock_gate.rs
+++ b/esp32h2/src/lp_apm0/clock_gate.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `CLOCK_GATE` reader"]
+pub type R = crate::R<CLOCK_GATE_SPEC>;
+#[doc = "Register `CLOCK_GATE` writer"]
+pub type W = crate::W<CLOCK_GATE_SPEC>;
+#[doc = "Field `CLK_EN` reader - reg_clk_en"]
+pub type CLK_EN_R = crate::BitReader;
+#[doc = "Field `CLK_EN` writer - reg_clk_en"]
+pub type CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - reg_clk_en"]
+    #[inline(always)]
+    pub fn clk_en(&self) -> CLK_EN_R {
+        CLK_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLOCK_GATE")
+            .field("clk_en", &self.clk_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - reg_clk_en"]
+    #[inline(always)]
+    pub fn clk_en(&mut self) -> CLK_EN_W<CLOCK_GATE_SPEC> {
+        CLK_EN_W::new(self, 0)
+    }
+}
+#[doc = "clock gating register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLOCK_GATE_SPEC;
+impl crate::RegisterSpec for CLOCK_GATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clock_gate::R`](R) reader structure"]
+impl crate::Readable for CLOCK_GATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`clock_gate::W`](W) writer structure"]
+impl crate::Writable for CLOCK_GATE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets CLOCK_GATE to value 0x01"]
+impl crate::Resettable for CLOCK_GATE_SPEC {
+    const RESET_VALUE: u32 = 0x01;
+}

--- a/esp32h2/src/lp_apm0/date.rs
+++ b/esp32h2/src/lp_apm0/date.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `DATE` reader"]
+pub type R = crate::R<DATE_SPEC>;
+#[doc = "Register `DATE` writer"]
+pub type W = crate::W<DATE_SPEC>;
+#[doc = "Field `DATE` reader - reg_date"]
+pub type DATE_R = crate::FieldReader<u32>;
+#[doc = "Field `DATE` writer - reg_date"]
+pub type DATE_W<'a, REG> = crate::FieldWriter<'a, REG, 28, u32>;
+impl R {
+    #[doc = "Bits 0:27 - reg_date"]
+    #[inline(always)]
+    pub fn date(&self) -> DATE_R {
+        DATE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DATE").field("date", &self.date()).finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:27 - reg_date"]
+    #[inline(always)]
+    pub fn date(&mut self) -> DATE_W<DATE_SPEC> {
+        DATE_W::new(self, 0)
+    }
+}
+#[doc = "Version register\n\nYou can [`read`](crate::Reg::read) this register and get [`date::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`date::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct DATE_SPEC;
+impl crate::RegisterSpec for DATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`date::R`](R) reader structure"]
+impl crate::Readable for DATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`date::W`](W) writer structure"]
+impl crate::Writable for DATE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets DATE to value 0x0220_5240"]
+impl crate::Resettable for DATE_SPEC {
+    const RESET_VALUE: u32 = 0x0220_5240;
+}

--- a/esp32h2/src/lp_apm0/func_ctrl.rs
+++ b/esp32h2/src/lp_apm0/func_ctrl.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `FUNC_CTRL` reader"]
+pub type R = crate::R<FUNC_CTRL_SPEC>;
+#[doc = "Register `FUNC_CTRL` writer"]
+pub type W = crate::W<FUNC_CTRL_SPEC>;
+#[doc = "Field `M0_PMS_FUNC_EN` reader - PMS M0 function enable"]
+pub type M0_PMS_FUNC_EN_R = crate::BitReader;
+#[doc = "Field `M0_PMS_FUNC_EN` writer - PMS M0 function enable"]
+pub type M0_PMS_FUNC_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - PMS M0 function enable"]
+    #[inline(always)]
+    pub fn m0_pms_func_en(&self) -> M0_PMS_FUNC_EN_R {
+        M0_PMS_FUNC_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FUNC_CTRL")
+            .field("m0_pms_func_en", &self.m0_pms_func_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PMS M0 function enable"]
+    #[inline(always)]
+    pub fn m0_pms_func_en(&mut self) -> M0_PMS_FUNC_EN_W<FUNC_CTRL_SPEC> {
+        M0_PMS_FUNC_EN_W::new(self, 0)
+    }
+}
+#[doc = "PMS function control register\n\nYou can [`read`](crate::Reg::read) this register and get [`func_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`func_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct FUNC_CTRL_SPEC;
+impl crate::RegisterSpec for FUNC_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`func_ctrl::R`](R) reader structure"]
+impl crate::Readable for FUNC_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`func_ctrl::W`](W) writer structure"]
+impl crate::Writable for FUNC_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets FUNC_CTRL to value 0x01"]
+impl crate::Resettable for FUNC_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x01;
+}

--- a/esp32h2/src/lp_apm0/int_en.rs
+++ b/esp32h2/src/lp_apm0/int_en.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `INT_EN` reader"]
+pub type R = crate::R<INT_EN_SPEC>;
+#[doc = "Register `INT_EN` writer"]
+pub type W = crate::W<INT_EN_SPEC>;
+#[doc = "Field `M0_APM_INT_EN` reader - APM M0 interrupt enable"]
+pub type M0_APM_INT_EN_R = crate::BitReader;
+#[doc = "Field `M0_APM_INT_EN` writer - APM M0 interrupt enable"]
+pub type M0_APM_INT_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - APM M0 interrupt enable"]
+    #[inline(always)]
+    pub fn m0_apm_int_en(&self) -> M0_APM_INT_EN_R {
+        M0_APM_INT_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("INT_EN")
+            .field("m0_apm_int_en", &self.m0_apm_int_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - APM M0 interrupt enable"]
+    #[inline(always)]
+    pub fn m0_apm_int_en(&mut self) -> M0_APM_INT_EN_W<INT_EN_SPEC> {
+        M0_APM_INT_EN_W::new(self, 0)
+    }
+}
+#[doc = "APM interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`int_en::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`int_en::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_EN_SPEC;
+impl crate::RegisterSpec for INT_EN_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`int_en::R`](R) reader structure"]
+impl crate::Readable for INT_EN_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`int_en::W`](W) writer structure"]
+impl crate::Writable for INT_EN_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets INT_EN to value 0"]
+impl crate::Resettable for INT_EN_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/m0_exception_info0.rs
+++ b/esp32h2/src/lp_apm0/m0_exception_info0.rs
@@ -1,0 +1,46 @@
+#[doc = "Register `M0_EXCEPTION_INFO0` reader"]
+pub type R = crate::R<M0_EXCEPTION_INFO0_SPEC>;
+#[doc = "Field `M0_EXCEPTION_REGION` reader - Exception region"]
+pub type M0_EXCEPTION_REGION_R = crate::FieldReader;
+#[doc = "Field `M0_EXCEPTION_MODE` reader - Exception mode"]
+pub type M0_EXCEPTION_MODE_R = crate::FieldReader;
+#[doc = "Field `M0_EXCEPTION_ID` reader - Exception id information"]
+pub type M0_EXCEPTION_ID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - Exception region"]
+    #[inline(always)]
+    pub fn m0_exception_region(&self) -> M0_EXCEPTION_REGION_R {
+        M0_EXCEPTION_REGION_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 16:17 - Exception mode"]
+    #[inline(always)]
+    pub fn m0_exception_mode(&self) -> M0_EXCEPTION_MODE_R {
+        M0_EXCEPTION_MODE_R::new(((self.bits >> 16) & 3) as u8)
+    }
+    #[doc = "Bits 18:22 - Exception id information"]
+    #[inline(always)]
+    pub fn m0_exception_id(&self) -> M0_EXCEPTION_ID_R {
+        M0_EXCEPTION_ID_R::new(((self.bits >> 18) & 0x1f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("M0_EXCEPTION_INFO0")
+            .field("m0_exception_region", &self.m0_exception_region())
+            .field("m0_exception_mode", &self.m0_exception_mode())
+            .field("m0_exception_id", &self.m0_exception_id())
+            .finish()
+    }
+}
+#[doc = "M0 exception_info0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_exception_info0::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct M0_EXCEPTION_INFO0_SPEC;
+impl crate::RegisterSpec for M0_EXCEPTION_INFO0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`m0_exception_info0::R`](R) reader structure"]
+impl crate::Readable for M0_EXCEPTION_INFO0_SPEC {}
+#[doc = "`reset()` method sets M0_EXCEPTION_INFO0 to value 0"]
+impl crate::Resettable for M0_EXCEPTION_INFO0_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/m0_exception_info1.rs
+++ b/esp32h2/src/lp_apm0/m0_exception_info1.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `M0_EXCEPTION_INFO1` reader"]
+pub type R = crate::R<M0_EXCEPTION_INFO1_SPEC>;
+#[doc = "Field `M0_EXCEPTION_ADDR` reader - Exception addr"]
+pub type M0_EXCEPTION_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Exception addr"]
+    #[inline(always)]
+    pub fn m0_exception_addr(&self) -> M0_EXCEPTION_ADDR_R {
+        M0_EXCEPTION_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("M0_EXCEPTION_INFO1")
+            .field("m0_exception_addr", &self.m0_exception_addr())
+            .finish()
+    }
+}
+#[doc = "M0 exception_info1 register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_exception_info1::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct M0_EXCEPTION_INFO1_SPEC;
+impl crate::RegisterSpec for M0_EXCEPTION_INFO1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`m0_exception_info1::R`](R) reader structure"]
+impl crate::Readable for M0_EXCEPTION_INFO1_SPEC {}
+#[doc = "`reset()` method sets M0_EXCEPTION_INFO1 to value 0"]
+impl crate::Resettable for M0_EXCEPTION_INFO1_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/m0_status.rs
+++ b/esp32h2/src/lp_apm0/m0_status.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `M0_STATUS` reader"]
+pub type R = crate::R<M0_STATUS_SPEC>;
+#[doc = "Field `M0_EXCEPTION_STATUS` reader - Exception status"]
+pub type M0_EXCEPTION_STATUS_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:1 - Exception status"]
+    #[inline(always)]
+    pub fn m0_exception_status(&self) -> M0_EXCEPTION_STATUS_R {
+        M0_EXCEPTION_STATUS_R::new((self.bits & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("M0_STATUS")
+            .field("m0_exception_status", &self.m0_exception_status())
+            .finish()
+    }
+}
+#[doc = "M0 status register\n\nYou can [`read`](crate::Reg::read) this register and get [`m0_status::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct M0_STATUS_SPEC;
+impl crate::RegisterSpec for M0_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`m0_status::R`](R) reader structure"]
+impl crate::Readable for M0_STATUS_SPEC {}
+#[doc = "`reset()` method sets M0_STATUS to value 0"]
+impl crate::Resettable for M0_STATUS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/m0_status_clr.rs
+++ b/esp32h2/src/lp_apm0/m0_status_clr.rs
@@ -1,0 +1,32 @@
+#[doc = "Register `M0_STATUS_CLR` writer"]
+pub type W = crate::W<M0_STATUS_CLR_SPEC>;
+#[doc = "Field `M0_REGION_STATUS_CLR` writer - Clear exception status"]
+pub type M0_REGION_STATUS_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<M0_STATUS_CLR_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clear exception status"]
+    #[inline(always)]
+    pub fn m0_region_status_clr(&mut self) -> M0_REGION_STATUS_CLR_W<M0_STATUS_CLR_SPEC> {
+        M0_REGION_STATUS_CLR_W::new(self, 0)
+    }
+}
+#[doc = "M0 status clear register\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`m0_status_clr::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct M0_STATUS_CLR_SPEC;
+impl crate::RegisterSpec for M0_STATUS_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`m0_status_clr::W`](W) writer structure"]
+impl crate::Writable for M0_STATUS_CLR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets M0_STATUS_CLR to value 0"]
+impl crate::Resettable for M0_STATUS_CLR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region0_addr_end.rs
+++ b/esp32h2/src/lp_apm0/region0_addr_end.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION0_ADDR_END` reader"]
+pub type R = crate::R<REGION0_ADDR_END_SPEC>;
+#[doc = "Register `REGION0_ADDR_END` writer"]
+pub type W = crate::W<REGION0_ADDR_END_SPEC>;
+#[doc = "Field `REGION0_ADDR_END` reader - End address of region0"]
+pub type REGION0_ADDR_END_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION0_ADDR_END` writer - End address of region0"]
+pub type REGION0_ADDR_END_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - End address of region0"]
+    #[inline(always)]
+    pub fn region0_addr_end(&self) -> REGION0_ADDR_END_R {
+        REGION0_ADDR_END_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION0_ADDR_END")
+            .field("region0_addr_end", &self.region0_addr_end())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - End address of region0"]
+    #[inline(always)]
+    pub fn region0_addr_end(&mut self) -> REGION0_ADDR_END_W<REGION0_ADDR_END_SPEC> {
+        REGION0_ADDR_END_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_addr_end::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_addr_end::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION0_ADDR_END_SPEC;
+impl crate::RegisterSpec for REGION0_ADDR_END_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region0_addr_end::R`](R) reader structure"]
+impl crate::Readable for REGION0_ADDR_END_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region0_addr_end::W`](W) writer structure"]
+impl crate::Writable for REGION0_ADDR_END_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION0_ADDR_END to value 0xffff_ffff"]
+impl crate::Resettable for REGION0_ADDR_END_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32h2/src/lp_apm0/region0_addr_start.rs
+++ b/esp32h2/src/lp_apm0/region0_addr_start.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION0_ADDR_START` reader"]
+pub type R = crate::R<REGION0_ADDR_START_SPEC>;
+#[doc = "Register `REGION0_ADDR_START` writer"]
+pub type W = crate::W<REGION0_ADDR_START_SPEC>;
+#[doc = "Field `REGION0_ADDR_START` reader - Start address of region0"]
+pub type REGION0_ADDR_START_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION0_ADDR_START` writer - Start address of region0"]
+pub type REGION0_ADDR_START_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Start address of region0"]
+    #[inline(always)]
+    pub fn region0_addr_start(&self) -> REGION0_ADDR_START_R {
+        REGION0_ADDR_START_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION0_ADDR_START")
+            .field("region0_addr_start", &self.region0_addr_start())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Start address of region0"]
+    #[inline(always)]
+    pub fn region0_addr_start(&mut self) -> REGION0_ADDR_START_W<REGION0_ADDR_START_SPEC> {
+        REGION0_ADDR_START_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_addr_start::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_addr_start::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION0_ADDR_START_SPEC;
+impl crate::RegisterSpec for REGION0_ADDR_START_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region0_addr_start::R`](R) reader structure"]
+impl crate::Readable for REGION0_ADDR_START_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region0_addr_start::W`](W) writer structure"]
+impl crate::Writable for REGION0_ADDR_START_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION0_ADDR_START to value 0"]
+impl crate::Resettable for REGION0_ADDR_START_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region0_pms_attr.rs
+++ b/esp32h2/src/lp_apm0/region0_pms_attr.rs
@@ -1,0 +1,167 @@
+#[doc = "Register `REGION0_PMS_ATTR` reader"]
+pub type R = crate::R<REGION0_PMS_ATTR_SPEC>;
+#[doc = "Register `REGION0_PMS_ATTR` writer"]
+pub type W = crate::W<REGION0_PMS_ATTR_SPEC>;
+#[doc = "Field `REGION0_R0_PMS_X` reader - Region execute authority in REE_MODE0"]
+pub type REGION0_R0_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION0_R0_PMS_X` writer - Region execute authority in REE_MODE0"]
+pub type REGION0_R0_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R0_PMS_W` reader - Region write authority in REE_MODE0"]
+pub type REGION0_R0_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION0_R0_PMS_W` writer - Region write authority in REE_MODE0"]
+pub type REGION0_R0_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R0_PMS_R` reader - Region read authority in REE_MODE0"]
+pub type REGION0_R0_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION0_R0_PMS_R` writer - Region read authority in REE_MODE0"]
+pub type REGION0_R0_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R1_PMS_X` reader - Region execute authority in REE_MODE1"]
+pub type REGION0_R1_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION0_R1_PMS_X` writer - Region execute authority in REE_MODE1"]
+pub type REGION0_R1_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R1_PMS_W` reader - Region write authority in REE_MODE1"]
+pub type REGION0_R1_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION0_R1_PMS_W` writer - Region write authority in REE_MODE1"]
+pub type REGION0_R1_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R1_PMS_R` reader - Region read authority in REE_MODE1"]
+pub type REGION0_R1_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION0_R1_PMS_R` writer - Region read authority in REE_MODE1"]
+pub type REGION0_R1_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R2_PMS_X` reader - Region execute authority in REE_MODE2"]
+pub type REGION0_R2_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION0_R2_PMS_X` writer - Region execute authority in REE_MODE2"]
+pub type REGION0_R2_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R2_PMS_W` reader - Region write authority in REE_MODE2"]
+pub type REGION0_R2_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION0_R2_PMS_W` writer - Region write authority in REE_MODE2"]
+pub type REGION0_R2_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION0_R2_PMS_R` reader - Region read authority in REE_MODE2"]
+pub type REGION0_R2_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION0_R2_PMS_R` writer - Region read authority in REE_MODE2"]
+pub type REGION0_R2_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_x(&self) -> REGION0_R0_PMS_X_R {
+        REGION0_R0_PMS_X_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_w(&self) -> REGION0_R0_PMS_W_R {
+        REGION0_R0_PMS_W_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_r(&self) -> REGION0_R0_PMS_R_R {
+        REGION0_R0_PMS_R_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_x(&self) -> REGION0_R1_PMS_X_R {
+        REGION0_R1_PMS_X_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_w(&self) -> REGION0_R1_PMS_W_R {
+        REGION0_R1_PMS_W_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_r(&self) -> REGION0_R1_PMS_R_R {
+        REGION0_R1_PMS_R_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_x(&self) -> REGION0_R2_PMS_X_R {
+        REGION0_R2_PMS_X_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_w(&self) -> REGION0_R2_PMS_W_R {
+        REGION0_R2_PMS_W_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_r(&self) -> REGION0_R2_PMS_R_R {
+        REGION0_R2_PMS_R_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION0_PMS_ATTR")
+            .field("region0_r0_pms_x", &self.region0_r0_pms_x())
+            .field("region0_r0_pms_w", &self.region0_r0_pms_w())
+            .field("region0_r0_pms_r", &self.region0_r0_pms_r())
+            .field("region0_r1_pms_x", &self.region0_r1_pms_x())
+            .field("region0_r1_pms_w", &self.region0_r1_pms_w())
+            .field("region0_r1_pms_r", &self.region0_r1_pms_r())
+            .field("region0_r2_pms_x", &self.region0_r2_pms_x())
+            .field("region0_r2_pms_w", &self.region0_r2_pms_w())
+            .field("region0_r2_pms_r", &self.region0_r2_pms_r())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_x(&mut self) -> REGION0_R0_PMS_X_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R0_PMS_X_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_w(&mut self) -> REGION0_R0_PMS_W_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R0_PMS_W_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region0_r0_pms_r(&mut self) -> REGION0_R0_PMS_R_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R0_PMS_R_W::new(self, 2)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_x(&mut self) -> REGION0_R1_PMS_X_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R1_PMS_X_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_w(&mut self) -> REGION0_R1_PMS_W_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R1_PMS_W_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region0_r1_pms_r(&mut self) -> REGION0_R1_PMS_R_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R1_PMS_R_W::new(self, 6)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_x(&mut self) -> REGION0_R2_PMS_X_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R2_PMS_X_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_w(&mut self) -> REGION0_R2_PMS_W_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R2_PMS_W_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region0_r2_pms_r(&mut self) -> REGION0_R2_PMS_R_W<REGION0_PMS_ATTR_SPEC> {
+        REGION0_R2_PMS_R_W::new(self, 10)
+    }
+}
+#[doc = "Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region0_pms_attr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region0_pms_attr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION0_PMS_ATTR_SPEC;
+impl crate::RegisterSpec for REGION0_PMS_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region0_pms_attr::R`](R) reader structure"]
+impl crate::Readable for REGION0_PMS_ATTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region0_pms_attr::W`](W) writer structure"]
+impl crate::Writable for REGION0_PMS_ATTR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION0_PMS_ATTR to value 0"]
+impl crate::Resettable for REGION0_PMS_ATTR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region1_addr_end.rs
+++ b/esp32h2/src/lp_apm0/region1_addr_end.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION1_ADDR_END` reader"]
+pub type R = crate::R<REGION1_ADDR_END_SPEC>;
+#[doc = "Register `REGION1_ADDR_END` writer"]
+pub type W = crate::W<REGION1_ADDR_END_SPEC>;
+#[doc = "Field `REGION1_ADDR_END` reader - End address of region1"]
+pub type REGION1_ADDR_END_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION1_ADDR_END` writer - End address of region1"]
+pub type REGION1_ADDR_END_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - End address of region1"]
+    #[inline(always)]
+    pub fn region1_addr_end(&self) -> REGION1_ADDR_END_R {
+        REGION1_ADDR_END_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION1_ADDR_END")
+            .field("region1_addr_end", &self.region1_addr_end())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - End address of region1"]
+    #[inline(always)]
+    pub fn region1_addr_end(&mut self) -> REGION1_ADDR_END_W<REGION1_ADDR_END_SPEC> {
+        REGION1_ADDR_END_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_addr_end::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_addr_end::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION1_ADDR_END_SPEC;
+impl crate::RegisterSpec for REGION1_ADDR_END_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region1_addr_end::R`](R) reader structure"]
+impl crate::Readable for REGION1_ADDR_END_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region1_addr_end::W`](W) writer structure"]
+impl crate::Writable for REGION1_ADDR_END_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION1_ADDR_END to value 0xffff_ffff"]
+impl crate::Resettable for REGION1_ADDR_END_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32h2/src/lp_apm0/region1_addr_start.rs
+++ b/esp32h2/src/lp_apm0/region1_addr_start.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION1_ADDR_START` reader"]
+pub type R = crate::R<REGION1_ADDR_START_SPEC>;
+#[doc = "Register `REGION1_ADDR_START` writer"]
+pub type W = crate::W<REGION1_ADDR_START_SPEC>;
+#[doc = "Field `REGION1_ADDR_START` reader - Start address of region1"]
+pub type REGION1_ADDR_START_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION1_ADDR_START` writer - Start address of region1"]
+pub type REGION1_ADDR_START_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Start address of region1"]
+    #[inline(always)]
+    pub fn region1_addr_start(&self) -> REGION1_ADDR_START_R {
+        REGION1_ADDR_START_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION1_ADDR_START")
+            .field("region1_addr_start", &self.region1_addr_start())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Start address of region1"]
+    #[inline(always)]
+    pub fn region1_addr_start(&mut self) -> REGION1_ADDR_START_W<REGION1_ADDR_START_SPEC> {
+        REGION1_ADDR_START_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_addr_start::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_addr_start::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION1_ADDR_START_SPEC;
+impl crate::RegisterSpec for REGION1_ADDR_START_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region1_addr_start::R`](R) reader structure"]
+impl crate::Readable for REGION1_ADDR_START_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region1_addr_start::W`](W) writer structure"]
+impl crate::Writable for REGION1_ADDR_START_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION1_ADDR_START to value 0"]
+impl crate::Resettable for REGION1_ADDR_START_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region1_pms_attr.rs
+++ b/esp32h2/src/lp_apm0/region1_pms_attr.rs
@@ -1,0 +1,167 @@
+#[doc = "Register `REGION1_PMS_ATTR` reader"]
+pub type R = crate::R<REGION1_PMS_ATTR_SPEC>;
+#[doc = "Register `REGION1_PMS_ATTR` writer"]
+pub type W = crate::W<REGION1_PMS_ATTR_SPEC>;
+#[doc = "Field `REGION1_R0_PMS_X` reader - Region execute authority in REE_MODE0"]
+pub type REGION1_R0_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION1_R0_PMS_X` writer - Region execute authority in REE_MODE0"]
+pub type REGION1_R0_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R0_PMS_W` reader - Region write authority in REE_MODE0"]
+pub type REGION1_R0_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION1_R0_PMS_W` writer - Region write authority in REE_MODE0"]
+pub type REGION1_R0_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R0_PMS_R` reader - Region read authority in REE_MODE0"]
+pub type REGION1_R0_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION1_R0_PMS_R` writer - Region read authority in REE_MODE0"]
+pub type REGION1_R0_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R1_PMS_X` reader - Region execute authority in REE_MODE1"]
+pub type REGION1_R1_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION1_R1_PMS_X` writer - Region execute authority in REE_MODE1"]
+pub type REGION1_R1_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R1_PMS_W` reader - Region write authority in REE_MODE1"]
+pub type REGION1_R1_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION1_R1_PMS_W` writer - Region write authority in REE_MODE1"]
+pub type REGION1_R1_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R1_PMS_R` reader - Region read authority in REE_MODE1"]
+pub type REGION1_R1_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION1_R1_PMS_R` writer - Region read authority in REE_MODE1"]
+pub type REGION1_R1_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R2_PMS_X` reader - Region execute authority in REE_MODE2"]
+pub type REGION1_R2_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION1_R2_PMS_X` writer - Region execute authority in REE_MODE2"]
+pub type REGION1_R2_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R2_PMS_W` reader - Region write authority in REE_MODE2"]
+pub type REGION1_R2_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION1_R2_PMS_W` writer - Region write authority in REE_MODE2"]
+pub type REGION1_R2_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION1_R2_PMS_R` reader - Region read authority in REE_MODE2"]
+pub type REGION1_R2_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION1_R2_PMS_R` writer - Region read authority in REE_MODE2"]
+pub type REGION1_R2_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_x(&self) -> REGION1_R0_PMS_X_R {
+        REGION1_R0_PMS_X_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_w(&self) -> REGION1_R0_PMS_W_R {
+        REGION1_R0_PMS_W_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_r(&self) -> REGION1_R0_PMS_R_R {
+        REGION1_R0_PMS_R_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_x(&self) -> REGION1_R1_PMS_X_R {
+        REGION1_R1_PMS_X_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_w(&self) -> REGION1_R1_PMS_W_R {
+        REGION1_R1_PMS_W_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_r(&self) -> REGION1_R1_PMS_R_R {
+        REGION1_R1_PMS_R_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_x(&self) -> REGION1_R2_PMS_X_R {
+        REGION1_R2_PMS_X_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_w(&self) -> REGION1_R2_PMS_W_R {
+        REGION1_R2_PMS_W_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_r(&self) -> REGION1_R2_PMS_R_R {
+        REGION1_R2_PMS_R_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION1_PMS_ATTR")
+            .field("region1_r0_pms_x", &self.region1_r0_pms_x())
+            .field("region1_r0_pms_w", &self.region1_r0_pms_w())
+            .field("region1_r0_pms_r", &self.region1_r0_pms_r())
+            .field("region1_r1_pms_x", &self.region1_r1_pms_x())
+            .field("region1_r1_pms_w", &self.region1_r1_pms_w())
+            .field("region1_r1_pms_r", &self.region1_r1_pms_r())
+            .field("region1_r2_pms_x", &self.region1_r2_pms_x())
+            .field("region1_r2_pms_w", &self.region1_r2_pms_w())
+            .field("region1_r2_pms_r", &self.region1_r2_pms_r())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_x(&mut self) -> REGION1_R0_PMS_X_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R0_PMS_X_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_w(&mut self) -> REGION1_R0_PMS_W_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R0_PMS_W_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region1_r0_pms_r(&mut self) -> REGION1_R0_PMS_R_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R0_PMS_R_W::new(self, 2)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_x(&mut self) -> REGION1_R1_PMS_X_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R1_PMS_X_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_w(&mut self) -> REGION1_R1_PMS_W_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R1_PMS_W_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region1_r1_pms_r(&mut self) -> REGION1_R1_PMS_R_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R1_PMS_R_W::new(self, 6)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_x(&mut self) -> REGION1_R2_PMS_X_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R2_PMS_X_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_w(&mut self) -> REGION1_R2_PMS_W_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R2_PMS_W_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region1_r2_pms_r(&mut self) -> REGION1_R2_PMS_R_W<REGION1_PMS_ATTR_SPEC> {
+        REGION1_R2_PMS_R_W::new(self, 10)
+    }
+}
+#[doc = "Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region1_pms_attr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region1_pms_attr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION1_PMS_ATTR_SPEC;
+impl crate::RegisterSpec for REGION1_PMS_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region1_pms_attr::R`](R) reader structure"]
+impl crate::Readable for REGION1_PMS_ATTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region1_pms_attr::W`](W) writer structure"]
+impl crate::Writable for REGION1_PMS_ATTR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION1_PMS_ATTR to value 0"]
+impl crate::Resettable for REGION1_PMS_ATTR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region2_addr_end.rs
+++ b/esp32h2/src/lp_apm0/region2_addr_end.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION2_ADDR_END` reader"]
+pub type R = crate::R<REGION2_ADDR_END_SPEC>;
+#[doc = "Register `REGION2_ADDR_END` writer"]
+pub type W = crate::W<REGION2_ADDR_END_SPEC>;
+#[doc = "Field `REGION2_ADDR_END` reader - End address of region2"]
+pub type REGION2_ADDR_END_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION2_ADDR_END` writer - End address of region2"]
+pub type REGION2_ADDR_END_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - End address of region2"]
+    #[inline(always)]
+    pub fn region2_addr_end(&self) -> REGION2_ADDR_END_R {
+        REGION2_ADDR_END_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION2_ADDR_END")
+            .field("region2_addr_end", &self.region2_addr_end())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - End address of region2"]
+    #[inline(always)]
+    pub fn region2_addr_end(&mut self) -> REGION2_ADDR_END_W<REGION2_ADDR_END_SPEC> {
+        REGION2_ADDR_END_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_addr_end::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_addr_end::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION2_ADDR_END_SPEC;
+impl crate::RegisterSpec for REGION2_ADDR_END_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region2_addr_end::R`](R) reader structure"]
+impl crate::Readable for REGION2_ADDR_END_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region2_addr_end::W`](W) writer structure"]
+impl crate::Writable for REGION2_ADDR_END_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION2_ADDR_END to value 0xffff_ffff"]
+impl crate::Resettable for REGION2_ADDR_END_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32h2/src/lp_apm0/region2_addr_start.rs
+++ b/esp32h2/src/lp_apm0/region2_addr_start.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION2_ADDR_START` reader"]
+pub type R = crate::R<REGION2_ADDR_START_SPEC>;
+#[doc = "Register `REGION2_ADDR_START` writer"]
+pub type W = crate::W<REGION2_ADDR_START_SPEC>;
+#[doc = "Field `REGION2_ADDR_START` reader - Start address of region2"]
+pub type REGION2_ADDR_START_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION2_ADDR_START` writer - Start address of region2"]
+pub type REGION2_ADDR_START_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Start address of region2"]
+    #[inline(always)]
+    pub fn region2_addr_start(&self) -> REGION2_ADDR_START_R {
+        REGION2_ADDR_START_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION2_ADDR_START")
+            .field("region2_addr_start", &self.region2_addr_start())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Start address of region2"]
+    #[inline(always)]
+    pub fn region2_addr_start(&mut self) -> REGION2_ADDR_START_W<REGION2_ADDR_START_SPEC> {
+        REGION2_ADDR_START_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_addr_start::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_addr_start::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION2_ADDR_START_SPEC;
+impl crate::RegisterSpec for REGION2_ADDR_START_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region2_addr_start::R`](R) reader structure"]
+impl crate::Readable for REGION2_ADDR_START_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region2_addr_start::W`](W) writer structure"]
+impl crate::Writable for REGION2_ADDR_START_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION2_ADDR_START to value 0"]
+impl crate::Resettable for REGION2_ADDR_START_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region2_pms_attr.rs
+++ b/esp32h2/src/lp_apm0/region2_pms_attr.rs
@@ -1,0 +1,167 @@
+#[doc = "Register `REGION2_PMS_ATTR` reader"]
+pub type R = crate::R<REGION2_PMS_ATTR_SPEC>;
+#[doc = "Register `REGION2_PMS_ATTR` writer"]
+pub type W = crate::W<REGION2_PMS_ATTR_SPEC>;
+#[doc = "Field `REGION2_R0_PMS_X` reader - Region execute authority in REE_MODE0"]
+pub type REGION2_R0_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION2_R0_PMS_X` writer - Region execute authority in REE_MODE0"]
+pub type REGION2_R0_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R0_PMS_W` reader - Region write authority in REE_MODE0"]
+pub type REGION2_R0_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION2_R0_PMS_W` writer - Region write authority in REE_MODE0"]
+pub type REGION2_R0_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R0_PMS_R` reader - Region read authority in REE_MODE0"]
+pub type REGION2_R0_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION2_R0_PMS_R` writer - Region read authority in REE_MODE0"]
+pub type REGION2_R0_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R1_PMS_X` reader - Region execute authority in REE_MODE1"]
+pub type REGION2_R1_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION2_R1_PMS_X` writer - Region execute authority in REE_MODE1"]
+pub type REGION2_R1_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R1_PMS_W` reader - Region write authority in REE_MODE1"]
+pub type REGION2_R1_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION2_R1_PMS_W` writer - Region write authority in REE_MODE1"]
+pub type REGION2_R1_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R1_PMS_R` reader - Region read authority in REE_MODE1"]
+pub type REGION2_R1_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION2_R1_PMS_R` writer - Region read authority in REE_MODE1"]
+pub type REGION2_R1_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R2_PMS_X` reader - Region execute authority in REE_MODE2"]
+pub type REGION2_R2_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION2_R2_PMS_X` writer - Region execute authority in REE_MODE2"]
+pub type REGION2_R2_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R2_PMS_W` reader - Region write authority in REE_MODE2"]
+pub type REGION2_R2_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION2_R2_PMS_W` writer - Region write authority in REE_MODE2"]
+pub type REGION2_R2_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION2_R2_PMS_R` reader - Region read authority in REE_MODE2"]
+pub type REGION2_R2_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION2_R2_PMS_R` writer - Region read authority in REE_MODE2"]
+pub type REGION2_R2_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_x(&self) -> REGION2_R0_PMS_X_R {
+        REGION2_R0_PMS_X_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_w(&self) -> REGION2_R0_PMS_W_R {
+        REGION2_R0_PMS_W_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_r(&self) -> REGION2_R0_PMS_R_R {
+        REGION2_R0_PMS_R_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_x(&self) -> REGION2_R1_PMS_X_R {
+        REGION2_R1_PMS_X_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_w(&self) -> REGION2_R1_PMS_W_R {
+        REGION2_R1_PMS_W_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_r(&self) -> REGION2_R1_PMS_R_R {
+        REGION2_R1_PMS_R_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_x(&self) -> REGION2_R2_PMS_X_R {
+        REGION2_R2_PMS_X_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_w(&self) -> REGION2_R2_PMS_W_R {
+        REGION2_R2_PMS_W_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_r(&self) -> REGION2_R2_PMS_R_R {
+        REGION2_R2_PMS_R_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION2_PMS_ATTR")
+            .field("region2_r0_pms_x", &self.region2_r0_pms_x())
+            .field("region2_r0_pms_w", &self.region2_r0_pms_w())
+            .field("region2_r0_pms_r", &self.region2_r0_pms_r())
+            .field("region2_r1_pms_x", &self.region2_r1_pms_x())
+            .field("region2_r1_pms_w", &self.region2_r1_pms_w())
+            .field("region2_r1_pms_r", &self.region2_r1_pms_r())
+            .field("region2_r2_pms_x", &self.region2_r2_pms_x())
+            .field("region2_r2_pms_w", &self.region2_r2_pms_w())
+            .field("region2_r2_pms_r", &self.region2_r2_pms_r())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_x(&mut self) -> REGION2_R0_PMS_X_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R0_PMS_X_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_w(&mut self) -> REGION2_R0_PMS_W_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R0_PMS_W_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region2_r0_pms_r(&mut self) -> REGION2_R0_PMS_R_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R0_PMS_R_W::new(self, 2)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_x(&mut self) -> REGION2_R1_PMS_X_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R1_PMS_X_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_w(&mut self) -> REGION2_R1_PMS_W_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R1_PMS_W_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region2_r1_pms_r(&mut self) -> REGION2_R1_PMS_R_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R1_PMS_R_W::new(self, 6)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_x(&mut self) -> REGION2_R2_PMS_X_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R2_PMS_X_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_w(&mut self) -> REGION2_R2_PMS_W_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R2_PMS_W_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region2_r2_pms_r(&mut self) -> REGION2_R2_PMS_R_W<REGION2_PMS_ATTR_SPEC> {
+        REGION2_R2_PMS_R_W::new(self, 10)
+    }
+}
+#[doc = "Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region2_pms_attr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region2_pms_attr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION2_PMS_ATTR_SPEC;
+impl crate::RegisterSpec for REGION2_PMS_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region2_pms_attr::R`](R) reader structure"]
+impl crate::Readable for REGION2_PMS_ATTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region2_pms_attr::W`](W) writer structure"]
+impl crate::Writable for REGION2_PMS_ATTR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION2_PMS_ATTR to value 0"]
+impl crate::Resettable for REGION2_PMS_ATTR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region3_addr_end.rs
+++ b/esp32h2/src/lp_apm0/region3_addr_end.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION3_ADDR_END` reader"]
+pub type R = crate::R<REGION3_ADDR_END_SPEC>;
+#[doc = "Register `REGION3_ADDR_END` writer"]
+pub type W = crate::W<REGION3_ADDR_END_SPEC>;
+#[doc = "Field `REGION3_ADDR_END` reader - End address of region3"]
+pub type REGION3_ADDR_END_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION3_ADDR_END` writer - End address of region3"]
+pub type REGION3_ADDR_END_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - End address of region3"]
+    #[inline(always)]
+    pub fn region3_addr_end(&self) -> REGION3_ADDR_END_R {
+        REGION3_ADDR_END_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION3_ADDR_END")
+            .field("region3_addr_end", &self.region3_addr_end())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - End address of region3"]
+    #[inline(always)]
+    pub fn region3_addr_end(&mut self) -> REGION3_ADDR_END_W<REGION3_ADDR_END_SPEC> {
+        REGION3_ADDR_END_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_addr_end::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_addr_end::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION3_ADDR_END_SPEC;
+impl crate::RegisterSpec for REGION3_ADDR_END_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region3_addr_end::R`](R) reader structure"]
+impl crate::Readable for REGION3_ADDR_END_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region3_addr_end::W`](W) writer structure"]
+impl crate::Writable for REGION3_ADDR_END_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION3_ADDR_END to value 0xffff_ffff"]
+impl crate::Resettable for REGION3_ADDR_END_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32h2/src/lp_apm0/region3_addr_start.rs
+++ b/esp32h2/src/lp_apm0/region3_addr_start.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION3_ADDR_START` reader"]
+pub type R = crate::R<REGION3_ADDR_START_SPEC>;
+#[doc = "Register `REGION3_ADDR_START` writer"]
+pub type W = crate::W<REGION3_ADDR_START_SPEC>;
+#[doc = "Field `REGION3_ADDR_START` reader - Start address of region3"]
+pub type REGION3_ADDR_START_R = crate::FieldReader<u32>;
+#[doc = "Field `REGION3_ADDR_START` writer - Start address of region3"]
+pub type REGION3_ADDR_START_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Start address of region3"]
+    #[inline(always)]
+    pub fn region3_addr_start(&self) -> REGION3_ADDR_START_R {
+        REGION3_ADDR_START_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION3_ADDR_START")
+            .field("region3_addr_start", &self.region3_addr_start())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Start address of region3"]
+    #[inline(always)]
+    pub fn region3_addr_start(&mut self) -> REGION3_ADDR_START_W<REGION3_ADDR_START_SPEC> {
+        REGION3_ADDR_START_W::new(self, 0)
+    }
+}
+#[doc = "Region address register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_addr_start::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_addr_start::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION3_ADDR_START_SPEC;
+impl crate::RegisterSpec for REGION3_ADDR_START_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region3_addr_start::R`](R) reader structure"]
+impl crate::Readable for REGION3_ADDR_START_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region3_addr_start::W`](W) writer structure"]
+impl crate::Writable for REGION3_ADDR_START_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION3_ADDR_START to value 0"]
+impl crate::Resettable for REGION3_ADDR_START_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region3_pms_attr.rs
+++ b/esp32h2/src/lp_apm0/region3_pms_attr.rs
@@ -1,0 +1,167 @@
+#[doc = "Register `REGION3_PMS_ATTR` reader"]
+pub type R = crate::R<REGION3_PMS_ATTR_SPEC>;
+#[doc = "Register `REGION3_PMS_ATTR` writer"]
+pub type W = crate::W<REGION3_PMS_ATTR_SPEC>;
+#[doc = "Field `REGION3_R0_PMS_X` reader - Region execute authority in REE_MODE0"]
+pub type REGION3_R0_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION3_R0_PMS_X` writer - Region execute authority in REE_MODE0"]
+pub type REGION3_R0_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R0_PMS_W` reader - Region write authority in REE_MODE0"]
+pub type REGION3_R0_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION3_R0_PMS_W` writer - Region write authority in REE_MODE0"]
+pub type REGION3_R0_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R0_PMS_R` reader - Region read authority in REE_MODE0"]
+pub type REGION3_R0_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION3_R0_PMS_R` writer - Region read authority in REE_MODE0"]
+pub type REGION3_R0_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R1_PMS_X` reader - Region execute authority in REE_MODE1"]
+pub type REGION3_R1_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION3_R1_PMS_X` writer - Region execute authority in REE_MODE1"]
+pub type REGION3_R1_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R1_PMS_W` reader - Region write authority in REE_MODE1"]
+pub type REGION3_R1_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION3_R1_PMS_W` writer - Region write authority in REE_MODE1"]
+pub type REGION3_R1_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R1_PMS_R` reader - Region read authority in REE_MODE1"]
+pub type REGION3_R1_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION3_R1_PMS_R` writer - Region read authority in REE_MODE1"]
+pub type REGION3_R1_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R2_PMS_X` reader - Region execute authority in REE_MODE2"]
+pub type REGION3_R2_PMS_X_R = crate::BitReader;
+#[doc = "Field `REGION3_R2_PMS_X` writer - Region execute authority in REE_MODE2"]
+pub type REGION3_R2_PMS_X_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R2_PMS_W` reader - Region write authority in REE_MODE2"]
+pub type REGION3_R2_PMS_W_R = crate::BitReader;
+#[doc = "Field `REGION3_R2_PMS_W` writer - Region write authority in REE_MODE2"]
+pub type REGION3_R2_PMS_W_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `REGION3_R2_PMS_R` reader - Region read authority in REE_MODE2"]
+pub type REGION3_R2_PMS_R_R = crate::BitReader;
+#[doc = "Field `REGION3_R2_PMS_R` writer - Region read authority in REE_MODE2"]
+pub type REGION3_R2_PMS_R_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_x(&self) -> REGION3_R0_PMS_X_R {
+        REGION3_R0_PMS_X_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_w(&self) -> REGION3_R0_PMS_W_R {
+        REGION3_R0_PMS_W_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_r(&self) -> REGION3_R0_PMS_R_R {
+        REGION3_R0_PMS_R_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_x(&self) -> REGION3_R1_PMS_X_R {
+        REGION3_R1_PMS_X_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_w(&self) -> REGION3_R1_PMS_W_R {
+        REGION3_R1_PMS_W_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_r(&self) -> REGION3_R1_PMS_R_R {
+        REGION3_R1_PMS_R_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_x(&self) -> REGION3_R2_PMS_X_R {
+        REGION3_R2_PMS_X_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_w(&self) -> REGION3_R2_PMS_W_R {
+        REGION3_R2_PMS_W_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_r(&self) -> REGION3_R2_PMS_R_R {
+        REGION3_R2_PMS_R_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION3_PMS_ATTR")
+            .field("region3_r0_pms_x", &self.region3_r0_pms_x())
+            .field("region3_r0_pms_w", &self.region3_r0_pms_w())
+            .field("region3_r0_pms_r", &self.region3_r0_pms_r())
+            .field("region3_r1_pms_x", &self.region3_r1_pms_x())
+            .field("region3_r1_pms_w", &self.region3_r1_pms_w())
+            .field("region3_r1_pms_r", &self.region3_r1_pms_r())
+            .field("region3_r2_pms_x", &self.region3_r2_pms_x())
+            .field("region3_r2_pms_w", &self.region3_r2_pms_w())
+            .field("region3_r2_pms_r", &self.region3_r2_pms_r())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Region execute authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_x(&mut self) -> REGION3_R0_PMS_X_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R0_PMS_X_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Region write authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_w(&mut self) -> REGION3_R0_PMS_W_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R0_PMS_W_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Region read authority in REE_MODE0"]
+    #[inline(always)]
+    pub fn region3_r0_pms_r(&mut self) -> REGION3_R0_PMS_R_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R0_PMS_R_W::new(self, 2)
+    }
+    #[doc = "Bit 4 - Region execute authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_x(&mut self) -> REGION3_R1_PMS_X_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R1_PMS_X_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Region write authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_w(&mut self) -> REGION3_R1_PMS_W_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R1_PMS_W_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Region read authority in REE_MODE1"]
+    #[inline(always)]
+    pub fn region3_r1_pms_r(&mut self) -> REGION3_R1_PMS_R_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R1_PMS_R_W::new(self, 6)
+    }
+    #[doc = "Bit 8 - Region execute authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_x(&mut self) -> REGION3_R2_PMS_X_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R2_PMS_X_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Region write authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_w(&mut self) -> REGION3_R2_PMS_W_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R2_PMS_W_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Region read authority in REE_MODE2"]
+    #[inline(always)]
+    pub fn region3_r2_pms_r(&mut self) -> REGION3_R2_PMS_R_W<REGION3_PMS_ATTR_SPEC> {
+        REGION3_R2_PMS_R_W::new(self, 10)
+    }
+}
+#[doc = "Region access authority attribute register\n\nYou can [`read`](crate::Reg::read) this register and get [`region3_pms_attr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region3_pms_attr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION3_PMS_ATTR_SPEC;
+impl crate::RegisterSpec for REGION3_PMS_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region3_pms_attr::R`](R) reader structure"]
+impl crate::Readable for REGION3_PMS_ATTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region3_pms_attr::W`](W) writer structure"]
+impl crate::Writable for REGION3_PMS_ATTR_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION3_PMS_ATTR to value 0"]
+impl crate::Resettable for REGION3_PMS_ATTR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32h2/src/lp_apm0/region_filter_en.rs
+++ b/esp32h2/src/lp_apm0/region_filter_en.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `REGION_FILTER_EN` reader"]
+pub type R = crate::R<REGION_FILTER_EN_SPEC>;
+#[doc = "Register `REGION_FILTER_EN` writer"]
+pub type W = crate::W<REGION_FILTER_EN_SPEC>;
+#[doc = "Field `REGION_FILTER_EN` reader - Region filter enable"]
+pub type REGION_FILTER_EN_R = crate::FieldReader;
+#[doc = "Field `REGION_FILTER_EN` writer - Region filter enable"]
+pub type REGION_FILTER_EN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 0:3 - Region filter enable"]
+    #[inline(always)]
+    pub fn region_filter_en(&self) -> REGION_FILTER_EN_R {
+        REGION_FILTER_EN_R::new((self.bits & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REGION_FILTER_EN")
+            .field("region_filter_en", &self.region_filter_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Region filter enable"]
+    #[inline(always)]
+    pub fn region_filter_en(&mut self) -> REGION_FILTER_EN_W<REGION_FILTER_EN_SPEC> {
+        REGION_FILTER_EN_W::new(self, 0)
+    }
+}
+#[doc = "Region filter enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`region_filter_en::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`region_filter_en::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REGION_FILTER_EN_SPEC;
+impl crate::RegisterSpec for REGION_FILTER_EN_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`region_filter_en::R`](R) reader structure"]
+impl crate::Readable for REGION_FILTER_EN_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`region_filter_en::W`](W) writer structure"]
+impl crate::Writable for REGION_FILTER_EN_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets REGION_FILTER_EN to value 0x01"]
+impl crate::Resettable for REGION_FILTER_EN_SPEC {
+    const RESET_VALUE: u32 = 0x01;
+}

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -604,6 +604,403 @@ _add:
             description: "?"
             bitOffset: 28
             bitWidth: 1
+  LP_APM0:
+    description: LP_APM0 Peripheral
+    groupName: LP_APM0
+    baseAddress: 0x60099800
+    addressBlocks:
+      - offset: 0x0
+        size: 0x54
+        usage: registers
+    registers:
+      REGION_FILTER_EN:
+        description: Region filter enable register
+        addressOffset: 0x0
+        size: 0x20
+        resetValue: 0x00000001
+        fields:
+          REGION_FILTER_EN:
+            description: Region filter enable
+            bitOffset: 0
+            bitWidth: 4
+            access: read-write
+      REGION0_ADDR_START:
+        description: Region address register
+        addressOffset: 0x4
+        size: 0x20
+        fields:
+          REGION0_ADDR_START:
+            description: Start address of region0
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION0_ADDR_END:
+        description: Region address register
+        addressOffset: 0x8
+        size: 0x20
+        resetValue: 0xFFFFFFFF
+        fields:
+          REGION0_ADDR_END:
+            description: End address of region0
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION0_PMS_ATTR:
+        description: Region access authority attribute register
+        addressOffset: 0xC
+        size: 0x20
+        fields:
+          REGION0_R0_PMS_X:
+            description: Region execute authority in REE_MODE0
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          REGION0_R0_PMS_W:
+            description: Region write authority in REE_MODE0
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          REGION0_R0_PMS_R:
+            description: Region read authority in REE_MODE0
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          REGION0_R1_PMS_X:
+            description: Region execute authority in REE_MODE1
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+          REGION0_R1_PMS_W:
+            description: Region write authority in REE_MODE1
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          REGION0_R1_PMS_R:
+            description: Region read authority in REE_MODE1
+            bitOffset: 6
+            bitWidth: 1
+            access: read-write
+          REGION0_R2_PMS_X:
+            description: Region execute authority in REE_MODE2
+            bitOffset: 8
+            bitWidth: 1
+            access: read-write
+          REGION0_R2_PMS_W:
+            description: Region write authority in REE_MODE2
+            bitOffset: 9
+            bitWidth: 1
+            access: read-write
+          REGION0_R2_PMS_R:
+            description: Region read authority in REE_MODE2
+            bitOffset: 10
+            bitWidth: 1
+            access: read-write
+      REGION1_ADDR_START:
+        description: Region address register
+        addressOffset: 0x10
+        size: 0x20
+        fields:
+          REGION1_ADDR_START:
+            description: Start address of region1
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION1_ADDR_END:
+        description: Region address register
+        addressOffset: 0x14
+        size: 0x20
+        resetValue: 0xFFFFFFFF
+        fields:
+          REGION1_ADDR_END:
+            description: End address of region1
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION1_PMS_ATTR:
+        description: Region access authority attribute register
+        addressOffset: 0x18
+        size: 0x20
+        fields:
+          REGION1_R0_PMS_X:
+            description: Region execute authority in REE_MODE0
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          REGION1_R0_PMS_W:
+            description: Region write authority in REE_MODE0
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          REGION1_R0_PMS_R:
+            description: Region read authority in REE_MODE0
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          REGION1_R1_PMS_X:
+            description: Region execute authority in REE_MODE1
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+          REGION1_R1_PMS_W:
+            description: Region write authority in REE_MODE1
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          REGION1_R1_PMS_R:
+            description: Region read authority in REE_MODE1
+            bitOffset: 6
+            bitWidth: 1
+            access: read-write
+          REGION1_R2_PMS_X:
+            description: Region execute authority in REE_MODE2
+            bitOffset: 8
+            bitWidth: 1
+            access: read-write
+          REGION1_R2_PMS_W:
+            description: Region write authority in REE_MODE2
+            bitOffset: 9
+            bitWidth: 1
+            access: read-write
+          REGION1_R2_PMS_R:
+            description: Region read authority in REE_MODE2
+            bitOffset: 10
+            bitWidth: 1
+            access: read-write
+      REGION2_ADDR_START:
+        description: Region address register
+        addressOffset: 0x1C
+        size: 0x20
+        fields:
+          REGION2_ADDR_START:
+            description: Start address of region2
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION2_ADDR_END:
+        description: Region address register
+        addressOffset: 0x20
+        size: 0x20
+        resetValue: 0xFFFFFFFF
+        fields:
+          REGION2_ADDR_END:
+            description: End address of region2
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION2_PMS_ATTR:
+        description: Region access authority attribute register
+        addressOffset: 0x24
+        size: 0x20
+        fields:
+          REGION2_R0_PMS_X:
+            description: Region execute authority in REE_MODE0
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          REGION2_R0_PMS_W:
+            description: Region write authority in REE_MODE0
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          REGION2_R0_PMS_R:
+            description: Region read authority in REE_MODE0
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          REGION2_R1_PMS_X:
+            description: Region execute authority in REE_MODE1
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+          REGION2_R1_PMS_W:
+            description: Region write authority in REE_MODE1
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          REGION2_R1_PMS_R:
+            description: Region read authority in REE_MODE1
+            bitOffset: 6
+            bitWidth: 1
+            access: read-write
+          REGION2_R2_PMS_X:
+            description: Region execute authority in REE_MODE2
+            bitOffset: 8
+            bitWidth: 1
+            access: read-write
+          REGION2_R2_PMS_W:
+            description: Region write authority in REE_MODE2
+            bitOffset: 9
+            bitWidth: 1
+            access: read-write
+          REGION2_R2_PMS_R:
+            description: Region read authority in REE_MODE2
+            bitOffset: 10
+            bitWidth: 1
+            access: read-write
+      REGION3_ADDR_START:
+        description: Region address register
+        addressOffset: 0x28
+        size: 0x20
+        fields:
+          REGION3_ADDR_START:
+            description: Start address of region3
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION3_ADDR_END:
+        description: Region address register
+        addressOffset: 0x2C
+        size: 0x20
+        resetValue: 0xFFFFFFFF
+        fields:
+          REGION3_ADDR_END:
+            description: End address of region3
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      REGION3_PMS_ATTR:
+        description: Region access authority attribute register
+        addressOffset: 0x30
+        size: 0x20
+        fields:
+          REGION3_R0_PMS_X:
+            description: Region execute authority in REE_MODE0
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          REGION3_R0_PMS_W:
+            description: Region write authority in REE_MODE0
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          REGION3_R0_PMS_R:
+            description: Region read authority in REE_MODE0
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          REGION3_R1_PMS_X:
+            description: Region execute authority in REE_MODE1
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+          REGION3_R1_PMS_W:
+            description: Region write authority in REE_MODE1
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          REGION3_R1_PMS_R:
+            description: Region read authority in REE_MODE1
+            bitOffset: 6
+            bitWidth: 1
+            access: read-write
+          REGION3_R2_PMS_X:
+            description: Region execute authority in REE_MODE2
+            bitOffset: 8
+            bitWidth: 1
+            access: read-write
+          REGION3_R2_PMS_W:
+            description: Region write authority in REE_MODE2
+            bitOffset: 9
+            bitWidth: 1
+            access: read-write
+          REGION3_R2_PMS_R:
+            description: Region read authority in REE_MODE2
+            bitOffset: 10
+            bitWidth: 1
+            access: read-write
+      FUNC_CTRL:
+        description: PMS function control register
+        addressOffset: 0xC4
+        size: 0x20
+        resetValue: 0x00000001
+        fields:
+          M0_PMS_FUNC_EN:
+            description: PMS M0 function enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+      M0_STATUS:
+        description: M0 status register
+        addressOffset: 0xC8
+        size: 0x20
+        fields:
+          M0_EXCEPTION_STATUS:
+            description: Exception status
+            bitOffset: 0
+            bitWidth: 2
+            access: read-only
+      M0_STATUS_CLR:
+        description: M0 status clear register
+        addressOffset: 0xCC
+        size: 0x20
+        fields:
+          M0_REGION_STATUS_CLR:
+            description: Clear exception status
+            bitOffset: 0
+            bitWidth: 1
+            access: write-only
+      M0_EXCEPTION_INFO0:
+        description: M0 exception_info0 register
+        addressOffset: 0xD0
+        size: 0x20
+        fields:
+          M0_EXCEPTION_REGION:
+            description: Exception region
+            bitOffset: 0
+            bitWidth: 4
+            access: read-only
+          M0_EXCEPTION_MODE:
+            description: Exception mode
+            bitOffset: 16
+            bitWidth: 2
+            access: read-only
+          M0_EXCEPTION_ID:
+            description: Exception id information
+            bitOffset: 18
+            bitWidth: 5
+            access: read-only
+      M0_EXCEPTION_INFO1:
+        description: M0 exception_info1 register
+        addressOffset: 0xD4
+        size: 0x20
+        fields:
+          M0_EXCEPTION_ADDR:
+            description: Exception addr
+            bitOffset: 0
+            bitWidth: 32
+            access: read-only
+      INT_EN:
+        description: APM interrupt enable register
+        addressOffset: 0xD8
+        size: 0x20
+        fields:
+          M0_APM_INT_EN:
+            description: APM M0 interrupt enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+      CLOCK_GATE:
+        description: clock gating register
+        addressOffset: 0xDC
+        size: 0x20
+        resetValue: 0x00000001
+        fields:
+          CLK_EN:
+            description: reg_clk_en
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+      DATE:
+        description: Version register
+        addressOffset: 0x7FC
+        size: 0x20
+        resetValue: 0x02205240
+        fields:
+          DATE:
+            description: reg_date
+            bitOffset: 0
+            bitWidth: 28
+            access: read-write
 
 _modify:
   IEEE802154:


### PR DESCRIPTION
This adds the LP_APM0 peripheral for ESP32-H2. It's just a copy of the same peripheral on ESP32-C6