### PR TITLE
Esp32s2 missing registers for sleep

### DIFF
--- a/esp32s2/src/fe.rs
+++ b/esp32s2/src/fe.rs
@@ -1,0 +1,18 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    _reserved0: [u8; 0x90],
+    gen_ctrl: GEN_CTRL,
+}
+impl RegisterBlock {
+    #[doc = "0x90 - FE General Control Register"]
+    #[inline(always)]
+    pub const fn gen_ctrl(&self) -> &GEN_CTRL {
+        &self.gen_ctrl
+    }
+}
+#[doc = "GEN_CTRL (rw) register accessor: FE General Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`gen_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`gen_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gen_ctrl`] module"]
+pub type GEN_CTRL = crate::Reg<gen_ctrl::GEN_CTRL_SPEC>;
+#[doc = "FE General Control Register"]
+pub mod gen_ctrl;

--- a/esp32s2/src/fe/gen_ctrl.rs
+++ b/esp32s2/src/fe/gen_ctrl.rs
@@ -1,0 +1,62 @@
+#[doc = "Register `GEN_CTRL` reader"]
+pub type R = crate::R<GEN_CTRL_SPEC>;
+#[doc = "Register `GEN_CTRL` writer"]
+pub type W = crate::W<GEN_CTRL_SPEC>;
+#[doc = "Field `IQ_EST_FORCE_PD` reader - Force Power Down for IQ Estimation"]
+pub type IQ_EST_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `IQ_EST_FORCE_PD` writer - Force Power Down for IQ Estimation"]
+pub type IQ_EST_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `IQ_EST_FORCE_PU` reader - Force Power Up for IQ Estimation"]
+pub type IQ_EST_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `IQ_EST_FORCE_PU` writer - Force Power Up for IQ Estimation"]
+pub type IQ_EST_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 4 - Force Power Down for IQ Estimation"]
+    #[inline(always)]
+    pub fn iq_est_force_pd(&self) -> IQ_EST_FORCE_PD_R {
+        IQ_EST_FORCE_PD_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Force Power Up for IQ Estimation"]
+    #[inline(always)]
+    pub fn iq_est_force_pu(&self) -> IQ_EST_FORCE_PU_R {
+        IQ_EST_FORCE_PU_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GEN_CTRL")
+            .field("iq_est_force_pu", &self.iq_est_force_pu())
+            .field("iq_est_force_pd", &self.iq_est_force_pd())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - Force Power Down for IQ Estimation"]
+    #[inline(always)]
+    pub fn iq_est_force_pd(&mut self) -> IQ_EST_FORCE_PD_W<GEN_CTRL_SPEC> {
+        IQ_EST_FORCE_PD_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Force Power Up for IQ Estimation"]
+    #[inline(always)]
+    pub fn iq_est_force_pu(&mut self) -> IQ_EST_FORCE_PU_W<GEN_CTRL_SPEC> {
+        IQ_EST_FORCE_PU_W::new(self, 5)
+    }
+}
+#[doc = "FE General Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`gen_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`gen_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GEN_CTRL_SPEC;
+impl crate::RegisterSpec for GEN_CTRL_SPEC {
+    type Ux = u8;
+}
+#[doc = "`read()` method returns [`gen_ctrl::R`](R) reader structure"]
+impl crate::Readable for GEN_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gen_ctrl::W`](W) writer structure"]
+impl crate::Writable for GEN_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+}
+#[doc = "`reset()` method sets GEN_CTRL to value 0"]
+impl crate::Resettable for GEN_CTRL_SPEC {
+    const RESET_VALUE: u8 = 0;
+}

--- a/esp32s2/src/fe2.rs
+++ b/esp32s2/src/fe2.rs
@@ -1,0 +1,18 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    _reserved0: [u8; 0xf0],
+    tx_interp_ctrl: TX_INTERP_CTRL,
+}
+impl RegisterBlock {
+    #[doc = "0xf0 - FE2 TX Interpolation Control Register"]
+    #[inline(always)]
+    pub const fn tx_interp_ctrl(&self) -> &TX_INTERP_CTRL {
+        &self.tx_interp_ctrl
+    }
+}
+#[doc = "TX_INTERP_CTRL (rw) register accessor: FE2 TX Interpolation Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_interp_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_interp_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_interp_ctrl`] module"]
+pub type TX_INTERP_CTRL = crate::Reg<tx_interp_ctrl::TX_INTERP_CTRL_SPEC>;
+#[doc = "FE2 TX Interpolation Control Register"]
+pub mod tx_interp_ctrl;

--- a/esp32s2/src/fe2/tx_interp_ctrl.rs
+++ b/esp32s2/src/fe2/tx_interp_ctrl.rs
@@ -1,0 +1,62 @@
+#[doc = "Register `TX_INTERP_CTRL` reader"]
+pub type R = crate::R<TX_INTERP_CTRL_SPEC>;
+#[doc = "Register `TX_INTERP_CTRL` writer"]
+pub type W = crate::W<TX_INTERP_CTRL_SPEC>;
+#[doc = "Field `TX_INF_FORCE_PD` reader - Force Power Down field"]
+pub type TX_INF_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `TX_INF_FORCE_PD` writer - Force Power Down field"]
+pub type TX_INF_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TX_INF_FORCE_PU` reader - Force Power Up field"]
+pub type TX_INF_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `TX_INF_FORCE_PU` writer - Force Power Up field"]
+pub type TX_INF_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 9 - Force Power Down field"]
+    #[inline(always)]
+    pub fn tx_inf_force_pd(&self) -> TX_INF_FORCE_PD_R {
+        TX_INF_FORCE_PD_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Force Power Up field"]
+    #[inline(always)]
+    pub fn tx_inf_force_pu(&self) -> TX_INF_FORCE_PU_R {
+        TX_INF_FORCE_PU_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_INTERP_CTRL")
+            .field("tx_inf_force_pu", &self.tx_inf_force_pu())
+            .field("tx_inf_force_pd", &self.tx_inf_force_pd())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 9 - Force Power Down field"]
+    #[inline(always)]
+    pub fn tx_inf_force_pd(&mut self) -> TX_INF_FORCE_PD_W<TX_INTERP_CTRL_SPEC> {
+        TX_INF_FORCE_PD_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Force Power Up field"]
+    #[inline(always)]
+    pub fn tx_inf_force_pu(&mut self) -> TX_INF_FORCE_PU_W<TX_INTERP_CTRL_SPEC> {
+        TX_INF_FORCE_PU_W::new(self, 10)
+    }
+}
+#[doc = "FE2 TX Interpolation Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_interp_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_interp_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_INTERP_CTRL_SPEC;
+impl crate::RegisterSpec for TX_INTERP_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_interp_ctrl::R`](R) reader structure"]
+impl crate::Readable for TX_INTERP_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_interp_ctrl::W`](W) writer structure"]
+impl crate::Writable for TX_INTERP_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets TX_INTERP_CTRL to value 0"]
+impl crate::Resettable for TX_INTERP_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32s2/src/lib.rs
+++ b/esp32s2/src/lib.rs
@@ -2567,6 +2567,144 @@ impl core::fmt::Debug for XTS_AES {
 }
 #[doc = "XTS-AES-128 Flash Encryption"]
 pub mod xts_aes;
+#[doc = "NRX Peripheral"]
+pub struct NRX {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for NRX {}
+impl NRX {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const nrx::RegisterBlock = 0x3f41_c000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const nrx::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for NRX {
+    type Target = nrx::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for NRX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NRX").finish()
+    }
+}
+#[doc = "NRX Peripheral"]
+pub mod nrx;
+#[doc = "FE Peripheral"]
+pub struct FE {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for FE {}
+impl FE {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const fe::RegisterBlock = 0x3f40_6000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const fe::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for FE {
+    type Target = fe::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for FE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FE").finish()
+    }
+}
+#[doc = "FE Peripheral"]
+pub mod fe;
+#[doc = "FE2 Peripheral"]
+pub struct FE2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for FE2 {}
+impl FE2 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const fe2::RegisterBlock = 0x3f40_5000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const fe2::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for FE2 {
+    type Target = fe2::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for FE2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FE2").finish()
+    }
+}
+#[doc = "FE2 Peripheral"]
+pub mod fe2;
 #[doc = "Copy DMA Controller"]
 pub struct COPY_DMA {
     _marker: PhantomData<*const ()>,
@@ -2796,6 +2934,12 @@ pub struct Peripherals {
     pub USB_WRAP: USB_WRAP,
     #[doc = "XTS_AES"]
     pub XTS_AES: XTS_AES,
+    #[doc = "NRX"]
+    pub NRX: NRX,
+    #[doc = "FE"]
+    pub FE: FE,
+    #[doc = "FE2"]
+    pub FE2: FE2,
     #[doc = "COPY_DMA"]
     pub COPY_DMA: COPY_DMA,
     #[doc = "CRYPTO_DMA"]
@@ -2867,6 +3011,9 @@ impl Peripherals {
             USB0: USB0::steal(),
             USB_WRAP: USB_WRAP::steal(),
             XTS_AES: XTS_AES::steal(),
+            NRX: NRX::steal(),
+            FE: FE::steal(),
+            FE2: FE2::steal(),
             COPY_DMA: COPY_DMA::steal(),
             CRYPTO_DMA: CRYPTO_DMA::steal(),
             WIFI: WIFI::steal(),

--- a/esp32s2/src/lib.rs
+++ b/esp32s2/src/lib.rs
@@ -2574,7 +2574,7 @@ pub struct NRX {
 unsafe impl Send for NRX {}
 impl NRX {
     #[doc = r"Pointer to the register block"]
-    pub const PTR: *const nrx::RegisterBlock = 0x3f41_c000 as *const _;
+    pub const PTR: *const nrx::RegisterBlock = 0x3f41_cc00 as *const _;
     #[doc = r"Return the pointer to the register block"]
     #[inline(always)]
     pub const fn ptr() -> *const nrx::RegisterBlock {

--- a/esp32s2/src/nrx.rs
+++ b/esp32s2/src/nrx.rs
@@ -1,0 +1,18 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    _reserved0: [u8; 0xd4],
+    nrxpd_ctrl: NRXPD_CTRL,
+}
+impl RegisterBlock {
+    #[doc = "0xd4 - NRX Power Down Control Register"]
+    #[inline(always)]
+    pub const fn nrxpd_ctrl(&self) -> &NRXPD_CTRL {
+        &self.nrxpd_ctrl
+    }
+}
+#[doc = "NRXPD_CTRL (rw) register accessor: NRX Power Down Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`nrxpd_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`nrxpd_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@nrxpd_ctrl`] module"]
+pub type NRXPD_CTRL = crate::Reg<nrxpd_ctrl::NRXPD_CTRL_SPEC>;
+#[doc = "NRX Power Down Control Register"]
+pub mod nrxpd_ctrl;

--- a/esp32s2/src/nrx/nrxpd_ctrl.rs
+++ b/esp32s2/src/nrx/nrxpd_ctrl.rs
@@ -1,0 +1,152 @@
+#[doc = "Register `NRXPD_CTRL` reader"]
+pub type R = crate::R<NRXPD_CTRL_SPEC>;
+#[doc = "Register `NRXPD_CTRL` writer"]
+pub type W = crate::W<NRXPD_CTRL_SPEC>;
+#[doc = "Field `DEMAP_FORCE_PD` reader - Force Power Down for Demapper"]
+pub type DEMAP_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `DEMAP_FORCE_PD` writer - Force Power Down for Demapper"]
+pub type DEMAP_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `DEMAP_FORCE_PU` reader - Force Power Up for Demapper"]
+pub type DEMAP_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `DEMAP_FORCE_PU` writer - Force Power Up for Demapper"]
+pub type DEMAP_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `VIT_FORCE_PD` reader - Force Power Down for Viterbi Decoder"]
+pub type VIT_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `VIT_FORCE_PD` writer - Force Power Down for Viterbi Decoder"]
+pub type VIT_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `VIT_FORCE_PU` reader - Force Power Up for Viterbi Decoder"]
+pub type VIT_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `VIT_FORCE_PU` writer - Force Power Up for Viterbi Decoder"]
+pub type VIT_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `RX_ROT_FORCE_PD` reader - Force Power Down for RX Rotation"]
+pub type RX_ROT_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `RX_ROT_FORCE_PD` writer - Force Power Down for RX Rotation"]
+pub type RX_ROT_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `RX_ROT_FORCE_PU` reader - Force Power Up for RX Rotation"]
+pub type RX_ROT_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `RX_ROT_FORCE_PU` writer - Force Power Up for RX Rotation"]
+pub type RX_ROT_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CHAN_EST_FORCE_PD` reader - Force Power Down for Channel Estimation"]
+pub type CHAN_EST_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `CHAN_EST_FORCE_PD` writer - Force Power Down for Channel Estimation"]
+pub type CHAN_EST_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CHAN_EST_FORCE_PU` reader - Force Power Up for Channel Estimation"]
+pub type CHAN_EST_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `CHAN_EST_FORCE_PU` writer - Force Power Up for Channel Estimation"]
+pub type CHAN_EST_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Force Power Down for Demapper"]
+    #[inline(always)]
+    pub fn demap_force_pd(&self) -> DEMAP_FORCE_PD_R {
+        DEMAP_FORCE_PD_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Force Power Up for Demapper"]
+    #[inline(always)]
+    pub fn demap_force_pu(&self) -> DEMAP_FORCE_PU_R {
+        DEMAP_FORCE_PU_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Force Power Down for Viterbi Decoder"]
+    #[inline(always)]
+    pub fn vit_force_pd(&self) -> VIT_FORCE_PD_R {
+        VIT_FORCE_PD_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Force Power Up for Viterbi Decoder"]
+    #[inline(always)]
+    pub fn vit_force_pu(&self) -> VIT_FORCE_PU_R {
+        VIT_FORCE_PU_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Force Power Down for RX Rotation"]
+    #[inline(always)]
+    pub fn rx_rot_force_pd(&self) -> RX_ROT_FORCE_PD_R {
+        RX_ROT_FORCE_PD_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Force Power Up for RX Rotation"]
+    #[inline(always)]
+    pub fn rx_rot_force_pu(&self) -> RX_ROT_FORCE_PU_R {
+        RX_ROT_FORCE_PU_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Force Power Down for Channel Estimation"]
+    #[inline(always)]
+    pub fn chan_est_force_pd(&self) -> CHAN_EST_FORCE_PD_R {
+        CHAN_EST_FORCE_PD_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Force Power Up for Channel Estimation"]
+    #[inline(always)]
+    pub fn chan_est_force_pu(&self) -> CHAN_EST_FORCE_PU_R {
+        CHAN_EST_FORCE_PU_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NRXPD_CTRL")
+            .field("chan_est_force_pu", &self.chan_est_force_pu())
+            .field("chan_est_force_pd", &self.chan_est_force_pd())
+            .field("rx_rot_force_pu", &self.rx_rot_force_pu())
+            .field("rx_rot_force_pd", &self.rx_rot_force_pd())
+            .field("vit_force_pu", &self.vit_force_pu())
+            .field("vit_force_pd", &self.vit_force_pd())
+            .field("demap_force_pu", &self.demap_force_pu())
+            .field("demap_force_pd", &self.demap_force_pd())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Force Power Down for Demapper"]
+    #[inline(always)]
+    pub fn demap_force_pd(&mut self) -> DEMAP_FORCE_PD_W<NRXPD_CTRL_SPEC> {
+        DEMAP_FORCE_PD_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Force Power Up for Demapper"]
+    #[inline(always)]
+    pub fn demap_force_pu(&mut self) -> DEMAP_FORCE_PU_W<NRXPD_CTRL_SPEC> {
+        DEMAP_FORCE_PU_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Force Power Down for Viterbi Decoder"]
+    #[inline(always)]
+    pub fn vit_force_pd(&mut self) -> VIT_FORCE_PD_W<NRXPD_CTRL_SPEC> {
+        VIT_FORCE_PD_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Force Power Up for Viterbi Decoder"]
+    #[inline(always)]
+    pub fn vit_force_pu(&mut self) -> VIT_FORCE_PU_W<NRXPD_CTRL_SPEC> {
+        VIT_FORCE_PU_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Force Power Down for RX Rotation"]
+    #[inline(always)]
+    pub fn rx_rot_force_pd(&mut self) -> RX_ROT_FORCE_PD_W<NRXPD_CTRL_SPEC> {
+        RX_ROT_FORCE_PD_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Force Power Up for RX Rotation"]
+    #[inline(always)]
+    pub fn rx_rot_force_pu(&mut self) -> RX_ROT_FORCE_PU_W<NRXPD_CTRL_SPEC> {
+        RX_ROT_FORCE_PU_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Force Power Down for Channel Estimation"]
+    #[inline(always)]
+    pub fn chan_est_force_pd(&mut self) -> CHAN_EST_FORCE_PD_W<NRXPD_CTRL_SPEC> {
+        CHAN_EST_FORCE_PD_W::new(self, 6)
+    }
+    #[doc = "Bit 7 - Force Power Up for Channel Estimation"]
+    #[inline(always)]
+    pub fn chan_est_force_pu(&mut self) -> CHAN_EST_FORCE_PU_W<NRXPD_CTRL_SPEC> {
+        CHAN_EST_FORCE_PU_W::new(self, 7)
+    }
+}
+#[doc = "NRX Power Down Control Register\n\nYou can [`read`](crate::Reg::read) this register and get [`nrxpd_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`nrxpd_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct NRXPD_CTRL_SPEC;
+impl crate::RegisterSpec for NRXPD_CTRL_SPEC {
+    type Ux = u8;
+}
+#[doc = "`read()` method returns [`nrxpd_ctrl::R`](R) reader structure"]
+impl crate::Readable for NRXPD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`nrxpd_ctrl::W`](W) writer structure"]
+impl crate::Writable for NRXPD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+}
+#[doc = "`reset()` method sets NRXPD_CTRL to value 0"]
+impl crate::Resettable for NRXPD_CTRL_SPEC {
+    const RESET_VALUE: u8 = 0;
+}

--- a/esp32s2/src/spi0.rs
+++ b/esp32s2/src/spi0.rs
@@ -40,7 +40,7 @@ pub struct RegisterBlock {
     outlink_dscr_bf1: OUTLINK_DSCR_BF1,
     dma_outstatus: DMA_OUTSTATUS,
     dma_instatus: DMA_INSTATUS,
-    w: [W; 18],
+    _reserved_38_w: [u8; 0x48],
     din_mode: DIN_MODE,
     din_num: DIN_NUM,
     dout_mode: DOUT_MODE,
@@ -267,13 +267,32 @@ impl RegisterBlock {
     #[doc = "0x98..0xe0 - Data buffer %s"]
     #[inline(always)]
     pub const fn w(&self, n: usize) -> &W {
-        &self.w[n]
+        #[allow(clippy::no_effect)]
+        [(); 18][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(152)
+                .add(4 * n)
+                .cast()
+        }
     }
     #[doc = "Iterator for array of:"]
     #[doc = "0x98..0xe0 - Data buffer %s"]
     #[inline(always)]
     pub fn w_iter(&self) -> impl Iterator<Item = &W> {
-        self.w.iter()
+        (0..18).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(152)
+                .add(4 * n)
+                .cast()
+        })
+    }
+    #[doc = "0xdc - SPI Memory Clock Gate Register"]
+    #[inline(always)]
+    pub const fn clock_gate(&self) -> &CLOCK_GATE {
+        unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(220).cast() }
     }
     #[doc = "0xe0 - SPI input delay mode configuration"]
     #[inline(always)]
@@ -538,3 +557,7 @@ pub mod sram_drd_cmd;
 pub type SRAM_CLK = crate::Reg<sram_clk::SRAM_CLK_SPEC>;
 #[doc = "SPI Memory SRAM Clock Register"]
 pub mod sram_clk;
+#[doc = "CLOCK_GATE (rw) register accessor: SPI Memory Clock Gate Register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clock_gate`] module"]
+pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
+#[doc = "SPI Memory Clock Gate Register"]
+pub mod clock_gate;

--- a/esp32s2/src/spi0/clock_gate.rs
+++ b/esp32s2/src/spi0/clock_gate.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `CLOCK_GATE` reader"]
+pub type R = crate::R<CLOCK_GATE_SPEC>;
+#[doc = "Register `CLOCK_GATE` writer"]
+pub type W = crate::W<CLOCK_GATE_SPEC>;
+#[doc = "Field `CLK_EN` reader - "]
+pub type CLK_EN_R = crate::BitReader;
+#[doc = "Field `CLK_EN` writer - "]
+pub type CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn clk_en(&self) -> CLK_EN_R {
+        CLK_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLOCK_GATE")
+            .field("clk_en", &self.clk_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn clk_en(&mut self) -> CLK_EN_W<CLOCK_GATE_SPEC> {
+        CLK_EN_W::new(self, 0)
+    }
+}
+#[doc = "SPI Memory Clock Gate Register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLOCK_GATE_SPEC;
+impl crate::RegisterSpec for CLOCK_GATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clock_gate::R`](R) reader structure"]
+impl crate::Readable for CLOCK_GATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`clock_gate::W`](W) writer structure"]
+impl crate::Writable for CLOCK_GATE_SPEC {
+    type Safety = crate::Unsafe;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets CLOCK_GATE to value 0"]
+impl crate::Resettable for CLOCK_GATE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/esp32s2/src/spi0/clock_gate.rs
+++ b/esp32s2/src/spi0/clock_gate.rs
@@ -2,12 +2,12 @@
 pub type R = crate::R<CLOCK_GATE_SPEC>;
 #[doc = "Register `CLOCK_GATE` writer"]
 pub type W = crate::W<CLOCK_GATE_SPEC>;
-#[doc = "Field `CLK_EN` reader - "]
+#[doc = "Field `CLK_EN` reader - Register clock gate enable signal. 1: Enable. 0. Disable."]
 pub type CLK_EN_R = crate::BitReader;
-#[doc = "Field `CLK_EN` writer - "]
+#[doc = "Field `CLK_EN` writer - Register clock gate enable signal. 1: Enable. 0. Disable."]
 pub type CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0"]
+    #[doc = "Bit 0 - Register clock gate enable signal. 1: Enable. 0. Disable."]
     #[inline(always)]
     pub fn clk_en(&self) -> CLK_EN_R {
         CLK_EN_R::new((self.bits & 1) != 0)
@@ -22,7 +22,7 @@ impl core::fmt::Debug for R {
     }
 }
 impl W {
-    #[doc = "Bit 0"]
+    #[doc = "Bit 0 - Register clock gate enable signal. 1: Enable. 0. Disable."]
     #[inline(always)]
     pub fn clk_en(&mut self) -> CLK_EN_W<CLOCK_GATE_SPEC> {
         CLK_EN_W::new(self, 0)

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -1416,7 +1416,7 @@ SPI0:
       access: read-write
       fields:
         CLK_EN:
-          description: ""
+          description: "Register clock gate enable signal. 1: Enable. 0. Disable."
           bitOffset: 0
           bitWidth: 1
           access: read-write

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -3,7 +3,7 @@ _svd: ../esp32s2.base.svd
 _add:
   NRX:
     description: NRX Peripheral
-    baseAddress: 0x3F41C000
+    baseAddress: 0x3F41CC00
     groupName: NRX
     addressBlock:
       offset: 0x0

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -1409,6 +1409,17 @@ SPI0:
           bitOffset: 0
           bitWidth: 8
           access: read-write
+    CLOCK_GATE:
+      description: "SPI Memory Clock Gate Register"
+      addressOffset: 0xDC
+      size: 0x20
+      access: read-write
+      fields:
+        CLK_EN:
+          description: ""
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
   MISC:
     _delete: ["CS0_DIS", "CS1_DIS", "CS2_DIS", "CS3_DIS", "CS4_DIS", "CS5_DIS"]
     _add:

--- a/esp32s2/svd/patches/esp32s2.yaml
+++ b/esp32s2/svd/patches/esp32s2.yaml
@@ -1,6 +1,111 @@
 _svd: ../esp32s2.base.svd
 
 _add:
+  NRX:
+    description: NRX Peripheral
+    baseAddress: 0x3F41C000
+    groupName: NRX
+    addressBlock:
+      offset: 0x0
+      size: 0x4
+      usage: registers
+    registers:
+      NRXPD_CTRL:
+        description: "NRX Power Down Control Register"
+        addressOffset: 0xD4
+        size: 0x4
+        access: read-write
+        fields:
+          CHAN_EST_FORCE_PU:
+            description: "Force Power Up for Channel Estimation"
+            bitOffset: 7
+            bitWidth: 1
+            access: read-write
+          CHAN_EST_FORCE_PD:
+            description: "Force Power Down for Channel Estimation"
+            bitOffset: 6
+            bitWidth: 1
+            access: read-write
+          RX_ROT_FORCE_PU:
+            description: "Force Power Up for RX Rotation"
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          RX_ROT_FORCE_PD:
+            description: "Force Power Down for RX Rotation"
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+          VIT_FORCE_PU:
+            description: "Force Power Up for Viterbi Decoder"
+            bitOffset: 3
+            bitWidth: 1
+            access: read-write
+          VIT_FORCE_PD:
+            description: "Force Power Down for Viterbi Decoder"
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          DEMAP_FORCE_PU:
+            description: "Force Power Up for Demapper"
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          DEMAP_FORCE_PD:
+            description: "Force Power Down for Demapper"
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+  FE:
+    description: FE Peripheral
+    baseAddress: 0x3F406000
+    groupName: FE
+    addressBlock:
+      offset: 0x0
+      size: 0x4
+      usage: registers
+    registers:
+      GEN_CTRL:
+        description: "FE General Control Register"
+        addressOffset: 0x0090
+        size: 0x2
+        access: read-write
+        fields:
+          IQ_EST_FORCE_PU:
+            description: "Force Power Up for IQ Estimation"
+            bitOffset: 5
+            bitWidth: 1
+            access: read-write
+          IQ_EST_FORCE_PD:
+            description: "Force Power Down for IQ Estimation"
+            bitOffset: 4
+            bitWidth: 1
+            access: read-write
+  FE2:
+    description: FE2 Peripheral
+    baseAddress: 0x3F405000
+    groupName: FE
+    addressBlock:
+      offset: 0x0
+      size: 0x4
+      usage: registers
+    registers:
+      TX_INTERP_CTRL:
+        description: "FE2 TX Interpolation Control Register"
+        addressOffset: 0x00f0
+        size: 0x20
+        access: read-write
+        fields:
+          TX_INF_FORCE_PU:
+            description: "Force Power Up field"
+            bitOffset: 10
+            bitWidth: 1
+            access: read-write
+          TX_INF_FORCE_PD:
+            description: "Force Power Down field"
+            bitOffset: 9
+            bitWidth: 1
+            access: read-write
   COPY_DMA:
     description: Copy DMA Controller
     baseAddress: 0x3F4C3000


### PR DESCRIPTION
I added the missing registers referenced by idf's sleep mode. I used the ESP32-S3 as a starting point, updated the addresses, and verified the offsets.