### PR TITLE
Remove the `_I2C` postfix from I2C-ST timeout fields

### DIFF
--- a/common_patches/i2c_st_timeouts.yaml
+++ b/common_patches/i2c_st_timeouts.yaml
@@ -1,0 +1,7 @@
+SCL_ST_TIME_OUT:
+    _strip_end:
+        - "_I2C"
+
+SCL_MAIN_ST_TIME_OUT:
+    _strip_end:
+        - "_I2C"

--- a/esp32c2/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32c2/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL main status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c2/src/i2c0/scl_st_time_out.rs
+++ b/esp32c2/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c2/svd/patches/esp32c2.yaml
+++ b/esp32c2/svd/patches/esp32c2.yaml
@@ -24,6 +24,7 @@ I2C0:
       name: INT_ST
   _include:
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 RTC_CNTL:
   _include: ../../../common_patches/rtc_cntl_int_strip.yaml

--- a/esp32c3/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32c3/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - reg_scl_main_st_to_regno more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - reg_scl_main_st_to_regno more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - reg_scl_main_st_to_regno more than 23"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - reg_scl_main_st_to_regno more than 23"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - reg_scl_main_st_to_regno more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - reg_scl_main_st_to_regno more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "I2C_SCL_MAIN_ST_TIME_OUT_REG\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c3/src/i2c0/scl_st_time_out.rs
+++ b/esp32c3/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - reg_scl_st_to_regno more than 23"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - reg_scl_st_to_regno more than 23"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - reg_scl_st_to_regno more than 23"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - reg_scl_st_to_regno more than 23"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - reg_scl_st_to_regno more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - reg_scl_st_to_regno more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "I2C_SCL_ST_TIME_OUT_REG\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -187,6 +187,7 @@ I2C0:
       name: INT_ST
   _include:
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 RTC_CNTL:
   _include: ../../../common_patches/rtc_cntl_int_strip.yaml

--- a/esp32c6/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32c6/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL main status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c6/src/i2c0/scl_st_time_out.rs
+++ b/esp32c6/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32c6/svd/patches/esp32c6.yaml
+++ b/esp32c6/svd/patches/esp32c6.yaml
@@ -1572,6 +1572,7 @@ I2C0:
       name: INT_ST
   _include:
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 GPIO:
   _modify:

--- a/esp32h2/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32h2/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL main status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32h2/src/i2c0/scl_st_time_out.rs
+++ b/esp32h2/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -1029,6 +1029,11 @@ I2C0:
       name: INT_ST
   _include:
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
+
+I2C1:
+  _include:
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 HP_APM,LP_APM:
   _include: ../../../common_patches/hp_apm.yaml

--- a/esp32p4/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32p4/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - Configures the threshold value of SCL_MAIN_FSM state unchanged period.nIt should be no more than 23. Measurement unit: i2c_sclk"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL main status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32p4/src/i2c0/scl_st_time_out.rs
+++ b/esp32p4/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - Configures the threshold value of SCL_FSM state unchanged period. It should be no more than 23. Measurement unit: i2c_sclk"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32p4/svd/patches/esp32p4.yaml
+++ b/esp32p4/svd/patches/esp32p4.yaml
@@ -50,6 +50,11 @@ LP_ANA:
 I2C0:
   _include:
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
+
+I2C1:
+  _include:
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 SPI[01]:
   _strip: SPI_MEM_

--- a/esp32s3/src/i2c0/scl_main_st_time_out.rs
+++ b/esp32s3/src/i2c0/scl_main_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_MAIN_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_MAIN_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_MAIN_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_MAIN_ST_TO_I2C` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
-pub type SCL_MAIN_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_MAIN_ST_TO` reader - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_MAIN_ST_TO` writer - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
+pub type SCL_MAIN_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&self) -> SCL_MAIN_ST_TO_I2C_R {
-        SCL_MAIN_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_main_st_to(&self) -> SCL_MAIN_ST_TO_R {
+        SCL_MAIN_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_MAIN_ST_TIME_OUT")
-            .field("scl_main_st_to_i2c", &self.scl_main_st_to_i2c())
+            .field("scl_main_st_to", &self.scl_main_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_MAIN_FSM state unchanged period.nIt should be o more than 23"]
     #[inline(always)]
-    pub fn scl_main_st_to_i2c(&mut self) -> SCL_MAIN_ST_TO_I2C_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
-        SCL_MAIN_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_main_st_to(&mut self) -> SCL_MAIN_ST_TO_W<SCL_MAIN_ST_TIME_OUT_SPEC> {
+        SCL_MAIN_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL main status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_main_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_main_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32s3/src/i2c0/scl_st_time_out.rs
+++ b/esp32s3/src/i2c0/scl_st_time_out.rs
@@ -2,30 +2,30 @@
 pub type R = crate::R<SCL_ST_TIME_OUT_SPEC>;
 #[doc = "Register `SCL_ST_TIME_OUT` writer"]
 pub type W = crate::W<SCL_ST_TIME_OUT_SPEC>;
-#[doc = "Field `SCL_ST_TO_I2C` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_R = crate::FieldReader;
-#[doc = "Field `SCL_ST_TO_I2C` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
-pub type SCL_ST_TO_I2C_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `SCL_ST_TO` reader - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_R = crate::FieldReader;
+#[doc = "Field `SCL_ST_TO` writer - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
+pub type SCL_ST_TO_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&self) -> SCL_ST_TO_I2C_R {
-        SCL_ST_TO_I2C_R::new((self.bits & 0x1f) as u8)
+    pub fn scl_st_to(&self) -> SCL_ST_TO_R {
+        SCL_ST_TO_R::new((self.bits & 0x1f) as u8)
     }
 }
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("SCL_ST_TIME_OUT")
-            .field("scl_st_to_i2c", &self.scl_st_to_i2c())
+            .field("scl_st_to", &self.scl_st_to())
             .finish()
     }
 }
 impl W {
     #[doc = "Bits 0:4 - The threshold value of SCL_FSM state unchanged period. It should be o more than 23"]
     #[inline(always)]
-    pub fn scl_st_to_i2c(&mut self) -> SCL_ST_TO_I2C_W<SCL_ST_TIME_OUT_SPEC> {
-        SCL_ST_TO_I2C_W::new(self, 0)
+    pub fn scl_st_to(&mut self) -> SCL_ST_TO_W<SCL_ST_TIME_OUT_SPEC> {
+        SCL_ST_TO_W::new(self, 0)
     }
 }
 #[doc = "SCL status time out register\n\nYou can [`read`](crate::Reg::read) this register and get [`scl_st_time_out::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`scl_st_time_out::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]

--- a/esp32s3/svd/patches/esp32s3.yaml
+++ b/esp32s3/svd/patches/esp32s3.yaml
@@ -142,6 +142,7 @@ I2C0:
   _include:
     - ../../../common_patches/int_strip.yaml
     - ../../../common_patches/i2c0.yaml
+    - ../../../common_patches/i2c_st_timeouts.yaml
 
 RTC_I2C:
   CMD*:


### PR DESCRIPTION
Remove the `_I2C` postfix from I2C-ST timeout fields