### PR TITLE
esp32c6: fix SLC0_LENGTH register name 

### DIFF
--- a/esp32c6/src/slc.rs
+++ b/esp32c6/src/slc.rs
@@ -29,7 +29,7 @@ pub struct RegisterBlock {
     slc_rx_dscr_conf: SLC_RX_DSCR_CONF,
     _reserved20: [u8; 0x48],
     slc0_len_conf: SLC0_LEN_CONF,
-    slc10_length: SLC10_LENGTH,
+    slc0_length: SLC0_LENGTH,
     _reserved22: [u8; 0x50],
     slc1int_st1: SLC1INT_ST1,
     slc1int_ena1: SLC1INT_ENA1,
@@ -152,8 +152,8 @@ impl RegisterBlock {
     }
     #[doc = "0xf8 - Length of transmitting packets"]
     #[inline(always)]
-    pub const fn slc10_length(&self) -> &SLC10_LENGTH {
-        &self.slc10_length
+    pub const fn slc0_length(&self) -> &SLC0_LENGTH {
+        &self.slc0_length
     }
     #[doc = "0x14c - SLC1 to slave masked interrupt status"]
     #[inline(always)]
@@ -339,7 +339,7 @@ pub mod slc1int_st1;
 pub type SLC1INT_ENA1 = crate::Reg<slc1int_ena1::SLC1INT_ENA1_SPEC>;
 #[doc = "SLC1 to slave interrupt enable"]
 pub mod slc1int_ena1;
-#[doc = "SLC10_LENGTH (r) register accessor: Length of transmitting packets\n\nYou can [`read`](crate::Reg::read) this register and get [`slc10_length::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slc10_length`] module"]
-pub type SLC10_LENGTH = crate::Reg<slc10_length::SLC10_LENGTH_SPEC>;
+#[doc = "SLC0_LENGTH (r) register accessor: Length of transmitting packets\n\nYou can [`read`](crate::Reg::read) this register and get [`slc0_length::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@slc0_length`] module"]
+pub type SLC0_LENGTH = crate::Reg<slc0_length::SLC0_LENGTH_SPEC>;
 #[doc = "Length of transmitting packets"]
-pub mod slc10_length;
+pub mod slc0_length;

--- a/esp32c6/src/slc/slc0_length.rs
+++ b/esp32c6/src/slc/slc0_length.rs
@@ -1,5 +1,5 @@
-#[doc = "Register `SLC10_LENGTH` reader"]
-pub type R = crate::R<SLC10_LENGTH_SPEC>;
+#[doc = "Register `SLC0_LENGTH` reader"]
+pub type R = crate::R<SLC0_LENGTH_SPEC>;
 #[doc = "Field `SDIO_SLC0_LEN` reader - Represents the accumulated length of data that the slave wants to send."]
 pub type SDIO_SLC0_LEN_R = crate::FieldReader<u32>;
 impl R {
@@ -12,19 +12,19 @@ impl R {
 #[cfg(feature = "impl-register-debug")]
 impl core::fmt::Debug for R {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("SLC10_LENGTH")
+        f.debug_struct("SLC0_LENGTH")
             .field("sdio_slc0_len", &self.sdio_slc0_len())
             .finish()
     }
 }
-#[doc = "Length of transmitting packets\n\nYou can [`read`](crate::Reg::read) this register and get [`slc10_length::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct SLC10_LENGTH_SPEC;
-impl crate::RegisterSpec for SLC10_LENGTH_SPEC {
+#[doc = "Length of transmitting packets\n\nYou can [`read`](crate::Reg::read) this register and get [`slc0_length::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SLC0_LENGTH_SPEC;
+impl crate::RegisterSpec for SLC0_LENGTH_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`slc10_length::R`](R) reader structure"]
-impl crate::Readable for SLC10_LENGTH_SPEC {}
-#[doc = "`reset()` method sets SLC10_LENGTH to value 0"]
-impl crate::Resettable for SLC10_LENGTH_SPEC {
+#[doc = "`read()` method returns [`slc0_length::R`](R) reader structure"]
+impl crate::Readable for SLC0_LENGTH_SPEC {}
+#[doc = "`reset()` method sets SLC0_LENGTH to value 0"]
+impl crate::Resettable for SLC0_LENGTH_SPEC {
     const RESET_VALUE: u32 = 0;
 }

--- a/esp32c6/svd/patches/esp32c6.yaml
+++ b/esp32c6/svd/patches/esp32c6.yaml
@@ -1534,7 +1534,7 @@ _add:
             bitOffset: 20
             bitWidth: 1
       # Status registers
-      SLC10_LENGTH:
+      SLC0_LENGTH:
         description: "Length of transmitting packets"
         addressOffset: 0x00F8
         size: 32


### PR DESCRIPTION
Fixes a typo in the SLC0_LENGTH register name in the SVD YAML patch file.

Re-generates the `esp32c6` PAC with the SLC0_LENGTH register name fix.