### PR TITLE
add IOMUX_CLK_CONF patch for h2

### DIFF
--- a/esp32h2/src/pcr/iomux_clk_conf.rs
+++ b/esp32h2/src/pcr/iomux_clk_conf.rs
@@ -2,16 +2,16 @@
 pub type R = crate::R<IOMUX_CLK_CONF_SPEC>;
 #[doc = "Register `IOMUX_CLK_CONF` writer"]
 pub type W = crate::W<IOMUX_CLK_CONF_SPEC>;
-#[doc = "Field `IOMUX_FUNC_CLK_SEL` reader - set this field to select clock-source. 0: do not select anyone clock, 1: 80MHz, 2: FOSC, 3(default): XTAL."]
+#[doc = "Field `IOMUX_FUNC_CLK_SEL` reader - Select clock source. 0: XTAL, 1: RC_FAST, 2: PLL_F48M, 3: No clock source."]
 pub type IOMUX_FUNC_CLK_SEL_R = crate::FieldReader;
-#[doc = "Field `IOMUX_FUNC_CLK_SEL` writer - set this field to select clock-source. 0: do not select anyone clock, 1: 80MHz, 2: FOSC, 3(default): XTAL."]
+#[doc = "Field `IOMUX_FUNC_CLK_SEL` writer - Select clock source. 0: XTAL, 1: RC_FAST, 2: PLL_F48M, 3: No clock source."]
 pub type IOMUX_FUNC_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
 #[doc = "Field `IOMUX_FUNC_CLK_EN` reader - Set 1 to enable iomux function clock"]
 pub type IOMUX_FUNC_CLK_EN_R = crate::BitReader;
 #[doc = "Field `IOMUX_FUNC_CLK_EN` writer - Set 1 to enable iomux function clock"]
 pub type IOMUX_FUNC_CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 20:21 - set this field to select clock-source. 0: do not select anyone clock, 1: 80MHz, 2: FOSC, 3(default): XTAL."]
+    #[doc = "Bits 20:21 - Select clock source. 0: XTAL, 1: RC_FAST, 2: PLL_F48M, 3: No clock source."]
     #[inline(always)]
     pub fn iomux_func_clk_sel(&self) -> IOMUX_FUNC_CLK_SEL_R {
         IOMUX_FUNC_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
@@ -32,7 +32,7 @@ impl core::fmt::Debug for R {
     }
 }
 impl W {
-    #[doc = "Bits 20:21 - set this field to select clock-source. 0: do not select anyone clock, 1: 80MHz, 2: FOSC, 3(default): XTAL."]
+    #[doc = "Bits 20:21 - Select clock source. 0: XTAL, 1: RC_FAST, 2: PLL_F48M, 3: No clock source."]
     #[inline(always)]
     pub fn iomux_func_clk_sel(&mut self) -> IOMUX_FUNC_CLK_SEL_W<'_, IOMUX_CLK_CONF_SPEC> {
         IOMUX_FUNC_CLK_SEL_W::new(self, 20)

--- a/esp32h2/svd/patches/_pcr.yml
+++ b/esp32h2/svd/patches/_pcr.yml
@@ -1,3 +1,7 @@
 PCR:
   RMT_SCLK_CONF:
     _strip: "RMT_"
+  IOMUX_CLK_CONF:
+    _modify:
+      IOMUX_FUNC_CLK_SEL:
+        description: "Select clock source. 0: XTAL, 1: RC_FAST, 2: PLL_F48M, 3: No clock source."


### PR DESCRIPTION
The current description in the SVD file does not match the TRM: 

SVD:
```xml
<field>
  <name>IOMUX_FUNC_CLK_SEL</name>
  <description>set this field to select clock-source. 0: do not select anyone clock, 1: 80MHz, 2: FOSC, 3(default): XTAL.</description>
  <bitOffset>20</bitOffset>
  <bitWidth>2</bitWidth>
  <access>read-write</access>
</field>
```
TRM page 324:
<img width="1160" height="664" alt="image" src="https://github.com/user-attachments/assets/45b50fb1-bf25-4006-89b2-acb8f88582db" />

The [idf implementation](https://github.com/espressif/esp-idf/blob/055ba9d3f9c6fd9a0efacd4993a2a942972dd65d/components/esp_hal_gpio/esp32h2/include/hal/gpio_ll.h#L589-L603) is consistent with the TRM: 

```c
static inline void gpio_ll_iomux_set_clk_src(soc_module_clk_t src)
{
    switch (src) {
    case SOC_MOD_CLK_XTAL:
        PCR.iomux_clk_conf.iomux_func_clk_sel = 0;
        break;
    case SOC_MOD_CLK_PLL_F48M:
        PCR.iomux_clk_conf.iomux_func_clk_sel = 2;
        break;
    default:
        // Unsupported IO_MUX clock source
        HAL_ASSERT(false);
    }
}
```
