### PR TITLE
Spawn fewer runners

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -1,70 +1,88 @@
-name: Check Package
+name: Check Packages
 
 inputs:
   msrv:
     description: Minimum Supported Rust Version
     type: string
     required: true
-  package:
-    description: Name of the package to check
+  packages:
+    description: Space-separated list of packages to check
+    type: string
+    required: true
+  arch:
+    description: Architecture of the specified packages, either `xtensa` or `riscv`
     type: string
     required: true
   target:
-    description: Target to use when checking the specified package
+    description: Target shared by the specified packages, required for `riscv` only
     type: string
-    required: true
+    required: false
+    default: ""
 
 runs:
   using: composite
 
   steps:
-    # Install the newest available version of the specified toolchain,
-    # required for building the PAC:
+    # Install the newest available version of the required toolchain,
+    # required for building the PACs:
 
     - uses: dtolnay/rust-toolchain@stable
-      if: startsWith(inputs.target, 'riscv')
+      if: inputs.arch == 'riscv'
       with:
         target: ${{ inputs.target }}
         components: rust-src
 
+    # The Xtensa toolchain ships support for every Xtensa chip, so a single
+    # installation covers all of the packages in the group:
+
     - uses: esp-rs/xtensa-toolchain@v1.6
-      if: startsWith(inputs.target, 'xtensa')
+      if: inputs.arch == 'xtensa'
       with:
-        buildtargets: ${{ inputs.package }}
         override: false
 
-    # Build the PAC using the newest available version of the specified
+    # Build the PACs using the newest available version of the required
     # toolchain:
 
-    - name: Build (${{ inputs.package }})
+    - name: Build
       shell: bash
-      run: cd ${{ inputs.package }} && cargo build
+      run: |
+        for package in ${{ inputs.packages }}; do
+          echo "::group::Build ($package)"
+          (cd "$package" && cargo build)
+          echo "::endgroup::"
+        done
 
-    # Install the MSRV of the specified toolchain:
+    # Install the MSRV of the required toolchain:
 
     - uses: dtolnay/rust-toolchain@v1
-      if: startsWith(inputs.target, 'riscv')
+      if: inputs.arch == 'riscv'
       with:
         toolchain: ${{ inputs.msrv }}
         target: ${{ inputs.target }}
         components: rust-src
 
     - uses: esp-rs/xtensa-toolchain@v1.6
-      if: startsWith(inputs.target, 'xtensa')
+      if: inputs.arch == 'xtensa'
       with:
         default: true
-        buildtargets: ${{ inputs.package }}
         override: false
         version: ${{ inputs.msrv }}
 
-    # Verify that the PAC builds using the MSRV of the specified toolchain:
+    # Verify that the PACs build using the MSRV of the required toolchain.
+    # The Xtensa MSRV toolchain replaces the `esp` toolchain selected by the
+    # `rust-toolchain.toml` of each package, so it needs no override:
 
     - name: Check MSRV
-      if: startsWith(inputs.target, 'riscv')
       shell: bash
-      run: cd ${{ inputs.package }} && cargo +${{ inputs.msrv }} build
+      run: |
+        if [[ "${{ inputs.arch }}" == "riscv" ]]; then
+          toolchain="+${{ inputs.msrv }}"
+        else
+          toolchain=""
+        fi
 
-    - name: Check MSRV
-      if: startsWith(inputs.target, 'xtensa')
-      shell: bash
-      run: cd ${{ inputs.package }} && cargo build
+        for package in ${{ inputs.packages }}; do
+          echo "::group::Check MSRV ($package)"
+          (cd "$package" && cargo $toolchain build)
+          echo "::endgroup::"
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,38 +26,41 @@ concurrency:
 jobs:
   # --------------------------------------------------------------------------
 
+  # Packages are grouped by the target they build for, so that each runner only
+  # has to install a single toolchain. All Xtensa packages share a group, since
+  # the Xtensa toolchain covers every Xtensa chip and is expensive to install.
   check:
+    name: check (${{ matrix.build.name }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        build: [
-            # Xtensa:
-            { package: "esp32",   target: "xtensa-esp32-none-elf" },
-            { package: "esp32s2", target: "xtensa-esp32s2-none-elf" },
-            { package: "esp32s3", target: "xtensa-esp32s3-none-elf" },
-  
-            # RISC-V:
-            { package: "esp32c2", target: "riscv32imc-unknown-none-elf" },
-            { package: "esp32c3", target: "riscv32imc-unknown-none-elf" },
-            { package: "esp32c5", target: "riscv32imac-unknown-none-elf" },
-            { package: "esp32c6", target: "riscv32imac-unknown-none-elf" },
-            { package: "esp32c61", target: "riscv32imac-unknown-none-elf" },
-            { package: "esp32h2", target: "riscv32imac-unknown-none-elf" },
-            { package: "esp32p4", target: "riscv32imafc-unknown-none-elf" },
-            { package: "esp32s31", target: "riscv32imafc-unknown-none-elf" },
+        build:
+          - name: xtensa
+            arch: xtensa
+            packages: "esp32 esp32s2 esp32s3"
 
-            # RISC-V (Ultra) Low-Power:
-            { package: "esp32c6-lp",  target: "riscv32imac-unknown-none-elf" },
-            { package: "esp32s2-ulp", target: "riscv32imc-unknown-none-elf" },
-            { package: "esp32s3-ulp", target: "riscv32imc-unknown-none-elf" },
-          ]
+          - name: riscv32imc
+            arch: riscv
+            target: riscv32imc-unknown-none-elf
+            packages: "esp32c2 esp32c3 esp32s2-ulp esp32s3-ulp"
+
+          - name: riscv32imac
+            arch: riscv
+            target: riscv32imac-unknown-none-elf
+            packages: "esp32c5 esp32c6 esp32c61 esp32h2 esp32c6-lp"
+
+          - name: riscv32imafc
+            arch: riscv
+            target: riscv32imafc-unknown-none-elf
+            packages: "esp32p4 esp32s31"
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/check
         with:
           msrv: "1.76.0"
-          package: ${{ matrix.build.package }}
+          packages: ${{ matrix.build.packages }}
+          arch: ${{ matrix.build.arch }}
           target: ${{ matrix.build.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - "**/README.md"
-  push:
-    branches-ignore:
-      - "gh-readonly-queue/**"
-      - "main"
   merge_group:
   workflow_dispatch:
 
@@ -15,8 +11,8 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# Cancel any currently running workflows from the same PR, branch, or
-# tag when a new workflow is triggered.
+# Cancel any currently running workflows from the same PR or merge queue
+# entry when a new workflow is triggered.
 #
 # https://stackoverflow.com/a/66336834
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,28 @@ jobs:
           packages: ${{ matrix.build.packages }}
           arch: ${{ matrix.build.arch }}
           target: ${{ matrix.build.target }}
+
+  # --------------------------------------------------------------------------
+
+  # This is the only job that should be marked as a required status check.
+  # Every other job must be listed in `needs` so that adding, removing or
+  # renaming a job never requires touching the branch protection settings.
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    if: always()
+
+    needs:
+      - check
+
+    steps:
+      - name: Check that all jobs succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+
+          if echo "$RESULTS" | jq -e 'any(.[].result; . != "success")' > /dev/null; then
+            echo "::error::One or more jobs did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
It takes a handful of seconds to check a package, we don't need to eat up all the CI runners we have.

Also removes the push trigger, so that we don't run CI twice.