### PR TITLE
ESP32-C6/H2: Describe the registers light-sleep retention needs

### DIFF
--- a/common_patches/plic.yaml
+++ b/common_patches/plic.yaml
@@ -87,6 +87,17 @@ _add:
             bitOffset: 0
             bitWidth: 32
             access: read-write
+      MXINT_CONF:
+        description: "PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)"
+        addressOffset: 0x03FC
+        size: 32
+        access: read-write
+        fields:
+          CPU_MXINT_CONF:
+            description: ""
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
 
   PLIC_UX:
     description: PLIC Peripheral
@@ -173,6 +184,17 @@ _add:
         fields:
           CPU_UXINT_CLAIM:
             description: "hp_mb_int is generated after writing 32'h20200721 to core0_lp_intr_flag."
+            bitOffset: 0
+            bitWidth: 32
+            access: read-write
+      UXINT_CONF:
+        description: "PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)"
+        addressOffset: 0x03FC
+        size: 32
+        access: read-write
+        fields:
+          CPU_UXINT_CONF:
+            description: ""
             bitOffset: 0
             bitWidth: 32
             access: read-write

--- a/common_patches/spi1_mspi_shared.yaml
+++ b/common_patches/spi1_mspi_shared.yaml
@@ -1,0 +1,101 @@
+# The two MSPI controllers share one register layout: SPI0 serves cache
+# accesses, SPI1 serves CPU accesses. The upstream SVD only describes the shared
+# ACE/permission, ECC, external-RAM timing and MMU windows on SPI0, even though
+# both controllers implement them (ESP-IDF's `spi_mem_reg.h` parameterises every
+# register below by controller index). Derive SPI1's copies from SPI0 so the
+# whole block is reachable by name.
+_derive:
+  SPI_SMEM_DDR:
+    _from: SPI0.SPI_SMEM_DDR
+    addressOffset: 0xD8
+    description: MSPI external RAM DDR mode control register
+
+  SPI_FMEM_PMS%s_ATTR:
+    _from: SPI0.SPI_FMEM_PMS%s_ATTR
+    addressOffset: 0x100
+    dim: 4
+    dimIncrement: 0x4
+  SPI_FMEM_PMS%s_ADDR:
+    _from: SPI0.SPI_FMEM_PMS%s_ADDR
+    addressOffset: 0x110
+    dim: 4
+    dimIncrement: 0x4
+  SPI_FMEM_PMS%s_SIZE:
+    _from: SPI0.SPI_FMEM_PMS%s_SIZE
+    addressOffset: 0x120
+    dim: 4
+    dimIncrement: 0x4
+  SPI_SMEM_PMS%s_ATTR:
+    _from: SPI0.SPI_SMEM_PMS%s_ATTR
+    addressOffset: 0x130
+    dim: 4
+    dimIncrement: 0x4
+  SPI_SMEM_PMS%s_ADDR:
+    _from: SPI0.SPI_SMEM_PMS%s_ADDR
+    addressOffset: 0x140
+    dim: 4
+    dimIncrement: 0x4
+  SPI_SMEM_PMS%s_SIZE:
+    _from: SPI0.SPI_SMEM_PMS%s_SIZE
+    addressOffset: 0x150
+    dim: 4
+    dimIncrement: 0x4
+
+  PMS_REJECT:
+    _from: SPI0.PMS_REJECT
+    addressOffset: 0x164
+  ECC_CTRL:
+    _from: SPI0.ECC_CTRL
+    addressOffset: 0x168
+  ECC_ERR_ADDR:
+    _from: SPI0.ECC_ERR_ADDR
+    addressOffset: 0x16C
+  AXI_ERR_ADDR:
+    _from: SPI0.AXI_ERR_ADDR
+    addressOffset: 0x170
+    description: MSPI AXI request error address
+  SPI_SMEM_ECC_CTRL:
+    _from: SPI0.SPI_SMEM_ECC_CTRL
+    addressOffset: 0x174
+
+  DIN_MODE:
+    _from: SPI0.DIN_MODE
+    addressOffset: 0x184
+  DIN_NUM:
+    _from: SPI0.DIN_NUM
+    addressOffset: 0x188
+  DOUT_MODE:
+    _from: SPI0.DOUT_MODE
+    addressOffset: 0x18C
+  SPI_SMEM_TIMING_CALI:
+    _from: SPI0.SPI_SMEM_TIMING_CALI
+    addressOffset: 0x190
+  SPI_SMEM_DIN_MODE:
+    _from: SPI0.SPI_SMEM_DIN_MODE
+    addressOffset: 0x194
+  SPI_SMEM_DIN_NUM:
+    _from: SPI0.SPI_SMEM_DIN_NUM
+    addressOffset: 0x198
+  SPI_SMEM_DOUT_MODE:
+    _from: SPI0.SPI_SMEM_DOUT_MODE
+    addressOffset: 0x19C
+  SPI_SMEM_AC:
+    _from: SPI0.SPI_SMEM_AC
+    addressOffset: 0x1A0
+
+  MMU_ITEM_CONTENT:
+    _from: SPI0.MMU_ITEM_CONTENT
+    addressOffset: 0x37C
+  MMU_ITEM_INDEX:
+    _from: SPI0.MMU_ITEM_INDEX
+    addressOffset: 0x380
+  MMU_POWER_CTRL:
+    _from: SPI0.MMU_POWER_CTRL
+    addressOffset: 0x384
+
+  REGISTERRND_ECO_HIGH:
+    _from: SPI0.REGISTERRND_ECO_HIGH
+    addressOffset: 0x3F0
+  REGISTERRND_ECO_LOW:
+    _from: SPI0.REGISTERRND_ECO_LOW
+    addressOffset: 0x3F4

--- a/esp32c6/src/plic_mx.rs
+++ b/esp32c6/src/plic_mx.rs
@@ -9,6 +9,8 @@ pub struct RegisterBlock {
     mxint_pri: [MXINT_PRI; 32],
     mxint_thresh: MXINT_THRESH,
     mxint_claim: MXINT_CLAIM,
+    _reserved7: [u8; 0x0364],
+    mxint_conf: MXINT_CONF,
 }
 impl RegisterBlock {
     #[doc = "0x00 - PLIC MX Interrupt Enable Register"]
@@ -212,6 +214,11 @@ impl RegisterBlock {
     pub const fn mxint_claim(&self) -> &MXINT_CLAIM {
         &self.mxint_claim
     }
+    #[doc = "0x3fc - PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)"]
+    #[inline(always)]
+    pub const fn mxint_conf(&self) -> &MXINT_CONF {
+        &self.mxint_conf
+    }
 }
 #[doc = "MXINT_ENABLE (rw) register accessor: PLIC MX Interrupt Enable Register\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_enable::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_enable::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mxint_enable`] module"]
 pub type MXINT_ENABLE = crate::Reg<mxint_enable::MXINT_ENABLE_SPEC>;
@@ -241,3 +248,7 @@ pub mod mxint_thresh;
 pub type MXINT_CLAIM = crate::Reg<mxint_claim::MXINT_CLAIM_SPEC>;
 #[doc = "PLIC MX Interrupt Claim Register"]
 pub mod mxint_claim;
+#[doc = "MXINT_CONF (rw) register accessor: PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mxint_conf`] module"]
+pub type MXINT_CONF = crate::Reg<mxint_conf::MXINT_CONF_SPEC>;
+#[doc = "PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)"]
+pub mod mxint_conf;

--- a/esp32c6/src/plic_mx/mxint_conf.rs
+++ b/esp32c6/src/plic_mx/mxint_conf.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `MXINT_CONF` reader"]
+pub type R = crate::R<MXINT_CONF_SPEC>;
+#[doc = "Register `MXINT_CONF` writer"]
+pub type W = crate::W<MXINT_CONF_SPEC>;
+#[doc = "Field `CPU_MXINT_CONF` reader - "]
+pub type CPU_MXINT_CONF_R = crate::FieldReader<u32>;
+#[doc = "Field `CPU_MXINT_CONF` writer - "]
+pub type CPU_MXINT_CONF_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_mxint_conf(&self) -> CPU_MXINT_CONF_R {
+        CPU_MXINT_CONF_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MXINT_CONF")
+            .field("cpu_mxint_conf", &self.cpu_mxint_conf())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_mxint_conf(&mut self) -> CPU_MXINT_CONF_W<'_, MXINT_CONF_SPEC> {
+        CPU_MXINT_CONF_W::new(self, 0)
+    }
+}
+#[doc = "PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MXINT_CONF_SPEC;
+impl crate::RegisterSpec for MXINT_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mxint_conf::R`](R) reader structure"]
+impl crate::Readable for MXINT_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mxint_conf::W`](W) writer structure"]
+impl crate::Writable for MXINT_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets MXINT_CONF to value 0"]
+impl crate::Resettable for MXINT_CONF_SPEC {}

--- a/esp32c6/src/plic_ux.rs
+++ b/esp32c6/src/plic_ux.rs
@@ -9,6 +9,8 @@ pub struct RegisterBlock {
     uxint_pri: [UXINT_PRI; 32],
     uxint_thresh: UXINT_THRESH,
     uxint_claim: UXINT_CLAIM,
+    _reserved7: [u8; 0x0364],
+    uxint_conf: UXINT_CONF,
 }
 impl RegisterBlock {
     #[doc = "0x00 - PLIC UX Interrupt Enable Register"]
@@ -212,6 +214,11 @@ impl RegisterBlock {
     pub const fn uxint_claim(&self) -> &UXINT_CLAIM {
         &self.uxint_claim
     }
+    #[doc = "0x3fc - PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)"]
+    #[inline(always)]
+    pub const fn uxint_conf(&self) -> &UXINT_CONF {
+        &self.uxint_conf
+    }
 }
 #[doc = "UXINT_ENABLE (rw) register accessor: PLIC UX Interrupt Enable Register\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_enable::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_enable::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@uxint_enable`] module"]
 pub type UXINT_ENABLE = crate::Reg<uxint_enable::UXINT_ENABLE_SPEC>;
@@ -241,3 +248,7 @@ pub mod uxint_thresh;
 pub type UXINT_CLAIM = crate::Reg<uxint_claim::UXINT_CLAIM_SPEC>;
 #[doc = "PLIC UX Interrupt Claim Register"]
 pub mod uxint_claim;
+#[doc = "UXINT_CONF (rw) register accessor: PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@uxint_conf`] module"]
+pub type UXINT_CONF = crate::Reg<uxint_conf::UXINT_CONF_SPEC>;
+#[doc = "PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)"]
+pub mod uxint_conf;

--- a/esp32c6/src/plic_ux/uxint_conf.rs
+++ b/esp32c6/src/plic_ux/uxint_conf.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `UXINT_CONF` reader"]
+pub type R = crate::R<UXINT_CONF_SPEC>;
+#[doc = "Register `UXINT_CONF` writer"]
+pub type W = crate::W<UXINT_CONF_SPEC>;
+#[doc = "Field `CPU_UXINT_CONF` reader - "]
+pub type CPU_UXINT_CONF_R = crate::FieldReader<u32>;
+#[doc = "Field `CPU_UXINT_CONF` writer - "]
+pub type CPU_UXINT_CONF_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_uxint_conf(&self) -> CPU_UXINT_CONF_R {
+        CPU_UXINT_CONF_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UXINT_CONF")
+            .field("cpu_uxint_conf", &self.cpu_uxint_conf())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_uxint_conf(&mut self) -> CPU_UXINT_CONF_W<'_, UXINT_CONF_SPEC> {
+        CPU_UXINT_CONF_W::new(self, 0)
+    }
+}
+#[doc = "PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct UXINT_CONF_SPEC;
+impl crate::RegisterSpec for UXINT_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`uxint_conf::R`](R) reader structure"]
+impl crate::Readable for UXINT_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`uxint_conf::W`](W) writer structure"]
+impl crate::Writable for UXINT_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets UXINT_CONF to value 0"]
+impl crate::Resettable for UXINT_CONF_SPEC {}

--- a/esp32c6/src/spi1.rs
+++ b/esp32c6/src/spi1.rs
@@ -31,11 +31,40 @@ pub struct RegisterBlock {
     int_st: INT_ST,
     _reserved24: [u8; 0x04],
     ddr: DDR,
-    _reserved25: [u8; 0xa8],
+    spi_smem_ddr: SPI_SMEM_DDR,
+    _reserved26: [u8; 0x24],
+    spi_fmem_pms_attr: [SPI_FMEM_PMS_ATTR; 4],
+    spi_fmem_pms_addr: [SPI_FMEM_PMS_ADDR; 4],
+    spi_fmem_pms_size: [SPI_FMEM_PMS_SIZE; 4],
+    spi_smem_pms_attr: [SPI_SMEM_PMS_ATTR; 4],
+    spi_smem_pms_addr: [SPI_SMEM_PMS_ADDR; 4],
+    spi_smem_pms_size: [SPI_SMEM_PMS_SIZE; 4],
+    _reserved32: [u8; 0x04],
+    pms_reject: PMS_REJECT,
+    ecc_ctrl: ECC_CTRL,
+    ecc_err_addr: ECC_ERR_ADDR,
+    axi_err_addr: AXI_ERR_ADDR,
+    spi_smem_ecc_ctrl: SPI_SMEM_ECC_CTRL,
+    _reserved37: [u8; 0x08],
     timing_cali: TIMING_CALI,
-    _reserved26: [u8; 0x7c],
+    din_mode: DIN_MODE,
+    din_num: DIN_NUM,
+    dout_mode: DOUT_MODE,
+    spi_smem_timing_cali: SPI_SMEM_TIMING_CALI,
+    spi_smem_din_mode: SPI_SMEM_DIN_MODE,
+    spi_smem_din_num: SPI_SMEM_DIN_NUM,
+    spi_smem_dout_mode: SPI_SMEM_DOUT_MODE,
+    spi_smem_ac: SPI_SMEM_AC,
+    _reserved46: [u8; 0x5c],
     clock_gate: CLOCK_GATE,
-    _reserved27: [u8; 0x01f8],
+    _reserved47: [u8; 0x0178],
+    mmu_item_content: MMU_ITEM_CONTENT,
+    mmu_item_index: MMU_ITEM_INDEX,
+    mmu_power_ctrl: MMU_POWER_CTRL,
+    _reserved50: [u8; 0x68],
+    registerrnd_eco_high: REGISTERRND_ECO_HIGH,
+    registerrnd_eco_low: REGISTERRND_ECO_LOW,
+    _reserved52: [u8; 0x04],
     date: DATE,
 }
 impl RegisterBlock {
@@ -170,15 +199,296 @@ impl RegisterBlock {
     pub const fn ddr(&self) -> &DDR {
         &self.ddr
     }
+    #[doc = "0xd8 - MSPI external RAM DDR mode control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ddr(&self) -> &SPI_SMEM_DDR {
+        &self.spi_smem_ddr
+    }
+    #[doc = "0x100..0x110 - MSPI flash ACE section %s attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_attr(&self, n: usize) -> &SPI_FMEM_PMS_ATTR {
+        &self.spi_fmem_pms_attr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x100..0x110 - MSPI flash ACE section %s attribute register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_attr_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_ATTR> {
+        self.spi_fmem_pms_attr.iter()
+    }
+    #[doc = "0x100 - MSPI flash ACE section 0 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(0)
+    }
+    #[doc = "0x104 - MSPI flash ACE section 1 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(1)
+    }
+    #[doc = "0x108 - MSPI flash ACE section 2 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(2)
+    }
+    #[doc = "0x10c - MSPI flash ACE section 3 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(3)
+    }
+    #[doc = "0x110..0x120 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_addr(&self, n: usize) -> &SPI_FMEM_PMS_ADDR {
+        &self.spi_fmem_pms_addr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x110..0x120 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_addr_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_ADDR> {
+        self.spi_fmem_pms_addr.iter()
+    }
+    #[doc = "0x110 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(0)
+    }
+    #[doc = "0x114 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(1)
+    }
+    #[doc = "0x118 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(2)
+    }
+    #[doc = "0x11c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(3)
+    }
+    #[doc = "0x120..0x130 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_size(&self, n: usize) -> &SPI_FMEM_PMS_SIZE {
+        &self.spi_fmem_pms_size[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x120..0x130 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_size_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_SIZE> {
+        self.spi_fmem_pms_size.iter()
+    }
+    #[doc = "0x120 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(0)
+    }
+    #[doc = "0x124 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(1)
+    }
+    #[doc = "0x128 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(2)
+    }
+    #[doc = "0x12c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(3)
+    }
+    #[doc = "0x130..0x140 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_attr(&self, n: usize) -> &SPI_SMEM_PMS_ATTR {
+        &self.spi_smem_pms_attr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x130..0x140 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_attr_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_ATTR> {
+        self.spi_smem_pms_attr.iter()
+    }
+    #[doc = "0x130 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(0)
+    }
+    #[doc = "0x134 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(1)
+    }
+    #[doc = "0x138 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(2)
+    }
+    #[doc = "0x13c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(3)
+    }
+    #[doc = "0x140..0x150 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_addr(&self, n: usize) -> &SPI_SMEM_PMS_ADDR {
+        &self.spi_smem_pms_addr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x140..0x150 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_addr_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_ADDR> {
+        self.spi_smem_pms_addr.iter()
+    }
+    #[doc = "0x140 - SPI1 external RAM ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(0)
+    }
+    #[doc = "0x144 - SPI1 external RAM ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(1)
+    }
+    #[doc = "0x148 - SPI1 external RAM ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(2)
+    }
+    #[doc = "0x14c - SPI1 external RAM ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(3)
+    }
+    #[doc = "0x150..0x160 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_size(&self, n: usize) -> &SPI_SMEM_PMS_SIZE {
+        &self.spi_smem_pms_size[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x150..0x160 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_size_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_SIZE> {
+        self.spi_smem_pms_size.iter()
+    }
+    #[doc = "0x150 - SPI1 external RAM ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(0)
+    }
+    #[doc = "0x154 - SPI1 external RAM ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(1)
+    }
+    #[doc = "0x158 - SPI1 external RAM ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(2)
+    }
+    #[doc = "0x15c - SPI1 external RAM ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(3)
+    }
+    #[doc = "0x164 - SPI1 access reject register"]
+    #[inline(always)]
+    pub const fn pms_reject(&self) -> &PMS_REJECT {
+        &self.pms_reject
+    }
+    #[doc = "0x168 - MSPI ECC control register"]
+    #[inline(always)]
+    pub const fn ecc_ctrl(&self) -> &ECC_CTRL {
+        &self.ecc_ctrl
+    }
+    #[doc = "0x16c - MSPI ECC error address register"]
+    #[inline(always)]
+    pub const fn ecc_err_addr(&self) -> &ECC_ERR_ADDR {
+        &self.ecc_err_addr
+    }
+    #[doc = "0x170 - MSPI AXI request error address"]
+    #[inline(always)]
+    pub const fn axi_err_addr(&self) -> &AXI_ERR_ADDR {
+        &self.axi_err_addr
+    }
+    #[doc = "0x174 - MSPI ECC control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ecc_ctrl(&self) -> &SPI_SMEM_ECC_CTRL {
+        &self.spi_smem_ecc_ctrl
+    }
     #[doc = "0x180 - SPI1 timing control register"]
     #[inline(always)]
     pub const fn timing_cali(&self) -> &TIMING_CALI {
         &self.timing_cali
     }
+    #[doc = "0x184 - MSPI flash input timing delay mode control register"]
+    #[inline(always)]
+    pub const fn din_mode(&self) -> &DIN_MODE {
+        &self.din_mode
+    }
+    #[doc = "0x188 - MSPI flash input timing delay number control register"]
+    #[inline(always)]
+    pub const fn din_num(&self) -> &DIN_NUM {
+        &self.din_num
+    }
+    #[doc = "0x18c - MSPI flash output timing adjustment control register"]
+    #[inline(always)]
+    pub const fn dout_mode(&self) -> &DOUT_MODE {
+        &self.dout_mode
+    }
+    #[doc = "0x190 - MSPI external RAM timing calibration register"]
+    #[inline(always)]
+    pub const fn spi_smem_timing_cali(&self) -> &SPI_SMEM_TIMING_CALI {
+        &self.spi_smem_timing_cali
+    }
+    #[doc = "0x194 - MSPI external RAM input timing delay mode control register"]
+    #[inline(always)]
+    pub const fn spi_smem_din_mode(&self) -> &SPI_SMEM_DIN_MODE {
+        &self.spi_smem_din_mode
+    }
+    #[doc = "0x198 - MSPI external RAM input timing delay number control register"]
+    #[inline(always)]
+    pub const fn spi_smem_din_num(&self) -> &SPI_SMEM_DIN_NUM {
+        &self.spi_smem_din_num
+    }
+    #[doc = "0x19c - MSPI external RAM output timing adjustment control register"]
+    #[inline(always)]
+    pub const fn spi_smem_dout_mode(&self) -> &SPI_SMEM_DOUT_MODE {
+        &self.spi_smem_dout_mode
+    }
+    #[doc = "0x1a0 - MSPI external RAM ECC and SPI CS timing control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ac(&self) -> &SPI_SMEM_AC {
+        &self.spi_smem_ac
+    }
     #[doc = "0x200 - SPI1 clk_gate register"]
     #[inline(always)]
     pub const fn clock_gate(&self) -> &CLOCK_GATE {
         &self.clock_gate
+    }
+    #[doc = "0x37c - MSPI-MMU item content register"]
+    #[inline(always)]
+    pub const fn mmu_item_content(&self) -> &MMU_ITEM_CONTENT {
+        &self.mmu_item_content
+    }
+    #[doc = "0x380 - MSPI-MMU item index register"]
+    #[inline(always)]
+    pub const fn mmu_item_index(&self) -> &MMU_ITEM_INDEX {
+        &self.mmu_item_index
+    }
+    #[doc = "0x384 - MSPI MMU power control register"]
+    #[inline(always)]
+    pub const fn mmu_power_ctrl(&self) -> &MMU_POWER_CTRL {
+        &self.mmu_power_ctrl
+    }
+    #[doc = "0x3f0 - MSPI ECO high register"]
+    #[inline(always)]
+    pub const fn registerrnd_eco_high(&self) -> &REGISTERRND_ECO_HIGH {
+        &self.registerrnd_eco_high
+    }
+    #[doc = "0x3f4 - MSPI ECO low register"]
+    #[inline(always)]
+    pub const fn registerrnd_eco_low(&self) -> &REGISTERRND_ECO_LOW {
+        &self.registerrnd_eco_low
     }
     #[doc = "0x3fc - Version control register"]
     #[inline(always)]
@@ -294,4 +604,58 @@ pub mod timing_cali;
 pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
 #[doc = "SPI1 clk_gate register"]
 pub mod clock_gate;
-pub use crate::aes::{date, DATE};
+pub use crate::{
+    aes::{date, DATE},
+    spi0::{
+        axi_err_addr,
+        din_mode,
+        din_num,
+        dout_mode,
+        ecc_ctrl,
+        ecc_err_addr,
+        mmu_item_content,
+        mmu_item_index,
+        mmu_power_ctrl,
+        pms_reject,
+        registerrnd_eco_high,
+        registerrnd_eco_low,
+        spi_fmem_pms_addr,
+        spi_fmem_pms_attr,
+        spi_fmem_pms_size,
+        spi_smem_ac,
+        spi_smem_ddr,
+        spi_smem_din_mode,
+        spi_smem_din_num,
+        spi_smem_dout_mode,
+        spi_smem_ecc_ctrl,
+        spi_smem_pms_addr,
+        spi_smem_pms_attr,
+        spi_smem_pms_size,
+        spi_smem_timing_cali,
+        AXI_ERR_ADDR,
+        DIN_MODE,
+        DIN_NUM,
+        DOUT_MODE,
+        ECC_CTRL,
+        ECC_ERR_ADDR,
+        MMU_ITEM_CONTENT,
+        MMU_ITEM_INDEX,
+        MMU_POWER_CTRL,
+        PMS_REJECT,
+        REGISTERRND_ECO_HIGH,
+        REGISTERRND_ECO_LOW,
+        SPI_FMEM_PMS_ADDR,
+        SPI_FMEM_PMS_ATTR,
+        SPI_FMEM_PMS_SIZE,
+        SPI_SMEM_AC,
+        SPI_SMEM_DDR,
+        SPI_SMEM_DIN_MODE,
+        SPI_SMEM_DIN_NUM,
+        SPI_SMEM_DOUT_MODE,
+        SPI_SMEM_ECC_CTRL,
+        SPI_SMEM_PMS_ADDR,
+        SPI_SMEM_PMS_ATTR,
+        SPI_SMEM_PMS_SIZE,
+        SPI_SMEM_TIMING_CALI,
+    },
+};

--- a/esp32c6/svd/patches/esp32c6.yaml
+++ b/esp32c6/svd/patches/esp32c6.yaml
@@ -205,7 +205,9 @@ PCNT:
   _include: ../../../common_patches/pcnt.yaml
 
 SPI1:
-  _include: ../../../common_patches/spi_w.yaml
+  _include:
+    - ../../../common_patches/spi_w.yaml
+    - ../../../common_patches/spi1_mspi_shared.yaml
 
 MCPWM0:
   _include: ../../../common_patches/mcpwm_collect.yaml

--- a/esp32h2/src/cache.rs
+++ b/esp32h2/src/cache.rs
@@ -1,0 +1,2585 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    l1_icache_ctrl: L1_ICACHE_CTRL,
+    l1_cache_ctrl: L1_CACHE_CTRL,
+    l1_bypass_cache_conf: L1_BYPASS_CACHE_CONF,
+    l1_cache_atomic_conf: L1_CACHE_ATOMIC_CONF,
+    l1_icache_cachesize_conf: L1_ICACHE_CACHESIZE_CONF,
+    l1_icache_blocksize_conf: L1_ICACHE_BLOCKSIZE_CONF,
+    l1_cache_cachesize_conf: L1_CACHE_CACHESIZE_CONF,
+    l1_cache_blocksize_conf: L1_CACHE_BLOCKSIZE_CONF,
+    l1_cache_wrap_around_ctrl: L1_CACHE_WRAP_AROUND_CTRL,
+    l1_cache_tag_mem_power_ctrl: L1_CACHE_TAG_MEM_POWER_CTRL,
+    l1_cache_data_mem_power_ctrl: L1_CACHE_DATA_MEM_POWER_CTRL,
+    l1_cache_freeze_ctrl: L1_CACHE_FREEZE_CTRL,
+    l1_cache_data_mem_acs_conf: L1_CACHE_DATA_MEM_ACS_CONF,
+    l1_cache_tag_mem_acs_conf: L1_CACHE_TAG_MEM_ACS_CONF,
+    l1_icache0_prelock_conf: L1_ICACHE0_PRELOCK_CONF,
+    l1_icache0_prelock_sct0_addr: L1_ICACHE0_PRELOCK_SCT0_ADDR,
+    l1_icache0_prelock_sct1_addr: L1_ICACHE0_PRELOCK_SCT1_ADDR,
+    l1_icache0_prelock_sct_size: L1_ICACHE0_PRELOCK_SCT_SIZE,
+    l1_icache1_prelock_conf: L1_ICACHE1_PRELOCK_CONF,
+    l1_icache1_prelock_sct0_addr: L1_ICACHE1_PRELOCK_SCT0_ADDR,
+    l1_icache1_prelock_sct1_addr: L1_ICACHE1_PRELOCK_SCT1_ADDR,
+    l1_icache1_prelock_sct_size: L1_ICACHE1_PRELOCK_SCT_SIZE,
+    l1_icache2_prelock_conf: L1_ICACHE2_PRELOCK_CONF,
+    l1_icache2_prelock_sct0_addr: L1_ICACHE2_PRELOCK_SCT0_ADDR,
+    l1_icache2_prelock_sct1_addr: L1_ICACHE2_PRELOCK_SCT1_ADDR,
+    l1_icache2_prelock_sct_size: L1_ICACHE2_PRELOCK_SCT_SIZE,
+    l1_icache3_prelock_conf: L1_ICACHE3_PRELOCK_CONF,
+    l1_icache3_prelock_sct0_addr: L1_ICACHE3_PRELOCK_SCT0_ADDR,
+    l1_icache3_prelock_sct1_addr: L1_ICACHE3_PRELOCK_SCT1_ADDR,
+    l1_icache3_prelock_sct_size: L1_ICACHE3_PRELOCK_SCT_SIZE,
+    l1_cache_prelock_conf: L1_CACHE_PRELOCK_CONF,
+    l1_cache_prelock_sct0_addr: L1_CACHE_PRELOCK_SCT0_ADDR,
+    l1_dcache_prelock_sct1_addr: L1_DCACHE_PRELOCK_SCT1_ADDR,
+    l1_dcache_prelock_sct_size: L1_DCACHE_PRELOCK_SCT_SIZE,
+    cache_lock_ctrl: CACHE_LOCK_CTRL,
+    cache_lock_map: CACHE_LOCK_MAP,
+    cache_lock_addr: CACHE_LOCK_ADDR,
+    cache_lock_size: CACHE_LOCK_SIZE,
+    cache_sync_ctrl: CACHE_SYNC_CTRL,
+    cache_sync_map: CACHE_SYNC_MAP,
+    cache_sync_addr: CACHE_SYNC_ADDR,
+    cache_sync_size: CACHE_SYNC_SIZE,
+    l1_icache0_preload_ctrl: L1_ICACHE0_PRELOAD_CTRL,
+    l1_icache0_preload_addr: L1_ICACHE0_PRELOAD_ADDR,
+    l1_icache0_preload_size: L1_ICACHE0_PRELOAD_SIZE,
+    l1_icache1_preload_ctrl: L1_ICACHE1_PRELOAD_CTRL,
+    l1_icache1_preload_addr: L1_ICACHE1_PRELOAD_ADDR,
+    l1_icache1_preload_size: L1_ICACHE1_PRELOAD_SIZE,
+    l1_icache2_preload_ctrl: L1_ICACHE2_PRELOAD_CTRL,
+    l1_icache2_preload_addr: L1_ICACHE2_PRELOAD_ADDR,
+    l1_icache2_preload_size: L1_ICACHE2_PRELOAD_SIZE,
+    l1_icache3_preload_ctrl: L1_ICACHE3_PRELOAD_CTRL,
+    l1_icache3_preload_addr: L1_ICACHE3_PRELOAD_ADDR,
+    l1_icache3_preload_size: L1_ICACHE3_PRELOAD_SIZE,
+    l1_cache_preload_ctrl: L1_CACHE_PRELOAD_CTRL,
+    l1_dcache_preload_addr: L1_DCACHE_PRELOAD_ADDR,
+    l1_dcache_preload_size: L1_DCACHE_PRELOAD_SIZE,
+    l1_icache0_autoload_ctrl: L1_ICACHE0_AUTOLOAD_CTRL,
+    l1_icache0_autoload_sct0_addr: L1_ICACHE0_AUTOLOAD_SCT0_ADDR,
+    l1_icache0_autoload_sct0_size: L1_ICACHE0_AUTOLOAD_SCT0_SIZE,
+    l1_icache0_autoload_sct1_addr: L1_ICACHE0_AUTOLOAD_SCT1_ADDR,
+    l1_icache0_autoload_sct1_size: L1_ICACHE0_AUTOLOAD_SCT1_SIZE,
+    l1_icache1_autoload_ctrl: L1_ICACHE1_AUTOLOAD_CTRL,
+    l1_icache1_autoload_sct0_addr: L1_ICACHE1_AUTOLOAD_SCT0_ADDR,
+    l1_icache1_autoload_sct0_size: L1_ICACHE1_AUTOLOAD_SCT0_SIZE,
+    l1_icache1_autoload_sct1_addr: L1_ICACHE1_AUTOLOAD_SCT1_ADDR,
+    l1_icache1_autoload_sct1_size: L1_ICACHE1_AUTOLOAD_SCT1_SIZE,
+    l1_icache2_autoload_ctrl: L1_ICACHE2_AUTOLOAD_CTRL,
+    l1_icache2_autoload_sct0_addr: L1_ICACHE2_AUTOLOAD_SCT0_ADDR,
+    l1_icache2_autoload_sct0_size: L1_ICACHE2_AUTOLOAD_SCT0_SIZE,
+    l1_icache2_autoload_sct1_addr: L1_ICACHE2_AUTOLOAD_SCT1_ADDR,
+    l1_icache2_autoload_sct1_size: L1_ICACHE2_AUTOLOAD_SCT1_SIZE,
+    l1_icache3_autoload_ctrl: L1_ICACHE3_AUTOLOAD_CTRL,
+    l1_icache3_autoload_sct0_addr: L1_ICACHE3_AUTOLOAD_SCT0_ADDR,
+    l1_icache3_autoload_sct0_size: L1_ICACHE3_AUTOLOAD_SCT0_SIZE,
+    l1_icache3_autoload_sct1_addr: L1_ICACHE3_AUTOLOAD_SCT1_ADDR,
+    l1_icache3_autoload_sct1_size: L1_ICACHE3_AUTOLOAD_SCT1_SIZE,
+    l1_cache_autoload_ctrl: L1_CACHE_AUTOLOAD_CTRL,
+    l1_cache_autoload_sct0_addr: L1_CACHE_AUTOLOAD_SCT0_ADDR,
+    l1_cache_autoload_sct0_size: L1_CACHE_AUTOLOAD_SCT0_SIZE,
+    l1_cache_autoload_sct1_addr: L1_CACHE_AUTOLOAD_SCT1_ADDR,
+    l1_cache_autoload_sct1_size: L1_CACHE_AUTOLOAD_SCT1_SIZE,
+    l1_cache_autoload_sct2_addr: L1_CACHE_AUTOLOAD_SCT2_ADDR,
+    l1_cache_autoload_sct2_size: L1_CACHE_AUTOLOAD_SCT2_SIZE,
+    l1_cache_autoload_sct3_addr: L1_CACHE_AUTOLOAD_SCT3_ADDR,
+    l1_cache_autoload_sct3_size: L1_CACHE_AUTOLOAD_SCT3_SIZE,
+    l1_cache_acs_cnt_int_ena: L1_CACHE_ACS_CNT_INT_ENA,
+    l1_cache_acs_cnt_int_clr: L1_CACHE_ACS_CNT_INT_CLR,
+    l1_cache_acs_cnt_int_raw: L1_CACHE_ACS_CNT_INT_RAW,
+    l1_cache_acs_cnt_int_st: L1_CACHE_ACS_CNT_INT_ST,
+    l1_cache_acs_fail_int_ena: L1_CACHE_ACS_FAIL_INT_ENA,
+    l1_cache_acs_fail_int_clr: L1_CACHE_ACS_FAIL_INT_CLR,
+    l1_cache_acs_fail_int_raw: L1_CACHE_ACS_FAIL_INT_RAW,
+    l1_cache_acs_fail_int_st: L1_CACHE_ACS_FAIL_INT_ST,
+    l1_cache_acs_cnt_ctrl: L1_CACHE_ACS_CNT_CTRL,
+    l1_ibus0_acs_hit_cnt: L1_IBUS0_ACS_HIT_CNT,
+    l1_ibus0_acs_miss_cnt: L1_IBUS0_ACS_MISS_CNT,
+    l1_ibus0_acs_conflict_cnt: L1_IBUS0_ACS_CONFLICT_CNT,
+    l1_ibus0_acs_nxtlvl_cnt: L1_IBUS0_ACS_NXTLVL_CNT,
+    l1_ibus1_acs_hit_cnt: L1_IBUS1_ACS_HIT_CNT,
+    l1_ibus1_acs_miss_cnt: L1_IBUS1_ACS_MISS_CNT,
+    l1_ibus1_acs_conflict_cnt: L1_IBUS1_ACS_CONFLICT_CNT,
+    l1_ibus1_acs_nxtlvl_cnt: L1_IBUS1_ACS_NXTLVL_CNT,
+    l1_ibus2_acs_hit_cnt: L1_IBUS2_ACS_HIT_CNT,
+    l1_ibus2_acs_miss_cnt: L1_IBUS2_ACS_MISS_CNT,
+    l1_ibus2_acs_conflict_cnt: L1_IBUS2_ACS_CONFLICT_CNT,
+    l1_ibus2_acs_nxtlvl_cnt: L1_IBUS2_ACS_NXTLVL_CNT,
+    l1_ibus3_acs_hit_cnt: L1_IBUS3_ACS_HIT_CNT,
+    l1_ibus3_acs_miss_cnt: L1_IBUS3_ACS_MISS_CNT,
+    l1_ibus3_acs_conflict_cnt: L1_IBUS3_ACS_CONFLICT_CNT,
+    l1_ibus3_acs_nxtlvl_cnt: L1_IBUS3_ACS_NXTLVL_CNT,
+    l1_bus0_acs_hit_cnt: L1_BUS0_ACS_HIT_CNT,
+    l1_bus0_acs_miss_cnt: L1_BUS0_ACS_MISS_CNT,
+    l1_bus0_acs_conflict_cnt: L1_BUS0_ACS_CONFLICT_CNT,
+    l1_bus0_acs_nxtlvl_cnt: L1_BUS0_ACS_NXTLVL_CNT,
+    l1_bus1_acs_hit_cnt: L1_BUS1_ACS_HIT_CNT,
+    l1_bus1_acs_miss_cnt: L1_BUS1_ACS_MISS_CNT,
+    l1_bus1_acs_conflict_cnt: L1_BUS1_ACS_CONFLICT_CNT,
+    l1_bus1_acs_nxtlvl_cnt: L1_BUS1_ACS_NXTLVL_CNT,
+    l1_dbus2_acs_hit_cnt: L1_DBUS2_ACS_HIT_CNT,
+    l1_dbus2_acs_miss_cnt: L1_DBUS2_ACS_MISS_CNT,
+    l1_dbus2_acs_conflict_cnt: L1_DBUS2_ACS_CONFLICT_CNT,
+    l1_dbus2_acs_nxtlvl_cnt: L1_DBUS2_ACS_NXTLVL_CNT,
+    l1_dbus3_acs_hit_cnt: L1_DBUS3_ACS_HIT_CNT,
+    l1_dbus3_acs_miss_cnt: L1_DBUS3_ACS_MISS_CNT,
+    l1_dbus3_acs_conflict_cnt: L1_DBUS3_ACS_CONFLICT_CNT,
+    l1_dbus3_acs_nxtlvl_cnt: L1_DBUS3_ACS_NXTLVL_CNT,
+    l1_icache0_acs_fail_id_attr: L1_ICACHE0_ACS_FAIL_ID_ATTR,
+    l1_icache0_acs_fail_addr: L1_ICACHE0_ACS_FAIL_ADDR,
+    l1_icache1_acs_fail_id_attr: L1_ICACHE1_ACS_FAIL_ID_ATTR,
+    l1_icache1_acs_fail_addr: L1_ICACHE1_ACS_FAIL_ADDR,
+    l1_icache2_acs_fail_id_attr: L1_ICACHE2_ACS_FAIL_ID_ATTR,
+    l1_icache2_acs_fail_addr: L1_ICACHE2_ACS_FAIL_ADDR,
+    l1_icache3_acs_fail_id_attr: L1_ICACHE3_ACS_FAIL_ID_ATTR,
+    l1_icache3_acs_fail_addr: L1_ICACHE3_ACS_FAIL_ADDR,
+    l1_cache_acs_fail_id_attr: L1_CACHE_ACS_FAIL_ID_ATTR,
+    l1_dcache_acs_fail_addr: L1_DCACHE_ACS_FAIL_ADDR,
+    l1_cache_sync_preload_int_ena: L1_CACHE_SYNC_PRELOAD_INT_ENA,
+    l1_cache_sync_preload_int_clr: L1_CACHE_SYNC_PRELOAD_INT_CLR,
+    l1_cache_sync_preload_int_raw: L1_CACHE_SYNC_PRELOAD_INT_RAW,
+    l1_cache_sync_preload_int_st: L1_CACHE_SYNC_PRELOAD_INT_ST,
+    l1_cache_sync_preload_exception: L1_CACHE_SYNC_PRELOAD_EXCEPTION,
+    l1_cache_sync_rst_ctrl: L1_CACHE_SYNC_RST_CTRL,
+    l1_cache_preload_rst_ctrl: L1_CACHE_PRELOAD_RST_CTRL,
+    l1_cache_autoload_buf_clr_ctrl: L1_CACHE_AUTOLOAD_BUF_CLR_CTRL,
+    l1_unallocate_buffer_clear: L1_UNALLOCATE_BUFFER_CLEAR,
+    l1_cache_object_ctrl: L1_CACHE_OBJECT_CTRL,
+    l1_cache_way_object: L1_CACHE_WAY_OBJECT,
+    l1_cache_vaddr: L1_CACHE_VADDR,
+    l1_cache_debug_bus: L1_CACHE_DEBUG_BUS,
+    level_split0: LEVEL_SPLIT0,
+    l2_cache_ctrl: L2_CACHE_CTRL,
+    l2_bypass_cache_conf: L2_BYPASS_CACHE_CONF,
+    l2_cache_cachesize_conf: L2_CACHE_CACHESIZE_CONF,
+    l2_cache_blocksize_conf: L2_CACHE_BLOCKSIZE_CONF,
+    l2_cache_wrap_around_ctrl: L2_CACHE_WRAP_AROUND_CTRL,
+    l2_cache_tag_mem_power_ctrl: L2_CACHE_TAG_MEM_POWER_CTRL,
+    l2_cache_data_mem_power_ctrl: L2_CACHE_DATA_MEM_POWER_CTRL,
+    l2_cache_freeze_ctrl: L2_CACHE_FREEZE_CTRL,
+    l2_cache_data_mem_acs_conf: L2_CACHE_DATA_MEM_ACS_CONF,
+    l2_cache_tag_mem_acs_conf: L2_CACHE_TAG_MEM_ACS_CONF,
+    l2_cache_prelock_conf: L2_CACHE_PRELOCK_CONF,
+    l2_cache_prelock_sct0_addr: L2_CACHE_PRELOCK_SCT0_ADDR,
+    l2_cache_prelock_sct1_addr: L2_CACHE_PRELOCK_SCT1_ADDR,
+    l2_cache_prelock_sct_size: L2_CACHE_PRELOCK_SCT_SIZE,
+    l2_cache_preload_ctrl: L2_CACHE_PRELOAD_CTRL,
+    l2_cache_preload_addr: L2_CACHE_PRELOAD_ADDR,
+    l2_cache_preload_size: L2_CACHE_PRELOAD_SIZE,
+    l2_cache_autoload_ctrl: L2_CACHE_AUTOLOAD_CTRL,
+    l2_cache_autoload_sct0_addr: L2_CACHE_AUTOLOAD_SCT0_ADDR,
+    l2_cache_autoload_sct0_size: L2_CACHE_AUTOLOAD_SCT0_SIZE,
+    l2_cache_autoload_sct1_addr: L2_CACHE_AUTOLOAD_SCT1_ADDR,
+    l2_cache_autoload_sct1_size: L2_CACHE_AUTOLOAD_SCT1_SIZE,
+    l2_cache_autoload_sct2_addr: L2_CACHE_AUTOLOAD_SCT2_ADDR,
+    l2_cache_autoload_sct2_size: L2_CACHE_AUTOLOAD_SCT2_SIZE,
+    l2_cache_autoload_sct3_addr: L2_CACHE_AUTOLOAD_SCT3_ADDR,
+    l2_cache_autoload_sct3_size: L2_CACHE_AUTOLOAD_SCT3_SIZE,
+    l2_cache_acs_cnt_int_ena: L2_CACHE_ACS_CNT_INT_ENA,
+    l2_cache_acs_cnt_int_clr: L2_CACHE_ACS_CNT_INT_CLR,
+    l2_cache_acs_cnt_int_raw: L2_CACHE_ACS_CNT_INT_RAW,
+    l2_cache_acs_cnt_int_st: L2_CACHE_ACS_CNT_INT_ST,
+    l2_cache_acs_fail_int_ena: L2_CACHE_ACS_FAIL_INT_ENA,
+    l2_cache_acs_fail_int_clr: L2_CACHE_ACS_FAIL_INT_CLR,
+    l2_cache_acs_fail_int_raw: L2_CACHE_ACS_FAIL_INT_RAW,
+    l2_cache_acs_fail_int_st: L2_CACHE_ACS_FAIL_INT_ST,
+    l2_cache_acs_cnt_ctrl: L2_CACHE_ACS_CNT_CTRL,
+    l2_ibus0_acs_hit_cnt: L2_IBUS0_ACS_HIT_CNT,
+    l2_ibus0_acs_miss_cnt: L2_IBUS0_ACS_MISS_CNT,
+    l2_ibus0_acs_conflict_cnt: L2_IBUS0_ACS_CONFLICT_CNT,
+    l2_ibus0_acs_nxtlvl_cnt: L2_IBUS0_ACS_NXTLVL_CNT,
+    l2_ibus1_acs_hit_cnt: L2_IBUS1_ACS_HIT_CNT,
+    l2_ibus1_acs_miss_cnt: L2_IBUS1_ACS_MISS_CNT,
+    l2_ibus1_acs_conflict_cnt: L2_IBUS1_ACS_CONFLICT_CNT,
+    l2_ibus1_acs_nxtlvl_cnt: L2_IBUS1_ACS_NXTLVL_CNT,
+    l2_ibus2_acs_hit_cnt: L2_IBUS2_ACS_HIT_CNT,
+    l2_ibus2_acs_miss_cnt: L2_IBUS2_ACS_MISS_CNT,
+    l2_ibus2_acs_conflict_cnt: L2_IBUS2_ACS_CONFLICT_CNT,
+    l2_ibus2_acs_nxtlvl_cnt: L2_IBUS2_ACS_NXTLVL_CNT,
+    l2_ibus3_acs_hit_cnt: L2_IBUS3_ACS_HIT_CNT,
+    l2_ibus3_acs_miss_cnt: L2_IBUS3_ACS_MISS_CNT,
+    l2_ibus3_acs_conflict_cnt: L2_IBUS3_ACS_CONFLICT_CNT,
+    l2_ibus3_acs_nxtlvl_cnt: L2_IBUS3_ACS_NXTLVL_CNT,
+    l2_dbus0_acs_hit_cnt: L2_DBUS0_ACS_HIT_CNT,
+    l2_dbus0_acs_miss_cnt: L2_DBUS0_ACS_MISS_CNT,
+    l2_dbus0_acs_conflict_cnt: L2_DBUS0_ACS_CONFLICT_CNT,
+    l2_dbus0_acs_nxtlvl_cnt: L2_DBUS0_ACS_NXTLVL_CNT,
+    l2_dbus1_acs_hit_cnt: L2_DBUS1_ACS_HIT_CNT,
+    l2_dbus1_acs_miss_cnt: L2_DBUS1_ACS_MISS_CNT,
+    l2_dbus1_acs_conflict_cnt: L2_DBUS1_ACS_CONFLICT_CNT,
+    l2_dbus1_acs_nxtlvl_cnt: L2_DBUS1_ACS_NXTLVL_CNT,
+    l2_dbus2_acs_hit_cnt: L2_DBUS2_ACS_HIT_CNT,
+    l2_dbus2_acs_miss_cnt: L2_DBUS2_ACS_MISS_CNT,
+    l2_dbus2_acs_conflict_cnt: L2_DBUS2_ACS_CONFLICT_CNT,
+    l2_dbus2_acs_nxtlvl_cnt: L2_DBUS2_ACS_NXTLVL_CNT,
+    l2_dbus3_acs_hit_cnt: L2_DBUS3_ACS_HIT_CNT,
+    l2_dbus3_acs_miss_cnt: L2_DBUS3_ACS_MISS_CNT,
+    l2_dbus3_acs_conflict_cnt: L2_DBUS3_ACS_CONFLICT_CNT,
+    l2_dbus3_acs_nxtlvl_cnt: L2_DBUS3_ACS_NXTLVL_CNT,
+    l2_cache_acs_fail_id_attr: L2_CACHE_ACS_FAIL_ID_ATTR,
+    l2_cache_acs_fail_addr: L2_CACHE_ACS_FAIL_ADDR,
+    l2_cache_sync_preload_int_ena: L2_CACHE_SYNC_PRELOAD_INT_ENA,
+    l2_cache_sync_preload_int_clr: L2_CACHE_SYNC_PRELOAD_INT_CLR,
+    l2_cache_sync_preload_int_raw: L2_CACHE_SYNC_PRELOAD_INT_RAW,
+    l2_cache_sync_preload_int_st: L2_CACHE_SYNC_PRELOAD_INT_ST,
+    l2_cache_sync_preload_exception: L2_CACHE_SYNC_PRELOAD_EXCEPTION,
+    l2_cache_sync_rst_ctrl: L2_CACHE_SYNC_RST_CTRL,
+    l2_cache_preload_rst_ctrl: L2_CACHE_PRELOAD_RST_CTRL,
+    l2_cache_autoload_buf_clr_ctrl: L2_CACHE_AUTOLOAD_BUF_CLR_CTRL,
+    l2_unallocate_buffer_clear: L2_UNALLOCATE_BUFFER_CLEAR,
+    l2_cache_access_attr_ctrl: L2_CACHE_ACCESS_ATTR_CTRL,
+    l2_cache_object_ctrl: L2_CACHE_OBJECT_CTRL,
+    l2_cache_way_object: L2_CACHE_WAY_OBJECT,
+    l2_cache_vaddr: L2_CACHE_VADDR,
+    l2_cache_debug_bus: L2_CACHE_DEBUG_BUS,
+    level_split1: LEVEL_SPLIT1,
+    clock_gate: CLOCK_GATE,
+    redundancy_sig0: REDUNDANCY_SIG0,
+    redundancy_sig1: REDUNDANCY_SIG1,
+    redundancy_sig2: REDUNDANCY_SIG2,
+    redundancy_sig3: REDUNDANCY_SIG3,
+    redundancy_sig4: REDUNDANCY_SIG4,
+    _reserved241: [u8; 0x38],
+    date: DATE,
+}
+impl RegisterBlock {
+    #[doc = "0x00 - L1 instruction Cache(L1-ICache) control register"]
+    #[inline(always)]
+    pub const fn l1_icache_ctrl(&self) -> &L1_ICACHE_CTRL {
+        &self.l1_icache_ctrl
+    }
+    #[doc = "0x04 - L1 data Cache(L1-Cache) control register"]
+    #[inline(always)]
+    pub const fn l1_cache_ctrl(&self) -> &L1_CACHE_CTRL {
+        &self.l1_cache_ctrl
+    }
+    #[doc = "0x08 - Bypass Cache configure register"]
+    #[inline(always)]
+    pub const fn l1_bypass_cache_conf(&self) -> &L1_BYPASS_CACHE_CONF {
+        &self.l1_bypass_cache_conf
+    }
+    #[doc = "0x0c - L1 Cache atomic feature configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_atomic_conf(&self) -> &L1_CACHE_ATOMIC_CONF {
+        &self.l1_cache_atomic_conf
+    }
+    #[doc = "0x10 - L1 instruction Cache CacheSize mode configure register"]
+    #[inline(always)]
+    pub const fn l1_icache_cachesize_conf(&self) -> &L1_ICACHE_CACHESIZE_CONF {
+        &self.l1_icache_cachesize_conf
+    }
+    #[doc = "0x14 - L1 instruction Cache BlockSize mode configure register"]
+    #[inline(always)]
+    pub const fn l1_icache_blocksize_conf(&self) -> &L1_ICACHE_BLOCKSIZE_CONF {
+        &self.l1_icache_blocksize_conf
+    }
+    #[doc = "0x18 - L1 data Cache CacheSize mode configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_cachesize_conf(&self) -> &L1_CACHE_CACHESIZE_CONF {
+        &self.l1_cache_cachesize_conf
+    }
+    #[doc = "0x1c - L1 data Cache BlockSize mode configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_blocksize_conf(&self) -> &L1_CACHE_BLOCKSIZE_CONF {
+        &self.l1_cache_blocksize_conf
+    }
+    #[doc = "0x20 - Cache wrap around control register"]
+    #[inline(always)]
+    pub const fn l1_cache_wrap_around_ctrl(&self) -> &L1_CACHE_WRAP_AROUND_CTRL {
+        &self.l1_cache_wrap_around_ctrl
+    }
+    #[doc = "0x24 - Cache tag memory power control register"]
+    #[inline(always)]
+    pub const fn l1_cache_tag_mem_power_ctrl(&self) -> &L1_CACHE_TAG_MEM_POWER_CTRL {
+        &self.l1_cache_tag_mem_power_ctrl
+    }
+    #[doc = "0x28 - Cache data memory power control register"]
+    #[inline(always)]
+    pub const fn l1_cache_data_mem_power_ctrl(&self) -> &L1_CACHE_DATA_MEM_POWER_CTRL {
+        &self.l1_cache_data_mem_power_ctrl
+    }
+    #[doc = "0x2c - Cache Freeze control register"]
+    #[inline(always)]
+    pub const fn l1_cache_freeze_ctrl(&self) -> &L1_CACHE_FREEZE_CTRL {
+        &self.l1_cache_freeze_ctrl
+    }
+    #[doc = "0x30 - Cache data memory access configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_data_mem_acs_conf(&self) -> &L1_CACHE_DATA_MEM_ACS_CONF {
+        &self.l1_cache_data_mem_acs_conf
+    }
+    #[doc = "0x34 - Cache tag memory access configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_tag_mem_acs_conf(&self) -> &L1_CACHE_TAG_MEM_ACS_CONF {
+        &self.l1_cache_tag_mem_acs_conf
+    }
+    #[doc = "0x38 - L1 instruction Cache 0 prelock configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_prelock_conf(&self) -> &L1_ICACHE0_PRELOCK_CONF {
+        &self.l1_icache0_prelock_conf
+    }
+    #[doc = "0x3c - L1 instruction Cache 0 prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_prelock_sct0_addr(&self) -> &L1_ICACHE0_PRELOCK_SCT0_ADDR {
+        &self.l1_icache0_prelock_sct0_addr
+    }
+    #[doc = "0x40 - L1 instruction Cache 0 prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_prelock_sct1_addr(&self) -> &L1_ICACHE0_PRELOCK_SCT1_ADDR {
+        &self.l1_icache0_prelock_sct1_addr
+    }
+    #[doc = "0x44 - L1 instruction Cache 0 prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_prelock_sct_size(&self) -> &L1_ICACHE0_PRELOCK_SCT_SIZE {
+        &self.l1_icache0_prelock_sct_size
+    }
+    #[doc = "0x48 - L1 instruction Cache 1 prelock configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_prelock_conf(&self) -> &L1_ICACHE1_PRELOCK_CONF {
+        &self.l1_icache1_prelock_conf
+    }
+    #[doc = "0x4c - L1 instruction Cache 1 prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_prelock_sct0_addr(&self) -> &L1_ICACHE1_PRELOCK_SCT0_ADDR {
+        &self.l1_icache1_prelock_sct0_addr
+    }
+    #[doc = "0x50 - L1 instruction Cache 1 prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_prelock_sct1_addr(&self) -> &L1_ICACHE1_PRELOCK_SCT1_ADDR {
+        &self.l1_icache1_prelock_sct1_addr
+    }
+    #[doc = "0x54 - L1 instruction Cache 1 prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_prelock_sct_size(&self) -> &L1_ICACHE1_PRELOCK_SCT_SIZE {
+        &self.l1_icache1_prelock_sct_size
+    }
+    #[doc = "0x58 - L1 instruction Cache 2 prelock configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_prelock_conf(&self) -> &L1_ICACHE2_PRELOCK_CONF {
+        &self.l1_icache2_prelock_conf
+    }
+    #[doc = "0x5c - L1 instruction Cache 2 prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_prelock_sct0_addr(&self) -> &L1_ICACHE2_PRELOCK_SCT0_ADDR {
+        &self.l1_icache2_prelock_sct0_addr
+    }
+    #[doc = "0x60 - L1 instruction Cache 2 prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_prelock_sct1_addr(&self) -> &L1_ICACHE2_PRELOCK_SCT1_ADDR {
+        &self.l1_icache2_prelock_sct1_addr
+    }
+    #[doc = "0x64 - L1 instruction Cache 2 prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_prelock_sct_size(&self) -> &L1_ICACHE2_PRELOCK_SCT_SIZE {
+        &self.l1_icache2_prelock_sct_size
+    }
+    #[doc = "0x68 - L1 instruction Cache 3 prelock configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_prelock_conf(&self) -> &L1_ICACHE3_PRELOCK_CONF {
+        &self.l1_icache3_prelock_conf
+    }
+    #[doc = "0x6c - L1 instruction Cache 3 prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_prelock_sct0_addr(&self) -> &L1_ICACHE3_PRELOCK_SCT0_ADDR {
+        &self.l1_icache3_prelock_sct0_addr
+    }
+    #[doc = "0x70 - L1 instruction Cache 3 prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_prelock_sct1_addr(&self) -> &L1_ICACHE3_PRELOCK_SCT1_ADDR {
+        &self.l1_icache3_prelock_sct1_addr
+    }
+    #[doc = "0x74 - L1 instruction Cache 3 prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_prelock_sct_size(&self) -> &L1_ICACHE3_PRELOCK_SCT_SIZE {
+        &self.l1_icache3_prelock_sct_size
+    }
+    #[doc = "0x78 - L1 Cache prelock configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_prelock_conf(&self) -> &L1_CACHE_PRELOCK_CONF {
+        &self.l1_cache_prelock_conf
+    }
+    #[doc = "0x7c - L1 Cache prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_prelock_sct0_addr(&self) -> &L1_CACHE_PRELOCK_SCT0_ADDR {
+        &self.l1_cache_prelock_sct0_addr
+    }
+    #[doc = "0x80 - L1 Cache prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_dcache_prelock_sct1_addr(&self) -> &L1_DCACHE_PRELOCK_SCT1_ADDR {
+        &self.l1_dcache_prelock_sct1_addr
+    }
+    #[doc = "0x84 - L1 Cache prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l1_dcache_prelock_sct_size(&self) -> &L1_DCACHE_PRELOCK_SCT_SIZE {
+        &self.l1_dcache_prelock_sct_size
+    }
+    #[doc = "0x88 - Lock-class (manual lock) operation control register"]
+    #[inline(always)]
+    pub const fn cache_lock_ctrl(&self) -> &CACHE_LOCK_CTRL {
+        &self.cache_lock_ctrl
+    }
+    #[doc = "0x8c - Lock (manual lock) map configure register"]
+    #[inline(always)]
+    pub const fn cache_lock_map(&self) -> &CACHE_LOCK_MAP {
+        &self.cache_lock_map
+    }
+    #[doc = "0x90 - Lock (manual lock) address configure register"]
+    #[inline(always)]
+    pub const fn cache_lock_addr(&self) -> &CACHE_LOCK_ADDR {
+        &self.cache_lock_addr
+    }
+    #[doc = "0x94 - Lock (manual lock) size configure register"]
+    #[inline(always)]
+    pub const fn cache_lock_size(&self) -> &CACHE_LOCK_SIZE {
+        &self.cache_lock_size
+    }
+    #[doc = "0x98 - Sync-class operation control register"]
+    #[inline(always)]
+    pub const fn cache_sync_ctrl(&self) -> &CACHE_SYNC_CTRL {
+        &self.cache_sync_ctrl
+    }
+    #[doc = "0x9c - Sync map configure register"]
+    #[inline(always)]
+    pub const fn cache_sync_map(&self) -> &CACHE_SYNC_MAP {
+        &self.cache_sync_map
+    }
+    #[doc = "0xa0 - Sync address configure register"]
+    #[inline(always)]
+    pub const fn cache_sync_addr(&self) -> &CACHE_SYNC_ADDR {
+        &self.cache_sync_addr
+    }
+    #[doc = "0xa4 - Sync size configure register"]
+    #[inline(always)]
+    pub const fn cache_sync_size(&self) -> &CACHE_SYNC_SIZE {
+        &self.cache_sync_size
+    }
+    #[doc = "0xa8 - L1 instruction Cache 0 preload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache0_preload_ctrl(&self) -> &L1_ICACHE0_PRELOAD_CTRL {
+        &self.l1_icache0_preload_ctrl
+    }
+    #[doc = "0xac - L1 instruction Cache 0 preload address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_preload_addr(&self) -> &L1_ICACHE0_PRELOAD_ADDR {
+        &self.l1_icache0_preload_addr
+    }
+    #[doc = "0xb0 - L1 instruction Cache 0 preload size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_preload_size(&self) -> &L1_ICACHE0_PRELOAD_SIZE {
+        &self.l1_icache0_preload_size
+    }
+    #[doc = "0xb4 - L1 instruction Cache 1 preload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache1_preload_ctrl(&self) -> &L1_ICACHE1_PRELOAD_CTRL {
+        &self.l1_icache1_preload_ctrl
+    }
+    #[doc = "0xb8 - L1 instruction Cache 1 preload address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_preload_addr(&self) -> &L1_ICACHE1_PRELOAD_ADDR {
+        &self.l1_icache1_preload_addr
+    }
+    #[doc = "0xbc - L1 instruction Cache 1 preload size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_preload_size(&self) -> &L1_ICACHE1_PRELOAD_SIZE {
+        &self.l1_icache1_preload_size
+    }
+    #[doc = "0xc0 - L1 instruction Cache 2 preload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache2_preload_ctrl(&self) -> &L1_ICACHE2_PRELOAD_CTRL {
+        &self.l1_icache2_preload_ctrl
+    }
+    #[doc = "0xc4 - L1 instruction Cache 2 preload address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_preload_addr(&self) -> &L1_ICACHE2_PRELOAD_ADDR {
+        &self.l1_icache2_preload_addr
+    }
+    #[doc = "0xc8 - L1 instruction Cache 2 preload size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_preload_size(&self) -> &L1_ICACHE2_PRELOAD_SIZE {
+        &self.l1_icache2_preload_size
+    }
+    #[doc = "0xcc - L1 instruction Cache 3 preload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache3_preload_ctrl(&self) -> &L1_ICACHE3_PRELOAD_CTRL {
+        &self.l1_icache3_preload_ctrl
+    }
+    #[doc = "0xd0 - L1 instruction Cache 3 preload address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_preload_addr(&self) -> &L1_ICACHE3_PRELOAD_ADDR {
+        &self.l1_icache3_preload_addr
+    }
+    #[doc = "0xd4 - L1 instruction Cache 3 preload size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_preload_size(&self) -> &L1_ICACHE3_PRELOAD_SIZE {
+        &self.l1_icache3_preload_size
+    }
+    #[doc = "0xd8 - L1 Cache preload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_cache_preload_ctrl(&self) -> &L1_CACHE_PRELOAD_CTRL {
+        &self.l1_cache_preload_ctrl
+    }
+    #[doc = "0xdc - L1 Cache preload address configure register"]
+    #[inline(always)]
+    pub const fn l1_dcache_preload_addr(&self) -> &L1_DCACHE_PRELOAD_ADDR {
+        &self.l1_dcache_preload_addr
+    }
+    #[doc = "0xe0 - L1 Cache preload size configure register"]
+    #[inline(always)]
+    pub const fn l1_dcache_preload_size(&self) -> &L1_DCACHE_PRELOAD_SIZE {
+        &self.l1_dcache_preload_size
+    }
+    #[doc = "0xe4 - L1 instruction Cache 0 autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache0_autoload_ctrl(&self) -> &L1_ICACHE0_AUTOLOAD_CTRL {
+        &self.l1_icache0_autoload_ctrl
+    }
+    #[doc = "0xe8 - L1 instruction Cache 0 autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_autoload_sct0_addr(&self) -> &L1_ICACHE0_AUTOLOAD_SCT0_ADDR {
+        &self.l1_icache0_autoload_sct0_addr
+    }
+    #[doc = "0xec - L1 instruction Cache 0 autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_autoload_sct0_size(&self) -> &L1_ICACHE0_AUTOLOAD_SCT0_SIZE {
+        &self.l1_icache0_autoload_sct0_size
+    }
+    #[doc = "0xf0 - L1 instruction Cache 0 autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_autoload_sct1_addr(&self) -> &L1_ICACHE0_AUTOLOAD_SCT1_ADDR {
+        &self.l1_icache0_autoload_sct1_addr
+    }
+    #[doc = "0xf4 - L1 instruction Cache 0 autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache0_autoload_sct1_size(&self) -> &L1_ICACHE0_AUTOLOAD_SCT1_SIZE {
+        &self.l1_icache0_autoload_sct1_size
+    }
+    #[doc = "0xf8 - L1 instruction Cache 1 autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache1_autoload_ctrl(&self) -> &L1_ICACHE1_AUTOLOAD_CTRL {
+        &self.l1_icache1_autoload_ctrl
+    }
+    #[doc = "0xfc - L1 instruction Cache 1 autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_autoload_sct0_addr(&self) -> &L1_ICACHE1_AUTOLOAD_SCT0_ADDR {
+        &self.l1_icache1_autoload_sct0_addr
+    }
+    #[doc = "0x100 - L1 instruction Cache 1 autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_autoload_sct0_size(&self) -> &L1_ICACHE1_AUTOLOAD_SCT0_SIZE {
+        &self.l1_icache1_autoload_sct0_size
+    }
+    #[doc = "0x104 - L1 instruction Cache 1 autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_autoload_sct1_addr(&self) -> &L1_ICACHE1_AUTOLOAD_SCT1_ADDR {
+        &self.l1_icache1_autoload_sct1_addr
+    }
+    #[doc = "0x108 - L1 instruction Cache 1 autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache1_autoload_sct1_size(&self) -> &L1_ICACHE1_AUTOLOAD_SCT1_SIZE {
+        &self.l1_icache1_autoload_sct1_size
+    }
+    #[doc = "0x10c - L1 instruction Cache 2 autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache2_autoload_ctrl(&self) -> &L1_ICACHE2_AUTOLOAD_CTRL {
+        &self.l1_icache2_autoload_ctrl
+    }
+    #[doc = "0x110 - L1 instruction Cache 2 autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_autoload_sct0_addr(&self) -> &L1_ICACHE2_AUTOLOAD_SCT0_ADDR {
+        &self.l1_icache2_autoload_sct0_addr
+    }
+    #[doc = "0x114 - L1 instruction Cache 2 autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_autoload_sct0_size(&self) -> &L1_ICACHE2_AUTOLOAD_SCT0_SIZE {
+        &self.l1_icache2_autoload_sct0_size
+    }
+    #[doc = "0x118 - L1 instruction Cache 2 autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_autoload_sct1_addr(&self) -> &L1_ICACHE2_AUTOLOAD_SCT1_ADDR {
+        &self.l1_icache2_autoload_sct1_addr
+    }
+    #[doc = "0x11c - L1 instruction Cache 2 autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache2_autoload_sct1_size(&self) -> &L1_ICACHE2_AUTOLOAD_SCT1_SIZE {
+        &self.l1_icache2_autoload_sct1_size
+    }
+    #[doc = "0x120 - L1 instruction Cache 3 autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_icache3_autoload_ctrl(&self) -> &L1_ICACHE3_AUTOLOAD_CTRL {
+        &self.l1_icache3_autoload_ctrl
+    }
+    #[doc = "0x124 - L1 instruction Cache 3 autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_autoload_sct0_addr(&self) -> &L1_ICACHE3_AUTOLOAD_SCT0_ADDR {
+        &self.l1_icache3_autoload_sct0_addr
+    }
+    #[doc = "0x128 - L1 instruction Cache 3 autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_autoload_sct0_size(&self) -> &L1_ICACHE3_AUTOLOAD_SCT0_SIZE {
+        &self.l1_icache3_autoload_sct0_size
+    }
+    #[doc = "0x12c - L1 instruction Cache 3 autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_autoload_sct1_addr(&self) -> &L1_ICACHE3_AUTOLOAD_SCT1_ADDR {
+        &self.l1_icache3_autoload_sct1_addr
+    }
+    #[doc = "0x130 - L1 instruction Cache 3 autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_icache3_autoload_sct1_size(&self) -> &L1_ICACHE3_AUTOLOAD_SCT1_SIZE {
+        &self.l1_icache3_autoload_sct1_size
+    }
+    #[doc = "0x134 - L1 Cache autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_ctrl(&self) -> &L1_CACHE_AUTOLOAD_CTRL {
+        &self.l1_cache_autoload_ctrl
+    }
+    #[doc = "0x138 - L1 Cache autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct0_addr(&self) -> &L1_CACHE_AUTOLOAD_SCT0_ADDR {
+        &self.l1_cache_autoload_sct0_addr
+    }
+    #[doc = "0x13c - L1 Cache autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct0_size(&self) -> &L1_CACHE_AUTOLOAD_SCT0_SIZE {
+        &self.l1_cache_autoload_sct0_size
+    }
+    #[doc = "0x140 - L1 Cache autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct1_addr(&self) -> &L1_CACHE_AUTOLOAD_SCT1_ADDR {
+        &self.l1_cache_autoload_sct1_addr
+    }
+    #[doc = "0x144 - L1 Cache autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct1_size(&self) -> &L1_CACHE_AUTOLOAD_SCT1_SIZE {
+        &self.l1_cache_autoload_sct1_size
+    }
+    #[doc = "0x148 - L1 Cache autoload section 2 address configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct2_addr(&self) -> &L1_CACHE_AUTOLOAD_SCT2_ADDR {
+        &self.l1_cache_autoload_sct2_addr
+    }
+    #[doc = "0x14c - L1 Cache autoload section 2 size configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct2_size(&self) -> &L1_CACHE_AUTOLOAD_SCT2_SIZE {
+        &self.l1_cache_autoload_sct2_size
+    }
+    #[doc = "0x150 - L1 Cache autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct3_addr(&self) -> &L1_CACHE_AUTOLOAD_SCT3_ADDR {
+        &self.l1_cache_autoload_sct3_addr
+    }
+    #[doc = "0x154 - L1 Cache autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_sct3_size(&self) -> &L1_CACHE_AUTOLOAD_SCT3_SIZE {
+        &self.l1_cache_autoload_sct3_size
+    }
+    #[doc = "0x158 - Cache Access Counter Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_cnt_int_ena(&self) -> &L1_CACHE_ACS_CNT_INT_ENA {
+        &self.l1_cache_acs_cnt_int_ena
+    }
+    #[doc = "0x15c - Cache Access Counter Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_cnt_int_clr(&self) -> &L1_CACHE_ACS_CNT_INT_CLR {
+        &self.l1_cache_acs_cnt_int_clr
+    }
+    #[doc = "0x160 - Cache Access Counter Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_cnt_int_raw(&self) -> &L1_CACHE_ACS_CNT_INT_RAW {
+        &self.l1_cache_acs_cnt_int_raw
+    }
+    #[doc = "0x164 - Cache Access Counter Interrupt status register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_cnt_int_st(&self) -> &L1_CACHE_ACS_CNT_INT_ST {
+        &self.l1_cache_acs_cnt_int_st
+    }
+    #[doc = "0x168 - Cache Access Fail Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_fail_int_ena(&self) -> &L1_CACHE_ACS_FAIL_INT_ENA {
+        &self.l1_cache_acs_fail_int_ena
+    }
+    #[doc = "0x16c - L1-Cache Access Fail Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_fail_int_clr(&self) -> &L1_CACHE_ACS_FAIL_INT_CLR {
+        &self.l1_cache_acs_fail_int_clr
+    }
+    #[doc = "0x170 - Cache Access Fail Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_fail_int_raw(&self) -> &L1_CACHE_ACS_FAIL_INT_RAW {
+        &self.l1_cache_acs_fail_int_raw
+    }
+    #[doc = "0x174 - Cache Access Fail Interrupt status register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_fail_int_st(&self) -> &L1_CACHE_ACS_FAIL_INT_ST {
+        &self.l1_cache_acs_fail_int_st
+    }
+    #[doc = "0x178 - Cache Access Counter enable and clear register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_cnt_ctrl(&self) -> &L1_CACHE_ACS_CNT_CTRL {
+        &self.l1_cache_acs_cnt_ctrl
+    }
+    #[doc = "0x17c - L1-ICache bus0 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus0_acs_hit_cnt(&self) -> &L1_IBUS0_ACS_HIT_CNT {
+        &self.l1_ibus0_acs_hit_cnt
+    }
+    #[doc = "0x180 - L1-ICache bus0 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus0_acs_miss_cnt(&self) -> &L1_IBUS0_ACS_MISS_CNT {
+        &self.l1_ibus0_acs_miss_cnt
+    }
+    #[doc = "0x184 - L1-ICache bus0 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus0_acs_conflict_cnt(&self) -> &L1_IBUS0_ACS_CONFLICT_CNT {
+        &self.l1_ibus0_acs_conflict_cnt
+    }
+    #[doc = "0x188 - L1-ICache bus0 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus0_acs_nxtlvl_cnt(&self) -> &L1_IBUS0_ACS_NXTLVL_CNT {
+        &self.l1_ibus0_acs_nxtlvl_cnt
+    }
+    #[doc = "0x18c - L1-ICache bus1 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus1_acs_hit_cnt(&self) -> &L1_IBUS1_ACS_HIT_CNT {
+        &self.l1_ibus1_acs_hit_cnt
+    }
+    #[doc = "0x190 - L1-ICache bus1 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus1_acs_miss_cnt(&self) -> &L1_IBUS1_ACS_MISS_CNT {
+        &self.l1_ibus1_acs_miss_cnt
+    }
+    #[doc = "0x194 - L1-ICache bus1 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus1_acs_conflict_cnt(&self) -> &L1_IBUS1_ACS_CONFLICT_CNT {
+        &self.l1_ibus1_acs_conflict_cnt
+    }
+    #[doc = "0x198 - L1-ICache bus1 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus1_acs_nxtlvl_cnt(&self) -> &L1_IBUS1_ACS_NXTLVL_CNT {
+        &self.l1_ibus1_acs_nxtlvl_cnt
+    }
+    #[doc = "0x19c - L1-ICache bus2 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus2_acs_hit_cnt(&self) -> &L1_IBUS2_ACS_HIT_CNT {
+        &self.l1_ibus2_acs_hit_cnt
+    }
+    #[doc = "0x1a0 - L1-ICache bus2 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus2_acs_miss_cnt(&self) -> &L1_IBUS2_ACS_MISS_CNT {
+        &self.l1_ibus2_acs_miss_cnt
+    }
+    #[doc = "0x1a4 - L1-ICache bus2 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus2_acs_conflict_cnt(&self) -> &L1_IBUS2_ACS_CONFLICT_CNT {
+        &self.l1_ibus2_acs_conflict_cnt
+    }
+    #[doc = "0x1a8 - L1-ICache bus2 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus2_acs_nxtlvl_cnt(&self) -> &L1_IBUS2_ACS_NXTLVL_CNT {
+        &self.l1_ibus2_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1ac - L1-ICache bus3 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus3_acs_hit_cnt(&self) -> &L1_IBUS3_ACS_HIT_CNT {
+        &self.l1_ibus3_acs_hit_cnt
+    }
+    #[doc = "0x1b0 - L1-ICache bus3 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus3_acs_miss_cnt(&self) -> &L1_IBUS3_ACS_MISS_CNT {
+        &self.l1_ibus3_acs_miss_cnt
+    }
+    #[doc = "0x1b4 - L1-ICache bus3 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus3_acs_conflict_cnt(&self) -> &L1_IBUS3_ACS_CONFLICT_CNT {
+        &self.l1_ibus3_acs_conflict_cnt
+    }
+    #[doc = "0x1b8 - L1-ICache bus3 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_ibus3_acs_nxtlvl_cnt(&self) -> &L1_IBUS3_ACS_NXTLVL_CNT {
+        &self.l1_ibus3_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1bc - L1-Cache bus0 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus0_acs_hit_cnt(&self) -> &L1_BUS0_ACS_HIT_CNT {
+        &self.l1_bus0_acs_hit_cnt
+    }
+    #[doc = "0x1c0 - L1-Cache bus0 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus0_acs_miss_cnt(&self) -> &L1_BUS0_ACS_MISS_CNT {
+        &self.l1_bus0_acs_miss_cnt
+    }
+    #[doc = "0x1c4 - L1-Cache bus0 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus0_acs_conflict_cnt(&self) -> &L1_BUS0_ACS_CONFLICT_CNT {
+        &self.l1_bus0_acs_conflict_cnt
+    }
+    #[doc = "0x1c8 - L1-Cache bus0 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus0_acs_nxtlvl_cnt(&self) -> &L1_BUS0_ACS_NXTLVL_CNT {
+        &self.l1_bus0_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1cc - L1-Cache bus1 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus1_acs_hit_cnt(&self) -> &L1_BUS1_ACS_HIT_CNT {
+        &self.l1_bus1_acs_hit_cnt
+    }
+    #[doc = "0x1d0 - L1-Cache bus1 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus1_acs_miss_cnt(&self) -> &L1_BUS1_ACS_MISS_CNT {
+        &self.l1_bus1_acs_miss_cnt
+    }
+    #[doc = "0x1d4 - L1-Cache bus1 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus1_acs_conflict_cnt(&self) -> &L1_BUS1_ACS_CONFLICT_CNT {
+        &self.l1_bus1_acs_conflict_cnt
+    }
+    #[doc = "0x1d8 - L1-Cache bus1 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_bus1_acs_nxtlvl_cnt(&self) -> &L1_BUS1_ACS_NXTLVL_CNT {
+        &self.l1_bus1_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1dc - L1-DCache bus2 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus2_acs_hit_cnt(&self) -> &L1_DBUS2_ACS_HIT_CNT {
+        &self.l1_dbus2_acs_hit_cnt
+    }
+    #[doc = "0x1e0 - L1-DCache bus2 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus2_acs_miss_cnt(&self) -> &L1_DBUS2_ACS_MISS_CNT {
+        &self.l1_dbus2_acs_miss_cnt
+    }
+    #[doc = "0x1e4 - L1-DCache bus2 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus2_acs_conflict_cnt(&self) -> &L1_DBUS2_ACS_CONFLICT_CNT {
+        &self.l1_dbus2_acs_conflict_cnt
+    }
+    #[doc = "0x1e8 - L1-DCache bus2 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus2_acs_nxtlvl_cnt(&self) -> &L1_DBUS2_ACS_NXTLVL_CNT {
+        &self.l1_dbus2_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1ec - L1-DCache bus3 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus3_acs_hit_cnt(&self) -> &L1_DBUS3_ACS_HIT_CNT {
+        &self.l1_dbus3_acs_hit_cnt
+    }
+    #[doc = "0x1f0 - L1-DCache bus3 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus3_acs_miss_cnt(&self) -> &L1_DBUS3_ACS_MISS_CNT {
+        &self.l1_dbus3_acs_miss_cnt
+    }
+    #[doc = "0x1f4 - L1-DCache bus3 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus3_acs_conflict_cnt(&self) -> &L1_DBUS3_ACS_CONFLICT_CNT {
+        &self.l1_dbus3_acs_conflict_cnt
+    }
+    #[doc = "0x1f8 - L1-DCache bus3 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l1_dbus3_acs_nxtlvl_cnt(&self) -> &L1_DBUS3_ACS_NXTLVL_CNT {
+        &self.l1_dbus3_acs_nxtlvl_cnt
+    }
+    #[doc = "0x1fc - L1-ICache0 Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l1_icache0_acs_fail_id_attr(&self) -> &L1_ICACHE0_ACS_FAIL_ID_ATTR {
+        &self.l1_icache0_acs_fail_id_attr
+    }
+    #[doc = "0x200 - L1-ICache0 Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l1_icache0_acs_fail_addr(&self) -> &L1_ICACHE0_ACS_FAIL_ADDR {
+        &self.l1_icache0_acs_fail_addr
+    }
+    #[doc = "0x204 - L1-ICache0 Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l1_icache1_acs_fail_id_attr(&self) -> &L1_ICACHE1_ACS_FAIL_ID_ATTR {
+        &self.l1_icache1_acs_fail_id_attr
+    }
+    #[doc = "0x208 - L1-ICache0 Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l1_icache1_acs_fail_addr(&self) -> &L1_ICACHE1_ACS_FAIL_ADDR {
+        &self.l1_icache1_acs_fail_addr
+    }
+    #[doc = "0x20c - L1-ICache0 Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l1_icache2_acs_fail_id_attr(&self) -> &L1_ICACHE2_ACS_FAIL_ID_ATTR {
+        &self.l1_icache2_acs_fail_id_attr
+    }
+    #[doc = "0x210 - L1-ICache0 Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l1_icache2_acs_fail_addr(&self) -> &L1_ICACHE2_ACS_FAIL_ADDR {
+        &self.l1_icache2_acs_fail_addr
+    }
+    #[doc = "0x214 - L1-ICache0 Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l1_icache3_acs_fail_id_attr(&self) -> &L1_ICACHE3_ACS_FAIL_ID_ATTR {
+        &self.l1_icache3_acs_fail_id_attr
+    }
+    #[doc = "0x218 - L1-ICache0 Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l1_icache3_acs_fail_addr(&self) -> &L1_ICACHE3_ACS_FAIL_ADDR {
+        &self.l1_icache3_acs_fail_addr
+    }
+    #[doc = "0x21c - L1-Cache Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l1_cache_acs_fail_id_attr(&self) -> &L1_CACHE_ACS_FAIL_ID_ATTR {
+        &self.l1_cache_acs_fail_id_attr
+    }
+    #[doc = "0x220 - L1-Cache Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l1_dcache_acs_fail_addr(&self) -> &L1_DCACHE_ACS_FAIL_ADDR {
+        &self.l1_dcache_acs_fail_addr
+    }
+    #[doc = "0x224 - L1-Cache Access Fail Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_preload_int_ena(&self) -> &L1_CACHE_SYNC_PRELOAD_INT_ENA {
+        &self.l1_cache_sync_preload_int_ena
+    }
+    #[doc = "0x228 - Sync Preload operation Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_preload_int_clr(&self) -> &L1_CACHE_SYNC_PRELOAD_INT_CLR {
+        &self.l1_cache_sync_preload_int_clr
+    }
+    #[doc = "0x22c - Sync Preload operation Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_preload_int_raw(&self) -> &L1_CACHE_SYNC_PRELOAD_INT_RAW {
+        &self.l1_cache_sync_preload_int_raw
+    }
+    #[doc = "0x230 - L1-Cache Access Fail Interrupt status register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_preload_int_st(&self) -> &L1_CACHE_SYNC_PRELOAD_INT_ST {
+        &self.l1_cache_sync_preload_int_st
+    }
+    #[doc = "0x234 - Cache Sync/Preload Operation exception register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_preload_exception(&self) -> &L1_CACHE_SYNC_PRELOAD_EXCEPTION {
+        &self.l1_cache_sync_preload_exception
+    }
+    #[doc = "0x238 - Cache Sync Reset control register"]
+    #[inline(always)]
+    pub const fn l1_cache_sync_rst_ctrl(&self) -> &L1_CACHE_SYNC_RST_CTRL {
+        &self.l1_cache_sync_rst_ctrl
+    }
+    #[doc = "0x23c - Cache Preload Reset control register"]
+    #[inline(always)]
+    pub const fn l1_cache_preload_rst_ctrl(&self) -> &L1_CACHE_PRELOAD_RST_CTRL {
+        &self.l1_cache_preload_rst_ctrl
+    }
+    #[doc = "0x240 - Cache Autoload buffer clear control register"]
+    #[inline(always)]
+    pub const fn l1_cache_autoload_buf_clr_ctrl(&self) -> &L1_CACHE_AUTOLOAD_BUF_CLR_CTRL {
+        &self.l1_cache_autoload_buf_clr_ctrl
+    }
+    #[doc = "0x244 - Unallocate request buffer clear registers"]
+    #[inline(always)]
+    pub const fn l1_unallocate_buffer_clear(&self) -> &L1_UNALLOCATE_BUFFER_CLEAR {
+        &self.l1_unallocate_buffer_clear
+    }
+    #[doc = "0x248 - Cache Tag and Data memory Object control register"]
+    #[inline(always)]
+    pub const fn l1_cache_object_ctrl(&self) -> &L1_CACHE_OBJECT_CTRL {
+        &self.l1_cache_object_ctrl
+    }
+    #[doc = "0x24c - Cache Tag and Data memory way register"]
+    #[inline(always)]
+    pub const fn l1_cache_way_object(&self) -> &L1_CACHE_WAY_OBJECT {
+        &self.l1_cache_way_object
+    }
+    #[doc = "0x250 - Cache Vaddr register"]
+    #[inline(always)]
+    pub const fn l1_cache_vaddr(&self) -> &L1_CACHE_VADDR {
+        &self.l1_cache_vaddr
+    }
+    #[doc = "0x254 - Cache Tag/data memory content register"]
+    #[inline(always)]
+    pub const fn l1_cache_debug_bus(&self) -> &L1_CACHE_DEBUG_BUS {
+        &self.l1_cache_debug_bus
+    }
+    #[doc = "0x258 - USED TO SPLIT L1 CACHE AND L2 CACHE"]
+    #[inline(always)]
+    pub const fn level_split0(&self) -> &LEVEL_SPLIT0 {
+        &self.level_split0
+    }
+    #[doc = "0x25c - L2 Cache(L2-Cache) control register"]
+    #[inline(always)]
+    pub const fn l2_cache_ctrl(&self) -> &L2_CACHE_CTRL {
+        &self.l2_cache_ctrl
+    }
+    #[doc = "0x260 - Bypass Cache configure register"]
+    #[inline(always)]
+    pub const fn l2_bypass_cache_conf(&self) -> &L2_BYPASS_CACHE_CONF {
+        &self.l2_bypass_cache_conf
+    }
+    #[doc = "0x264 - L2 Cache CacheSize mode configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_cachesize_conf(&self) -> &L2_CACHE_CACHESIZE_CONF {
+        &self.l2_cache_cachesize_conf
+    }
+    #[doc = "0x268 - L2 Cache BlockSize mode configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_blocksize_conf(&self) -> &L2_CACHE_BLOCKSIZE_CONF {
+        &self.l2_cache_blocksize_conf
+    }
+    #[doc = "0x26c - Cache wrap around control register"]
+    #[inline(always)]
+    pub const fn l2_cache_wrap_around_ctrl(&self) -> &L2_CACHE_WRAP_AROUND_CTRL {
+        &self.l2_cache_wrap_around_ctrl
+    }
+    #[doc = "0x270 - Cache tag memory power control register"]
+    #[inline(always)]
+    pub const fn l2_cache_tag_mem_power_ctrl(&self) -> &L2_CACHE_TAG_MEM_POWER_CTRL {
+        &self.l2_cache_tag_mem_power_ctrl
+    }
+    #[doc = "0x274 - Cache data memory power control register"]
+    #[inline(always)]
+    pub const fn l2_cache_data_mem_power_ctrl(&self) -> &L2_CACHE_DATA_MEM_POWER_CTRL {
+        &self.l2_cache_data_mem_power_ctrl
+    }
+    #[doc = "0x278 - Cache Freeze control register"]
+    #[inline(always)]
+    pub const fn l2_cache_freeze_ctrl(&self) -> &L2_CACHE_FREEZE_CTRL {
+        &self.l2_cache_freeze_ctrl
+    }
+    #[doc = "0x27c - Cache data memory access configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_data_mem_acs_conf(&self) -> &L2_CACHE_DATA_MEM_ACS_CONF {
+        &self.l2_cache_data_mem_acs_conf
+    }
+    #[doc = "0x280 - Cache tag memory access configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_tag_mem_acs_conf(&self) -> &L2_CACHE_TAG_MEM_ACS_CONF {
+        &self.l2_cache_tag_mem_acs_conf
+    }
+    #[doc = "0x284 - L2 Cache prelock configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_prelock_conf(&self) -> &L2_CACHE_PRELOCK_CONF {
+        &self.l2_cache_prelock_conf
+    }
+    #[doc = "0x288 - L2 Cache prelock section0 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_prelock_sct0_addr(&self) -> &L2_CACHE_PRELOCK_SCT0_ADDR {
+        &self.l2_cache_prelock_sct0_addr
+    }
+    #[doc = "0x28c - L2 Cache prelock section1 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_prelock_sct1_addr(&self) -> &L2_CACHE_PRELOCK_SCT1_ADDR {
+        &self.l2_cache_prelock_sct1_addr
+    }
+    #[doc = "0x290 - L2 Cache prelock section size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_prelock_sct_size(&self) -> &L2_CACHE_PRELOCK_SCT_SIZE {
+        &self.l2_cache_prelock_sct_size
+    }
+    #[doc = "0x294 - L2 Cache preload-operation control register"]
+    #[inline(always)]
+    pub const fn l2_cache_preload_ctrl(&self) -> &L2_CACHE_PRELOAD_CTRL {
+        &self.l2_cache_preload_ctrl
+    }
+    #[doc = "0x298 - L2 Cache preload address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_preload_addr(&self) -> &L2_CACHE_PRELOAD_ADDR {
+        &self.l2_cache_preload_addr
+    }
+    #[doc = "0x29c - L2 Cache preload size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_preload_size(&self) -> &L2_CACHE_PRELOAD_SIZE {
+        &self.l2_cache_preload_size
+    }
+    #[doc = "0x2a0 - L2 Cache autoload-operation control register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_ctrl(&self) -> &L2_CACHE_AUTOLOAD_CTRL {
+        &self.l2_cache_autoload_ctrl
+    }
+    #[doc = "0x2a4 - L2 Cache autoload section 0 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct0_addr(&self) -> &L2_CACHE_AUTOLOAD_SCT0_ADDR {
+        &self.l2_cache_autoload_sct0_addr
+    }
+    #[doc = "0x2a8 - L2 Cache autoload section 0 size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct0_size(&self) -> &L2_CACHE_AUTOLOAD_SCT0_SIZE {
+        &self.l2_cache_autoload_sct0_size
+    }
+    #[doc = "0x2ac - L2 Cache autoload section 1 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct1_addr(&self) -> &L2_CACHE_AUTOLOAD_SCT1_ADDR {
+        &self.l2_cache_autoload_sct1_addr
+    }
+    #[doc = "0x2b0 - L2 Cache autoload section 1 size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct1_size(&self) -> &L2_CACHE_AUTOLOAD_SCT1_SIZE {
+        &self.l2_cache_autoload_sct1_size
+    }
+    #[doc = "0x2b4 - L2 Cache autoload section 2 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct2_addr(&self) -> &L2_CACHE_AUTOLOAD_SCT2_ADDR {
+        &self.l2_cache_autoload_sct2_addr
+    }
+    #[doc = "0x2b8 - L2 Cache autoload section 2 size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct2_size(&self) -> &L2_CACHE_AUTOLOAD_SCT2_SIZE {
+        &self.l2_cache_autoload_sct2_size
+    }
+    #[doc = "0x2bc - L2 Cache autoload section 3 address configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct3_addr(&self) -> &L2_CACHE_AUTOLOAD_SCT3_ADDR {
+        &self.l2_cache_autoload_sct3_addr
+    }
+    #[doc = "0x2c0 - L2 Cache autoload section 3 size configure register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_sct3_size(&self) -> &L2_CACHE_AUTOLOAD_SCT3_SIZE {
+        &self.l2_cache_autoload_sct3_size
+    }
+    #[doc = "0x2c4 - Cache Access Counter Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_cnt_int_ena(&self) -> &L2_CACHE_ACS_CNT_INT_ENA {
+        &self.l2_cache_acs_cnt_int_ena
+    }
+    #[doc = "0x2c8 - Cache Access Counter Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_cnt_int_clr(&self) -> &L2_CACHE_ACS_CNT_INT_CLR {
+        &self.l2_cache_acs_cnt_int_clr
+    }
+    #[doc = "0x2cc - Cache Access Counter Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_cnt_int_raw(&self) -> &L2_CACHE_ACS_CNT_INT_RAW {
+        &self.l2_cache_acs_cnt_int_raw
+    }
+    #[doc = "0x2d0 - Cache Access Counter Interrupt status register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_cnt_int_st(&self) -> &L2_CACHE_ACS_CNT_INT_ST {
+        &self.l2_cache_acs_cnt_int_st
+    }
+    #[doc = "0x2d4 - Cache Access Fail Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_int_ena(&self) -> &L2_CACHE_ACS_FAIL_INT_ENA {
+        &self.l2_cache_acs_fail_int_ena
+    }
+    #[doc = "0x2d8 - L1-Cache Access Fail Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_int_clr(&self) -> &L2_CACHE_ACS_FAIL_INT_CLR {
+        &self.l2_cache_acs_fail_int_clr
+    }
+    #[doc = "0x2dc - Cache Access Fail Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_int_raw(&self) -> &L2_CACHE_ACS_FAIL_INT_RAW {
+        &self.l2_cache_acs_fail_int_raw
+    }
+    #[doc = "0x2e0 - Cache Access Fail Interrupt status register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_int_st(&self) -> &L2_CACHE_ACS_FAIL_INT_ST {
+        &self.l2_cache_acs_fail_int_st
+    }
+    #[doc = "0x2e4 - Cache Access Counter enable and clear register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_cnt_ctrl(&self) -> &L2_CACHE_ACS_CNT_CTRL {
+        &self.l2_cache_acs_cnt_ctrl
+    }
+    #[doc = "0x2e8 - L2-Cache bus0 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus0_acs_hit_cnt(&self) -> &L2_IBUS0_ACS_HIT_CNT {
+        &self.l2_ibus0_acs_hit_cnt
+    }
+    #[doc = "0x2ec - L2-Cache bus0 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus0_acs_miss_cnt(&self) -> &L2_IBUS0_ACS_MISS_CNT {
+        &self.l2_ibus0_acs_miss_cnt
+    }
+    #[doc = "0x2f0 - L2-Cache bus0 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus0_acs_conflict_cnt(&self) -> &L2_IBUS0_ACS_CONFLICT_CNT {
+        &self.l2_ibus0_acs_conflict_cnt
+    }
+    #[doc = "0x2f4 - L2-Cache bus0 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus0_acs_nxtlvl_cnt(&self) -> &L2_IBUS0_ACS_NXTLVL_CNT {
+        &self.l2_ibus0_acs_nxtlvl_cnt
+    }
+    #[doc = "0x2f8 - L2-Cache bus1 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus1_acs_hit_cnt(&self) -> &L2_IBUS1_ACS_HIT_CNT {
+        &self.l2_ibus1_acs_hit_cnt
+    }
+    #[doc = "0x2fc - L2-Cache bus1 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus1_acs_miss_cnt(&self) -> &L2_IBUS1_ACS_MISS_CNT {
+        &self.l2_ibus1_acs_miss_cnt
+    }
+    #[doc = "0x300 - L2-Cache bus1 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus1_acs_conflict_cnt(&self) -> &L2_IBUS1_ACS_CONFLICT_CNT {
+        &self.l2_ibus1_acs_conflict_cnt
+    }
+    #[doc = "0x304 - L2-Cache bus1 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus1_acs_nxtlvl_cnt(&self) -> &L2_IBUS1_ACS_NXTLVL_CNT {
+        &self.l2_ibus1_acs_nxtlvl_cnt
+    }
+    #[doc = "0x308 - L2-Cache bus2 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus2_acs_hit_cnt(&self) -> &L2_IBUS2_ACS_HIT_CNT {
+        &self.l2_ibus2_acs_hit_cnt
+    }
+    #[doc = "0x30c - L2-Cache bus2 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus2_acs_miss_cnt(&self) -> &L2_IBUS2_ACS_MISS_CNT {
+        &self.l2_ibus2_acs_miss_cnt
+    }
+    #[doc = "0x310 - L2-Cache bus2 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus2_acs_conflict_cnt(&self) -> &L2_IBUS2_ACS_CONFLICT_CNT {
+        &self.l2_ibus2_acs_conflict_cnt
+    }
+    #[doc = "0x314 - L2-Cache bus2 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus2_acs_nxtlvl_cnt(&self) -> &L2_IBUS2_ACS_NXTLVL_CNT {
+        &self.l2_ibus2_acs_nxtlvl_cnt
+    }
+    #[doc = "0x318 - L2-Cache bus3 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus3_acs_hit_cnt(&self) -> &L2_IBUS3_ACS_HIT_CNT {
+        &self.l2_ibus3_acs_hit_cnt
+    }
+    #[doc = "0x31c - L2-Cache bus3 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus3_acs_miss_cnt(&self) -> &L2_IBUS3_ACS_MISS_CNT {
+        &self.l2_ibus3_acs_miss_cnt
+    }
+    #[doc = "0x320 - L2-Cache bus3 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus3_acs_conflict_cnt(&self) -> &L2_IBUS3_ACS_CONFLICT_CNT {
+        &self.l2_ibus3_acs_conflict_cnt
+    }
+    #[doc = "0x324 - L2-Cache bus3 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_ibus3_acs_nxtlvl_cnt(&self) -> &L2_IBUS3_ACS_NXTLVL_CNT {
+        &self.l2_ibus3_acs_nxtlvl_cnt
+    }
+    #[doc = "0x328 - L2-Cache bus0 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus0_acs_hit_cnt(&self) -> &L2_DBUS0_ACS_HIT_CNT {
+        &self.l2_dbus0_acs_hit_cnt
+    }
+    #[doc = "0x32c - L2-Cache bus0 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus0_acs_miss_cnt(&self) -> &L2_DBUS0_ACS_MISS_CNT {
+        &self.l2_dbus0_acs_miss_cnt
+    }
+    #[doc = "0x330 - L2-Cache bus0 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus0_acs_conflict_cnt(&self) -> &L2_DBUS0_ACS_CONFLICT_CNT {
+        &self.l2_dbus0_acs_conflict_cnt
+    }
+    #[doc = "0x334 - L2-Cache bus0 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus0_acs_nxtlvl_cnt(&self) -> &L2_DBUS0_ACS_NXTLVL_CNT {
+        &self.l2_dbus0_acs_nxtlvl_cnt
+    }
+    #[doc = "0x338 - L2-Cache bus1 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus1_acs_hit_cnt(&self) -> &L2_DBUS1_ACS_HIT_CNT {
+        &self.l2_dbus1_acs_hit_cnt
+    }
+    #[doc = "0x33c - L2-Cache bus1 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus1_acs_miss_cnt(&self) -> &L2_DBUS1_ACS_MISS_CNT {
+        &self.l2_dbus1_acs_miss_cnt
+    }
+    #[doc = "0x340 - L2-Cache bus1 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus1_acs_conflict_cnt(&self) -> &L2_DBUS1_ACS_CONFLICT_CNT {
+        &self.l2_dbus1_acs_conflict_cnt
+    }
+    #[doc = "0x344 - L2-Cache bus1 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus1_acs_nxtlvl_cnt(&self) -> &L2_DBUS1_ACS_NXTLVL_CNT {
+        &self.l2_dbus1_acs_nxtlvl_cnt
+    }
+    #[doc = "0x348 - L2-Cache bus2 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus2_acs_hit_cnt(&self) -> &L2_DBUS2_ACS_HIT_CNT {
+        &self.l2_dbus2_acs_hit_cnt
+    }
+    #[doc = "0x34c - L2-Cache bus2 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus2_acs_miss_cnt(&self) -> &L2_DBUS2_ACS_MISS_CNT {
+        &self.l2_dbus2_acs_miss_cnt
+    }
+    #[doc = "0x350 - L2-Cache bus2 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus2_acs_conflict_cnt(&self) -> &L2_DBUS2_ACS_CONFLICT_CNT {
+        &self.l2_dbus2_acs_conflict_cnt
+    }
+    #[doc = "0x354 - L2-Cache bus2 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus2_acs_nxtlvl_cnt(&self) -> &L2_DBUS2_ACS_NXTLVL_CNT {
+        &self.l2_dbus2_acs_nxtlvl_cnt
+    }
+    #[doc = "0x358 - L2-Cache bus3 Hit-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus3_acs_hit_cnt(&self) -> &L2_DBUS3_ACS_HIT_CNT {
+        &self.l2_dbus3_acs_hit_cnt
+    }
+    #[doc = "0x35c - L2-Cache bus3 Miss-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus3_acs_miss_cnt(&self) -> &L2_DBUS3_ACS_MISS_CNT {
+        &self.l2_dbus3_acs_miss_cnt
+    }
+    #[doc = "0x360 - L2-Cache bus3 Conflict-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus3_acs_conflict_cnt(&self) -> &L2_DBUS3_ACS_CONFLICT_CNT {
+        &self.l2_dbus3_acs_conflict_cnt
+    }
+    #[doc = "0x364 - L2-Cache bus3 Next-Level-Access Counter register"]
+    #[inline(always)]
+    pub const fn l2_dbus3_acs_nxtlvl_cnt(&self) -> &L2_DBUS3_ACS_NXTLVL_CNT {
+        &self.l2_dbus3_acs_nxtlvl_cnt
+    }
+    #[doc = "0x368 - L2-Cache Access Fail ID/attribution information register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_id_attr(&self) -> &L2_CACHE_ACS_FAIL_ID_ATTR {
+        &self.l2_cache_acs_fail_id_attr
+    }
+    #[doc = "0x36c - L2-Cache Access Fail Address information register"]
+    #[inline(always)]
+    pub const fn l2_cache_acs_fail_addr(&self) -> &L2_CACHE_ACS_FAIL_ADDR {
+        &self.l2_cache_acs_fail_addr
+    }
+    #[doc = "0x370 - L1-Cache Access Fail Interrupt enable register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_preload_int_ena(&self) -> &L2_CACHE_SYNC_PRELOAD_INT_ENA {
+        &self.l2_cache_sync_preload_int_ena
+    }
+    #[doc = "0x374 - Sync Preload operation Interrupt clear register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_preload_int_clr(&self) -> &L2_CACHE_SYNC_PRELOAD_INT_CLR {
+        &self.l2_cache_sync_preload_int_clr
+    }
+    #[doc = "0x378 - Sync Preload operation Interrupt raw register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_preload_int_raw(&self) -> &L2_CACHE_SYNC_PRELOAD_INT_RAW {
+        &self.l2_cache_sync_preload_int_raw
+    }
+    #[doc = "0x37c - L1-Cache Access Fail Interrupt status register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_preload_int_st(&self) -> &L2_CACHE_SYNC_PRELOAD_INT_ST {
+        &self.l2_cache_sync_preload_int_st
+    }
+    #[doc = "0x380 - Cache Sync/Preload Operation exception register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_preload_exception(&self) -> &L2_CACHE_SYNC_PRELOAD_EXCEPTION {
+        &self.l2_cache_sync_preload_exception
+    }
+    #[doc = "0x384 - Cache Sync Reset control register"]
+    #[inline(always)]
+    pub const fn l2_cache_sync_rst_ctrl(&self) -> &L2_CACHE_SYNC_RST_CTRL {
+        &self.l2_cache_sync_rst_ctrl
+    }
+    #[doc = "0x388 - Cache Preload Reset control register"]
+    #[inline(always)]
+    pub const fn l2_cache_preload_rst_ctrl(&self) -> &L2_CACHE_PRELOAD_RST_CTRL {
+        &self.l2_cache_preload_rst_ctrl
+    }
+    #[doc = "0x38c - Cache Autoload buffer clear control register"]
+    #[inline(always)]
+    pub const fn l2_cache_autoload_buf_clr_ctrl(&self) -> &L2_CACHE_AUTOLOAD_BUF_CLR_CTRL {
+        &self.l2_cache_autoload_buf_clr_ctrl
+    }
+    #[doc = "0x390 - Unallocate request buffer clear registers"]
+    #[inline(always)]
+    pub const fn l2_unallocate_buffer_clear(&self) -> &L2_UNALLOCATE_BUFFER_CLEAR {
+        &self.l2_unallocate_buffer_clear
+    }
+    #[doc = "0x394 - L1 Cache access Attribute propagation control register"]
+    #[inline(always)]
+    pub const fn l2_cache_access_attr_ctrl(&self) -> &L2_CACHE_ACCESS_ATTR_CTRL {
+        &self.l2_cache_access_attr_ctrl
+    }
+    #[doc = "0x398 - Cache Tag and Data memory Object control register"]
+    #[inline(always)]
+    pub const fn l2_cache_object_ctrl(&self) -> &L2_CACHE_OBJECT_CTRL {
+        &self.l2_cache_object_ctrl
+    }
+    #[doc = "0x39c - Cache Tag and Data memory way register"]
+    #[inline(always)]
+    pub const fn l2_cache_way_object(&self) -> &L2_CACHE_WAY_OBJECT {
+        &self.l2_cache_way_object
+    }
+    #[doc = "0x3a0 - Cache Vaddr register"]
+    #[inline(always)]
+    pub const fn l2_cache_vaddr(&self) -> &L2_CACHE_VADDR {
+        &self.l2_cache_vaddr
+    }
+    #[doc = "0x3a4 - Cache Tag/data memory content register"]
+    #[inline(always)]
+    pub const fn l2_cache_debug_bus(&self) -> &L2_CACHE_DEBUG_BUS {
+        &self.l2_cache_debug_bus
+    }
+    #[doc = "0x3a8 - USED TO SPLIT L1 CACHE AND L2 CACHE"]
+    #[inline(always)]
+    pub const fn level_split1(&self) -> &LEVEL_SPLIT1 {
+        &self.level_split1
+    }
+    #[doc = "0x3ac - Clock gate control register"]
+    #[inline(always)]
+    pub const fn clock_gate(&self) -> &CLOCK_GATE {
+        &self.clock_gate
+    }
+    #[doc = "0x3b0 - Cache redundancy signal 0 register"]
+    #[inline(always)]
+    pub const fn redundancy_sig0(&self) -> &REDUNDANCY_SIG0 {
+        &self.redundancy_sig0
+    }
+    #[doc = "0x3b4 - Cache redundancy signal 1 register"]
+    #[inline(always)]
+    pub const fn redundancy_sig1(&self) -> &REDUNDANCY_SIG1 {
+        &self.redundancy_sig1
+    }
+    #[doc = "0x3b8 - Cache redundancy signal 2 register"]
+    #[inline(always)]
+    pub const fn redundancy_sig2(&self) -> &REDUNDANCY_SIG2 {
+        &self.redundancy_sig2
+    }
+    #[doc = "0x3bc - Cache redundancy signal 3 register"]
+    #[inline(always)]
+    pub const fn redundancy_sig3(&self) -> &REDUNDANCY_SIG3 {
+        &self.redundancy_sig3
+    }
+    #[doc = "0x3c0 - Cache redundancy signal 0 register"]
+    #[inline(always)]
+    pub const fn redundancy_sig4(&self) -> &REDUNDANCY_SIG4 {
+        &self.redundancy_sig4
+    }
+    #[doc = "0x3fc - Version control register"]
+    #[inline(always)]
+    pub const fn date(&self) -> &DATE {
+        &self.date
+    }
+}
+#[doc = "L1_ICACHE_CTRL (r) register accessor: L1 instruction Cache(L1-ICache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache_ctrl`] module"]
+pub type L1_ICACHE_CTRL = crate::Reg<l1_icache_ctrl::L1_ICACHE_CTRL_SPEC>;
+#[doc = "L1 instruction Cache(L1-ICache) control register"]
+pub mod l1_icache_ctrl;
+#[doc = "L1_CACHE_CTRL (rw) register accessor: L1 data Cache(L1-Cache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_ctrl`] module"]
+pub type L1_CACHE_CTRL = crate::Reg<l1_cache_ctrl::L1_CACHE_CTRL_SPEC>;
+#[doc = "L1 data Cache(L1-Cache) control register"]
+pub mod l1_cache_ctrl;
+#[doc = "L1_BYPASS_CACHE_CONF (r) register accessor: Bypass Cache configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bypass_cache_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bypass_cache_conf`] module"]
+pub type L1_BYPASS_CACHE_CONF = crate::Reg<l1_bypass_cache_conf::L1_BYPASS_CACHE_CONF_SPEC>;
+#[doc = "Bypass Cache configure register"]
+pub mod l1_bypass_cache_conf;
+#[doc = "L1_CACHE_ATOMIC_CONF (r) register accessor: L1 Cache atomic feature configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_atomic_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_atomic_conf`] module"]
+pub type L1_CACHE_ATOMIC_CONF = crate::Reg<l1_cache_atomic_conf::L1_CACHE_ATOMIC_CONF_SPEC>;
+#[doc = "L1 Cache atomic feature configure register"]
+pub mod l1_cache_atomic_conf;
+#[doc = "L1_ICACHE_CACHESIZE_CONF (r) register accessor: L1 instruction Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_cachesize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache_cachesize_conf`] module"]
+pub type L1_ICACHE_CACHESIZE_CONF =
+    crate::Reg<l1_icache_cachesize_conf::L1_ICACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "L1 instruction Cache CacheSize mode configure register"]
+pub mod l1_icache_cachesize_conf;
+#[doc = "L1_ICACHE_BLOCKSIZE_CONF (r) register accessor: L1 instruction Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_blocksize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache_blocksize_conf`] module"]
+pub type L1_ICACHE_BLOCKSIZE_CONF =
+    crate::Reg<l1_icache_blocksize_conf::L1_ICACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "L1 instruction Cache BlockSize mode configure register"]
+pub mod l1_icache_blocksize_conf;
+#[doc = "L1_CACHE_CACHESIZE_CONF (r) register accessor: L1 data Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_cachesize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_cachesize_conf`] module"]
+pub type L1_CACHE_CACHESIZE_CONF =
+    crate::Reg<l1_cache_cachesize_conf::L1_CACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "L1 data Cache CacheSize mode configure register"]
+pub mod l1_cache_cachesize_conf;
+#[doc = "L1_CACHE_BLOCKSIZE_CONF (r) register accessor: L1 data Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_blocksize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_blocksize_conf`] module"]
+pub type L1_CACHE_BLOCKSIZE_CONF =
+    crate::Reg<l1_cache_blocksize_conf::L1_CACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "L1 data Cache BlockSize mode configure register"]
+pub mod l1_cache_blocksize_conf;
+#[doc = "L1_CACHE_WRAP_AROUND_CTRL (rw) register accessor: Cache wrap around control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_wrap_around_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_wrap_around_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_wrap_around_ctrl`] module"]
+pub type L1_CACHE_WRAP_AROUND_CTRL =
+    crate::Reg<l1_cache_wrap_around_ctrl::L1_CACHE_WRAP_AROUND_CTRL_SPEC>;
+#[doc = "Cache wrap around control register"]
+pub mod l1_cache_wrap_around_ctrl;
+#[doc = "L1_CACHE_TAG_MEM_POWER_CTRL (rw) register accessor: Cache tag memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_tag_mem_power_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_tag_mem_power_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_tag_mem_power_ctrl`] module"]
+pub type L1_CACHE_TAG_MEM_POWER_CTRL =
+    crate::Reg<l1_cache_tag_mem_power_ctrl::L1_CACHE_TAG_MEM_POWER_CTRL_SPEC>;
+#[doc = "Cache tag memory power control register"]
+pub mod l1_cache_tag_mem_power_ctrl;
+#[doc = "L1_CACHE_DATA_MEM_POWER_CTRL (rw) register accessor: Cache data memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_data_mem_power_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_data_mem_power_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_data_mem_power_ctrl`] module"]
+pub type L1_CACHE_DATA_MEM_POWER_CTRL =
+    crate::Reg<l1_cache_data_mem_power_ctrl::L1_CACHE_DATA_MEM_POWER_CTRL_SPEC>;
+#[doc = "Cache data memory power control register"]
+pub mod l1_cache_data_mem_power_ctrl;
+#[doc = "L1_CACHE_FREEZE_CTRL (rw) register accessor: Cache Freeze control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_freeze_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_freeze_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_freeze_ctrl`] module"]
+pub type L1_CACHE_FREEZE_CTRL = crate::Reg<l1_cache_freeze_ctrl::L1_CACHE_FREEZE_CTRL_SPEC>;
+#[doc = "Cache Freeze control register"]
+pub mod l1_cache_freeze_ctrl;
+#[doc = "L1_CACHE_DATA_MEM_ACS_CONF (rw) register accessor: Cache data memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_data_mem_acs_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_data_mem_acs_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_data_mem_acs_conf`] module"]
+pub type L1_CACHE_DATA_MEM_ACS_CONF =
+    crate::Reg<l1_cache_data_mem_acs_conf::L1_CACHE_DATA_MEM_ACS_CONF_SPEC>;
+#[doc = "Cache data memory access configure register"]
+pub mod l1_cache_data_mem_acs_conf;
+#[doc = "L1_CACHE_TAG_MEM_ACS_CONF (rw) register accessor: Cache tag memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_tag_mem_acs_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_tag_mem_acs_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_tag_mem_acs_conf`] module"]
+pub type L1_CACHE_TAG_MEM_ACS_CONF =
+    crate::Reg<l1_cache_tag_mem_acs_conf::L1_CACHE_TAG_MEM_ACS_CONF_SPEC>;
+#[doc = "Cache tag memory access configure register"]
+pub mod l1_cache_tag_mem_acs_conf;
+#[doc = "L1_ICACHE0_PRELOCK_CONF (r) register accessor: L1 instruction Cache 0 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_prelock_conf`] module"]
+pub type L1_ICACHE0_PRELOCK_CONF =
+    crate::Reg<l1_icache0_prelock_conf::L1_ICACHE0_PRELOCK_CONF_SPEC>;
+#[doc = "L1 instruction Cache 0 prelock configure register"]
+pub mod l1_icache0_prelock_conf;
+#[doc = "L1_ICACHE0_PRELOCK_SCT0_ADDR (r) register accessor: L1 instruction Cache 0 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_prelock_sct0_addr`] module"]
+pub type L1_ICACHE0_PRELOCK_SCT0_ADDR =
+    crate::Reg<l1_icache0_prelock_sct0_addr::L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 0 prelock section0 address configure register"]
+pub mod l1_icache0_prelock_sct0_addr;
+#[doc = "L1_ICACHE0_PRELOCK_SCT1_ADDR (r) register accessor: L1 instruction Cache 0 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_prelock_sct1_addr`] module"]
+pub type L1_ICACHE0_PRELOCK_SCT1_ADDR =
+    crate::Reg<l1_icache0_prelock_sct1_addr::L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 0 prelock section1 address configure register"]
+pub mod l1_icache0_prelock_sct1_addr;
+#[doc = "L1_ICACHE0_PRELOCK_SCT_SIZE (r) register accessor: L1 instruction Cache 0 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_prelock_sct_size`] module"]
+pub type L1_ICACHE0_PRELOCK_SCT_SIZE =
+    crate::Reg<l1_icache0_prelock_sct_size::L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 0 prelock section size configure register"]
+pub mod l1_icache0_prelock_sct_size;
+#[doc = "L1_ICACHE1_PRELOCK_CONF (r) register accessor: L1 instruction Cache 1 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_prelock_conf`] module"]
+pub type L1_ICACHE1_PRELOCK_CONF =
+    crate::Reg<l1_icache1_prelock_conf::L1_ICACHE1_PRELOCK_CONF_SPEC>;
+#[doc = "L1 instruction Cache 1 prelock configure register"]
+pub mod l1_icache1_prelock_conf;
+#[doc = "L1_ICACHE1_PRELOCK_SCT0_ADDR (r) register accessor: L1 instruction Cache 1 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_prelock_sct0_addr`] module"]
+pub type L1_ICACHE1_PRELOCK_SCT0_ADDR =
+    crate::Reg<l1_icache1_prelock_sct0_addr::L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 1 prelock section0 address configure register"]
+pub mod l1_icache1_prelock_sct0_addr;
+#[doc = "L1_ICACHE1_PRELOCK_SCT1_ADDR (r) register accessor: L1 instruction Cache 1 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_prelock_sct1_addr`] module"]
+pub type L1_ICACHE1_PRELOCK_SCT1_ADDR =
+    crate::Reg<l1_icache1_prelock_sct1_addr::L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 1 prelock section1 address configure register"]
+pub mod l1_icache1_prelock_sct1_addr;
+#[doc = "L1_ICACHE1_PRELOCK_SCT_SIZE (r) register accessor: L1 instruction Cache 1 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_prelock_sct_size`] module"]
+pub type L1_ICACHE1_PRELOCK_SCT_SIZE =
+    crate::Reg<l1_icache1_prelock_sct_size::L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 1 prelock section size configure register"]
+pub mod l1_icache1_prelock_sct_size;
+#[doc = "L1_ICACHE2_PRELOCK_CONF (r) register accessor: L1 instruction Cache 2 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_prelock_conf`] module"]
+pub type L1_ICACHE2_PRELOCK_CONF =
+    crate::Reg<l1_icache2_prelock_conf::L1_ICACHE2_PRELOCK_CONF_SPEC>;
+#[doc = "L1 instruction Cache 2 prelock configure register"]
+pub mod l1_icache2_prelock_conf;
+#[doc = "L1_ICACHE2_PRELOCK_SCT0_ADDR (r) register accessor: L1 instruction Cache 2 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_prelock_sct0_addr`] module"]
+pub type L1_ICACHE2_PRELOCK_SCT0_ADDR =
+    crate::Reg<l1_icache2_prelock_sct0_addr::L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 2 prelock section0 address configure register"]
+pub mod l1_icache2_prelock_sct0_addr;
+#[doc = "L1_ICACHE2_PRELOCK_SCT1_ADDR (r) register accessor: L1 instruction Cache 2 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_prelock_sct1_addr`] module"]
+pub type L1_ICACHE2_PRELOCK_SCT1_ADDR =
+    crate::Reg<l1_icache2_prelock_sct1_addr::L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 2 prelock section1 address configure register"]
+pub mod l1_icache2_prelock_sct1_addr;
+#[doc = "L1_ICACHE2_PRELOCK_SCT_SIZE (r) register accessor: L1 instruction Cache 2 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_prelock_sct_size`] module"]
+pub type L1_ICACHE2_PRELOCK_SCT_SIZE =
+    crate::Reg<l1_icache2_prelock_sct_size::L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 2 prelock section size configure register"]
+pub mod l1_icache2_prelock_sct_size;
+#[doc = "L1_ICACHE3_PRELOCK_CONF (r) register accessor: L1 instruction Cache 3 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_prelock_conf`] module"]
+pub type L1_ICACHE3_PRELOCK_CONF =
+    crate::Reg<l1_icache3_prelock_conf::L1_ICACHE3_PRELOCK_CONF_SPEC>;
+#[doc = "L1 instruction Cache 3 prelock configure register"]
+pub mod l1_icache3_prelock_conf;
+#[doc = "L1_ICACHE3_PRELOCK_SCT0_ADDR (r) register accessor: L1 instruction Cache 3 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_prelock_sct0_addr`] module"]
+pub type L1_ICACHE3_PRELOCK_SCT0_ADDR =
+    crate::Reg<l1_icache3_prelock_sct0_addr::L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 3 prelock section0 address configure register"]
+pub mod l1_icache3_prelock_sct0_addr;
+#[doc = "L1_ICACHE3_PRELOCK_SCT1_ADDR (r) register accessor: L1 instruction Cache 3 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_prelock_sct1_addr`] module"]
+pub type L1_ICACHE3_PRELOCK_SCT1_ADDR =
+    crate::Reg<l1_icache3_prelock_sct1_addr::L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 3 prelock section1 address configure register"]
+pub mod l1_icache3_prelock_sct1_addr;
+#[doc = "L1_ICACHE3_PRELOCK_SCT_SIZE (r) register accessor: L1 instruction Cache 3 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_prelock_sct_size`] module"]
+pub type L1_ICACHE3_PRELOCK_SCT_SIZE =
+    crate::Reg<l1_icache3_prelock_sct_size::L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 3 prelock section size configure register"]
+pub mod l1_icache3_prelock_sct_size;
+#[doc = "L1_CACHE_PRELOCK_CONF (rw) register accessor: L1 Cache prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_prelock_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_prelock_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_prelock_conf`] module"]
+pub type L1_CACHE_PRELOCK_CONF = crate::Reg<l1_cache_prelock_conf::L1_CACHE_PRELOCK_CONF_SPEC>;
+#[doc = "L1 Cache prelock configure register"]
+pub mod l1_cache_prelock_conf;
+#[doc = "L1_CACHE_PRELOCK_SCT0_ADDR (rw) register accessor: L1 Cache prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_prelock_sct0_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_prelock_sct0_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_prelock_sct0_addr`] module"]
+pub type L1_CACHE_PRELOCK_SCT0_ADDR =
+    crate::Reg<l1_cache_prelock_sct0_addr::L1_CACHE_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L1 Cache prelock section0 address configure register"]
+pub mod l1_cache_prelock_sct0_addr;
+#[doc = "L1_DCACHE_PRELOCK_SCT1_ADDR (rw) register accessor: L1 Cache prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_prelock_sct1_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_prelock_sct1_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dcache_prelock_sct1_addr`] module"]
+pub type L1_DCACHE_PRELOCK_SCT1_ADDR =
+    crate::Reg<l1_dcache_prelock_sct1_addr::L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L1 Cache prelock section1 address configure register"]
+pub mod l1_dcache_prelock_sct1_addr;
+#[doc = "L1_DCACHE_PRELOCK_SCT_SIZE (rw) register accessor: L1 Cache prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_prelock_sct_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_prelock_sct_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dcache_prelock_sct_size`] module"]
+pub type L1_DCACHE_PRELOCK_SCT_SIZE =
+    crate::Reg<l1_dcache_prelock_sct_size::L1_DCACHE_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L1 Cache prelock section size configure register"]
+pub mod l1_dcache_prelock_sct_size;
+#[doc = "CACHE_LOCK_CTRL (rw) register accessor: Lock-class (manual lock) operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_lock_ctrl`] module"]
+pub type CACHE_LOCK_CTRL = crate::Reg<cache_lock_ctrl::CACHE_LOCK_CTRL_SPEC>;
+#[doc = "Lock-class (manual lock) operation control register"]
+pub mod cache_lock_ctrl;
+#[doc = "CACHE_LOCK_MAP (rw) register accessor: Lock (manual lock) map configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_map::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_map::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_lock_map`] module"]
+pub type CACHE_LOCK_MAP = crate::Reg<cache_lock_map::CACHE_LOCK_MAP_SPEC>;
+#[doc = "Lock (manual lock) map configure register"]
+pub mod cache_lock_map;
+#[doc = "CACHE_LOCK_ADDR (rw) register accessor: Lock (manual lock) address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_lock_addr`] module"]
+pub type CACHE_LOCK_ADDR = crate::Reg<cache_lock_addr::CACHE_LOCK_ADDR_SPEC>;
+#[doc = "Lock (manual lock) address configure register"]
+pub mod cache_lock_addr;
+#[doc = "CACHE_LOCK_SIZE (rw) register accessor: Lock (manual lock) size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_lock_size`] module"]
+pub type CACHE_LOCK_SIZE = crate::Reg<cache_lock_size::CACHE_LOCK_SIZE_SPEC>;
+#[doc = "Lock (manual lock) size configure register"]
+pub mod cache_lock_size;
+#[doc = "CACHE_SYNC_CTRL (rw) register accessor: Sync-class operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_sync_ctrl`] module"]
+pub type CACHE_SYNC_CTRL = crate::Reg<cache_sync_ctrl::CACHE_SYNC_CTRL_SPEC>;
+#[doc = "Sync-class operation control register"]
+pub mod cache_sync_ctrl;
+#[doc = "CACHE_SYNC_MAP (rw) register accessor: Sync map configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_map::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_map::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_sync_map`] module"]
+pub type CACHE_SYNC_MAP = crate::Reg<cache_sync_map::CACHE_SYNC_MAP_SPEC>;
+#[doc = "Sync map configure register"]
+pub mod cache_sync_map;
+#[doc = "CACHE_SYNC_ADDR (rw) register accessor: Sync address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_sync_addr`] module"]
+pub type CACHE_SYNC_ADDR = crate::Reg<cache_sync_addr::CACHE_SYNC_ADDR_SPEC>;
+#[doc = "Sync address configure register"]
+pub mod cache_sync_addr;
+#[doc = "CACHE_SYNC_SIZE (rw) register accessor: Sync size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@cache_sync_size`] module"]
+pub type CACHE_SYNC_SIZE = crate::Reg<cache_sync_size::CACHE_SYNC_SIZE_SPEC>;
+#[doc = "Sync size configure register"]
+pub mod cache_sync_size;
+#[doc = "L1_ICACHE0_PRELOAD_CTRL (rw) register accessor: L1 instruction Cache 0 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache0_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_preload_ctrl`] module"]
+pub type L1_ICACHE0_PRELOAD_CTRL =
+    crate::Reg<l1_icache0_preload_ctrl::L1_ICACHE0_PRELOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 0 preload-operation control register"]
+pub mod l1_icache0_preload_ctrl;
+#[doc = "L1_ICACHE0_PRELOAD_ADDR (r) register accessor: L1 instruction Cache 0 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_preload_addr`] module"]
+pub type L1_ICACHE0_PRELOAD_ADDR =
+    crate::Reg<l1_icache0_preload_addr::L1_ICACHE0_PRELOAD_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 0 preload address configure register"]
+pub mod l1_icache0_preload_addr;
+#[doc = "L1_ICACHE0_PRELOAD_SIZE (r) register accessor: L1 instruction Cache 0 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_preload_size`] module"]
+pub type L1_ICACHE0_PRELOAD_SIZE =
+    crate::Reg<l1_icache0_preload_size::L1_ICACHE0_PRELOAD_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 0 preload size configure register"]
+pub mod l1_icache0_preload_size;
+#[doc = "L1_ICACHE1_PRELOAD_CTRL (rw) register accessor: L1 instruction Cache 1 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache1_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_preload_ctrl`] module"]
+pub type L1_ICACHE1_PRELOAD_CTRL =
+    crate::Reg<l1_icache1_preload_ctrl::L1_ICACHE1_PRELOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 1 preload-operation control register"]
+pub mod l1_icache1_preload_ctrl;
+#[doc = "L1_ICACHE1_PRELOAD_ADDR (r) register accessor: L1 instruction Cache 1 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_preload_addr`] module"]
+pub type L1_ICACHE1_PRELOAD_ADDR =
+    crate::Reg<l1_icache1_preload_addr::L1_ICACHE1_PRELOAD_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 1 preload address configure register"]
+pub mod l1_icache1_preload_addr;
+#[doc = "L1_ICACHE1_PRELOAD_SIZE (r) register accessor: L1 instruction Cache 1 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_preload_size`] module"]
+pub type L1_ICACHE1_PRELOAD_SIZE =
+    crate::Reg<l1_icache1_preload_size::L1_ICACHE1_PRELOAD_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 1 preload size configure register"]
+pub mod l1_icache1_preload_size;
+#[doc = "L1_ICACHE2_PRELOAD_CTRL (rw) register accessor: L1 instruction Cache 2 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache2_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_preload_ctrl`] module"]
+pub type L1_ICACHE2_PRELOAD_CTRL =
+    crate::Reg<l1_icache2_preload_ctrl::L1_ICACHE2_PRELOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 2 preload-operation control register"]
+pub mod l1_icache2_preload_ctrl;
+#[doc = "L1_ICACHE2_PRELOAD_ADDR (r) register accessor: L1 instruction Cache 2 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_preload_addr`] module"]
+pub type L1_ICACHE2_PRELOAD_ADDR =
+    crate::Reg<l1_icache2_preload_addr::L1_ICACHE2_PRELOAD_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 2 preload address configure register"]
+pub mod l1_icache2_preload_addr;
+#[doc = "L1_ICACHE2_PRELOAD_SIZE (r) register accessor: L1 instruction Cache 2 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_preload_size`] module"]
+pub type L1_ICACHE2_PRELOAD_SIZE =
+    crate::Reg<l1_icache2_preload_size::L1_ICACHE2_PRELOAD_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 2 preload size configure register"]
+pub mod l1_icache2_preload_size;
+#[doc = "L1_ICACHE3_PRELOAD_CTRL (rw) register accessor: L1 instruction Cache 3 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache3_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_preload_ctrl`] module"]
+pub type L1_ICACHE3_PRELOAD_CTRL =
+    crate::Reg<l1_icache3_preload_ctrl::L1_ICACHE3_PRELOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 3 preload-operation control register"]
+pub mod l1_icache3_preload_ctrl;
+#[doc = "L1_ICACHE3_PRELOAD_ADDR (r) register accessor: L1 instruction Cache 3 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_preload_addr`] module"]
+pub type L1_ICACHE3_PRELOAD_ADDR =
+    crate::Reg<l1_icache3_preload_addr::L1_ICACHE3_PRELOAD_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 3 preload address configure register"]
+pub mod l1_icache3_preload_addr;
+#[doc = "L1_ICACHE3_PRELOAD_SIZE (r) register accessor: L1 instruction Cache 3 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_preload_size`] module"]
+pub type L1_ICACHE3_PRELOAD_SIZE =
+    crate::Reg<l1_icache3_preload_size::L1_ICACHE3_PRELOAD_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 3 preload size configure register"]
+pub mod l1_icache3_preload_size;
+#[doc = "L1_CACHE_PRELOAD_CTRL (rw) register accessor: L1 Cache preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_preload_ctrl`] module"]
+pub type L1_CACHE_PRELOAD_CTRL = crate::Reg<l1_cache_preload_ctrl::L1_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "L1 Cache preload-operation control register"]
+pub mod l1_cache_preload_ctrl;
+#[doc = "L1_DCACHE_PRELOAD_ADDR (rw) register accessor: L1 Cache preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_preload_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_preload_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dcache_preload_addr`] module"]
+pub type L1_DCACHE_PRELOAD_ADDR = crate::Reg<l1_dcache_preload_addr::L1_DCACHE_PRELOAD_ADDR_SPEC>;
+#[doc = "L1 Cache preload address configure register"]
+pub mod l1_dcache_preload_addr;
+#[doc = "L1_DCACHE_PRELOAD_SIZE (rw) register accessor: L1 Cache preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_preload_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_preload_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dcache_preload_size`] module"]
+pub type L1_DCACHE_PRELOAD_SIZE = crate::Reg<l1_dcache_preload_size::L1_DCACHE_PRELOAD_SIZE_SPEC>;
+#[doc = "L1 Cache preload size configure register"]
+pub mod l1_dcache_preload_size;
+#[doc = "L1_ICACHE0_AUTOLOAD_CTRL (r) register accessor: L1 instruction Cache 0 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_autoload_ctrl`] module"]
+pub type L1_ICACHE0_AUTOLOAD_CTRL =
+    crate::Reg<l1_icache0_autoload_ctrl::L1_ICACHE0_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 0 autoload-operation control register"]
+pub mod l1_icache0_autoload_ctrl;
+#[doc = "L1_ICACHE0_AUTOLOAD_SCT0_ADDR (r) register accessor: L1 instruction Cache 0 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_autoload_sct0_addr`] module"]
+pub type L1_ICACHE0_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l1_icache0_autoload_sct0_addr::L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 0 autoload section 0 address configure register"]
+pub mod l1_icache0_autoload_sct0_addr;
+#[doc = "L1_ICACHE0_AUTOLOAD_SCT0_SIZE (r) register accessor: L1 instruction Cache 0 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct0_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_autoload_sct0_size`] module"]
+pub type L1_ICACHE0_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l1_icache0_autoload_sct0_size::L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 0 autoload section 0 size configure register"]
+pub mod l1_icache0_autoload_sct0_size;
+#[doc = "L1_ICACHE0_AUTOLOAD_SCT1_ADDR (r) register accessor: L1 instruction Cache 0 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_autoload_sct1_addr`] module"]
+pub type L1_ICACHE0_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l1_icache0_autoload_sct1_addr::L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 0 autoload section 1 address configure register"]
+pub mod l1_icache0_autoload_sct1_addr;
+#[doc = "L1_ICACHE0_AUTOLOAD_SCT1_SIZE (r) register accessor: L1 instruction Cache 0 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct1_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_autoload_sct1_size`] module"]
+pub type L1_ICACHE0_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l1_icache0_autoload_sct1_size::L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 0 autoload section 1 size configure register"]
+pub mod l1_icache0_autoload_sct1_size;
+#[doc = "L1_ICACHE1_AUTOLOAD_CTRL (r) register accessor: L1 instruction Cache 1 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_autoload_ctrl`] module"]
+pub type L1_ICACHE1_AUTOLOAD_CTRL =
+    crate::Reg<l1_icache1_autoload_ctrl::L1_ICACHE1_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 1 autoload-operation control register"]
+pub mod l1_icache1_autoload_ctrl;
+#[doc = "L1_ICACHE1_AUTOLOAD_SCT0_ADDR (r) register accessor: L1 instruction Cache 1 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_autoload_sct0_addr`] module"]
+pub type L1_ICACHE1_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l1_icache1_autoload_sct0_addr::L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 1 autoload section 0 address configure register"]
+pub mod l1_icache1_autoload_sct0_addr;
+#[doc = "L1_ICACHE1_AUTOLOAD_SCT0_SIZE (r) register accessor: L1 instruction Cache 1 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct0_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_autoload_sct0_size`] module"]
+pub type L1_ICACHE1_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l1_icache1_autoload_sct0_size::L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 1 autoload section 0 size configure register"]
+pub mod l1_icache1_autoload_sct0_size;
+#[doc = "L1_ICACHE1_AUTOLOAD_SCT1_ADDR (r) register accessor: L1 instruction Cache 1 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_autoload_sct1_addr`] module"]
+pub type L1_ICACHE1_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l1_icache1_autoload_sct1_addr::L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 1 autoload section 1 address configure register"]
+pub mod l1_icache1_autoload_sct1_addr;
+#[doc = "L1_ICACHE1_AUTOLOAD_SCT1_SIZE (r) register accessor: L1 instruction Cache 1 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct1_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_autoload_sct1_size`] module"]
+pub type L1_ICACHE1_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l1_icache1_autoload_sct1_size::L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 1 autoload section 1 size configure register"]
+pub mod l1_icache1_autoload_sct1_size;
+#[doc = "L1_ICACHE2_AUTOLOAD_CTRL (r) register accessor: L1 instruction Cache 2 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_autoload_ctrl`] module"]
+pub type L1_ICACHE2_AUTOLOAD_CTRL =
+    crate::Reg<l1_icache2_autoload_ctrl::L1_ICACHE2_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 2 autoload-operation control register"]
+pub mod l1_icache2_autoload_ctrl;
+#[doc = "L1_ICACHE2_AUTOLOAD_SCT0_ADDR (r) register accessor: L1 instruction Cache 2 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_autoload_sct0_addr`] module"]
+pub type L1_ICACHE2_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l1_icache2_autoload_sct0_addr::L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 2 autoload section 0 address configure register"]
+pub mod l1_icache2_autoload_sct0_addr;
+#[doc = "L1_ICACHE2_AUTOLOAD_SCT0_SIZE (r) register accessor: L1 instruction Cache 2 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct0_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_autoload_sct0_size`] module"]
+pub type L1_ICACHE2_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l1_icache2_autoload_sct0_size::L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 2 autoload section 0 size configure register"]
+pub mod l1_icache2_autoload_sct0_size;
+#[doc = "L1_ICACHE2_AUTOLOAD_SCT1_ADDR (r) register accessor: L1 instruction Cache 2 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_autoload_sct1_addr`] module"]
+pub type L1_ICACHE2_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l1_icache2_autoload_sct1_addr::L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 2 autoload section 1 address configure register"]
+pub mod l1_icache2_autoload_sct1_addr;
+#[doc = "L1_ICACHE2_AUTOLOAD_SCT1_SIZE (r) register accessor: L1 instruction Cache 2 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct1_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_autoload_sct1_size`] module"]
+pub type L1_ICACHE2_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l1_icache2_autoload_sct1_size::L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 2 autoload section 1 size configure register"]
+pub mod l1_icache2_autoload_sct1_size;
+#[doc = "L1_ICACHE3_AUTOLOAD_CTRL (r) register accessor: L1 instruction Cache 3 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_autoload_ctrl`] module"]
+pub type L1_ICACHE3_AUTOLOAD_CTRL =
+    crate::Reg<l1_icache3_autoload_ctrl::L1_ICACHE3_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L1 instruction Cache 3 autoload-operation control register"]
+pub mod l1_icache3_autoload_ctrl;
+#[doc = "L1_ICACHE3_AUTOLOAD_SCT0_ADDR (r) register accessor: L1 instruction Cache 3 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_autoload_sct0_addr`] module"]
+pub type L1_ICACHE3_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l1_icache3_autoload_sct0_addr::L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 3 autoload section 0 address configure register"]
+pub mod l1_icache3_autoload_sct0_addr;
+#[doc = "L1_ICACHE3_AUTOLOAD_SCT0_SIZE (r) register accessor: L1 instruction Cache 3 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct0_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_autoload_sct0_size`] module"]
+pub type L1_ICACHE3_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l1_icache3_autoload_sct0_size::L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 3 autoload section 0 size configure register"]
+pub mod l1_icache3_autoload_sct0_size;
+#[doc = "L1_ICACHE3_AUTOLOAD_SCT1_ADDR (r) register accessor: L1 instruction Cache 3 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_autoload_sct1_addr`] module"]
+pub type L1_ICACHE3_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l1_icache3_autoload_sct1_addr::L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L1 instruction Cache 3 autoload section 1 address configure register"]
+pub mod l1_icache3_autoload_sct1_addr;
+#[doc = "L1_ICACHE3_AUTOLOAD_SCT1_SIZE (r) register accessor: L1 instruction Cache 3 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct1_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_autoload_sct1_size`] module"]
+pub type L1_ICACHE3_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l1_icache3_autoload_sct1_size::L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L1 instruction Cache 3 autoload section 1 size configure register"]
+pub mod l1_icache3_autoload_sct1_size;
+#[doc = "L1_CACHE_AUTOLOAD_CTRL (rw) register accessor: L1 Cache autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_ctrl`] module"]
+pub type L1_CACHE_AUTOLOAD_CTRL = crate::Reg<l1_cache_autoload_ctrl::L1_CACHE_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L1 Cache autoload-operation control register"]
+pub mod l1_cache_autoload_ctrl;
+#[doc = "L1_CACHE_AUTOLOAD_SCT0_ADDR (rw) register accessor: L1 Cache autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct0_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct0_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct0_addr`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l1_cache_autoload_sct0_addr::L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L1 Cache autoload section 0 address configure register"]
+pub mod l1_cache_autoload_sct0_addr;
+#[doc = "L1_CACHE_AUTOLOAD_SCT0_SIZE (rw) register accessor: L1 Cache autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct0_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct0_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct0_size`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l1_cache_autoload_sct0_size::L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L1 Cache autoload section 0 size configure register"]
+pub mod l1_cache_autoload_sct0_size;
+#[doc = "L1_CACHE_AUTOLOAD_SCT1_ADDR (rw) register accessor: L1 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct1_addr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct1_addr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct1_addr`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l1_cache_autoload_sct1_addr::L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L1 Cache autoload section 1 address configure register"]
+pub mod l1_cache_autoload_sct1_addr;
+#[doc = "L1_CACHE_AUTOLOAD_SCT1_SIZE (rw) register accessor: L1 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct1_size::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct1_size::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct1_size`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l1_cache_autoload_sct1_size::L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L1 Cache autoload section 1 size configure register"]
+pub mod l1_cache_autoload_sct1_size;
+#[doc = "L1_CACHE_AUTOLOAD_SCT2_ADDR (r) register accessor: L1 Cache autoload section 2 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct2_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct2_addr`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT2_ADDR =
+    crate::Reg<l1_cache_autoload_sct2_addr::L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC>;
+#[doc = "L1 Cache autoload section 2 address configure register"]
+pub mod l1_cache_autoload_sct2_addr;
+#[doc = "L1_CACHE_AUTOLOAD_SCT2_SIZE (r) register accessor: L1 Cache autoload section 2 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct2_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct2_size`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT2_SIZE =
+    crate::Reg<l1_cache_autoload_sct2_size::L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC>;
+#[doc = "L1 Cache autoload section 2 size configure register"]
+pub mod l1_cache_autoload_sct2_size;
+#[doc = "L1_CACHE_AUTOLOAD_SCT3_ADDR (r) register accessor: L1 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct3_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct3_addr`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT3_ADDR =
+    crate::Reg<l1_cache_autoload_sct3_addr::L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC>;
+#[doc = "L1 Cache autoload section 1 address configure register"]
+pub mod l1_cache_autoload_sct3_addr;
+#[doc = "L1_CACHE_AUTOLOAD_SCT3_SIZE (r) register accessor: L1 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct3_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_sct3_size`] module"]
+pub type L1_CACHE_AUTOLOAD_SCT3_SIZE =
+    crate::Reg<l1_cache_autoload_sct3_size::L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC>;
+#[doc = "L1 Cache autoload section 1 size configure register"]
+pub mod l1_cache_autoload_sct3_size;
+#[doc = "L1_CACHE_ACS_CNT_INT_ENA (rw) register accessor: Cache Access Counter Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_ena::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_ena::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_cnt_int_ena`] module"]
+pub type L1_CACHE_ACS_CNT_INT_ENA =
+    crate::Reg<l1_cache_acs_cnt_int_ena::L1_CACHE_ACS_CNT_INT_ENA_SPEC>;
+#[doc = "Cache Access Counter Interrupt enable register"]
+pub mod l1_cache_acs_cnt_int_ena;
+#[doc = "L1_CACHE_ACS_CNT_INT_CLR (rw) register accessor: Cache Access Counter Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_clr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_clr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_cnt_int_clr`] module"]
+pub type L1_CACHE_ACS_CNT_INT_CLR =
+    crate::Reg<l1_cache_acs_cnt_int_clr::L1_CACHE_ACS_CNT_INT_CLR_SPEC>;
+#[doc = "Cache Access Counter Interrupt clear register"]
+pub mod l1_cache_acs_cnt_int_clr;
+#[doc = "L1_CACHE_ACS_CNT_INT_RAW (rw) register accessor: Cache Access Counter Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_cnt_int_raw`] module"]
+pub type L1_CACHE_ACS_CNT_INT_RAW =
+    crate::Reg<l1_cache_acs_cnt_int_raw::L1_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Cache Access Counter Interrupt raw register"]
+pub mod l1_cache_acs_cnt_int_raw;
+#[doc = "L1_CACHE_ACS_CNT_INT_ST (r) register accessor: Cache Access Counter Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_cnt_int_st`] module"]
+pub type L1_CACHE_ACS_CNT_INT_ST =
+    crate::Reg<l1_cache_acs_cnt_int_st::L1_CACHE_ACS_CNT_INT_ST_SPEC>;
+#[doc = "Cache Access Counter Interrupt status register"]
+pub mod l1_cache_acs_cnt_int_st;
+#[doc = "L1_CACHE_ACS_FAIL_INT_ENA (rw) register accessor: Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_ena::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_ena::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_fail_int_ena`] module"]
+pub type L1_CACHE_ACS_FAIL_INT_ENA =
+    crate::Reg<l1_cache_acs_fail_int_ena::L1_CACHE_ACS_FAIL_INT_ENA_SPEC>;
+#[doc = "Cache Access Fail Interrupt enable register"]
+pub mod l1_cache_acs_fail_int_ena;
+#[doc = "L1_CACHE_ACS_FAIL_INT_CLR (rw) register accessor: L1-Cache Access Fail Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_clr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_clr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_fail_int_clr`] module"]
+pub type L1_CACHE_ACS_FAIL_INT_CLR =
+    crate::Reg<l1_cache_acs_fail_int_clr::L1_CACHE_ACS_FAIL_INT_CLR_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt clear register"]
+pub mod l1_cache_acs_fail_int_clr;
+#[doc = "L1_CACHE_ACS_FAIL_INT_RAW (rw) register accessor: Cache Access Fail Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_fail_int_raw`] module"]
+pub type L1_CACHE_ACS_FAIL_INT_RAW =
+    crate::Reg<l1_cache_acs_fail_int_raw::L1_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Cache Access Fail Interrupt raw register"]
+pub mod l1_cache_acs_fail_int_raw;
+#[doc = "L1_CACHE_ACS_FAIL_INT_ST (r) register accessor: Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_fail_int_st`] module"]
+pub type L1_CACHE_ACS_FAIL_INT_ST =
+    crate::Reg<l1_cache_acs_fail_int_st::L1_CACHE_ACS_FAIL_INT_ST_SPEC>;
+#[doc = "Cache Access Fail Interrupt status register"]
+pub mod l1_cache_acs_fail_int_st;
+#[doc = "L1_CACHE_ACS_CNT_CTRL (rw) register accessor: Cache Access Counter enable and clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_cnt_ctrl`] module"]
+pub type L1_CACHE_ACS_CNT_CTRL = crate::Reg<l1_cache_acs_cnt_ctrl::L1_CACHE_ACS_CNT_CTRL_SPEC>;
+#[doc = "Cache Access Counter enable and clear register"]
+pub mod l1_cache_acs_cnt_ctrl;
+#[doc = "L1_IBUS0_ACS_HIT_CNT (r) register accessor: L1-ICache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus0_acs_hit_cnt`] module"]
+pub type L1_IBUS0_ACS_HIT_CNT = crate::Reg<l1_ibus0_acs_hit_cnt::L1_IBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-ICache bus0 Hit-Access Counter register"]
+pub mod l1_ibus0_acs_hit_cnt;
+#[doc = "L1_IBUS0_ACS_MISS_CNT (r) register accessor: L1-ICache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus0_acs_miss_cnt`] module"]
+pub type L1_IBUS0_ACS_MISS_CNT = crate::Reg<l1_ibus0_acs_miss_cnt::L1_IBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-ICache bus0 Miss-Access Counter register"]
+pub mod l1_ibus0_acs_miss_cnt;
+#[doc = "L1_IBUS0_ACS_CONFLICT_CNT (r) register accessor: L1-ICache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus0_acs_conflict_cnt`] module"]
+pub type L1_IBUS0_ACS_CONFLICT_CNT =
+    crate::Reg<l1_ibus0_acs_conflict_cnt::L1_IBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-ICache bus0 Conflict-Access Counter register"]
+pub mod l1_ibus0_acs_conflict_cnt;
+#[doc = "L1_IBUS0_ACS_NXTLVL_CNT (r) register accessor: L1-ICache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus0_acs_nxtlvl_cnt`] module"]
+pub type L1_IBUS0_ACS_NXTLVL_CNT =
+    crate::Reg<l1_ibus0_acs_nxtlvl_cnt::L1_IBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-ICache bus0 Next-Level-Access Counter register"]
+pub mod l1_ibus0_acs_nxtlvl_cnt;
+#[doc = "L1_IBUS1_ACS_HIT_CNT (r) register accessor: L1-ICache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus1_acs_hit_cnt`] module"]
+pub type L1_IBUS1_ACS_HIT_CNT = crate::Reg<l1_ibus1_acs_hit_cnt::L1_IBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-ICache bus1 Hit-Access Counter register"]
+pub mod l1_ibus1_acs_hit_cnt;
+#[doc = "L1_IBUS1_ACS_MISS_CNT (r) register accessor: L1-ICache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus1_acs_miss_cnt`] module"]
+pub type L1_IBUS1_ACS_MISS_CNT = crate::Reg<l1_ibus1_acs_miss_cnt::L1_IBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-ICache bus1 Miss-Access Counter register"]
+pub mod l1_ibus1_acs_miss_cnt;
+#[doc = "L1_IBUS1_ACS_CONFLICT_CNT (r) register accessor: L1-ICache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus1_acs_conflict_cnt`] module"]
+pub type L1_IBUS1_ACS_CONFLICT_CNT =
+    crate::Reg<l1_ibus1_acs_conflict_cnt::L1_IBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-ICache bus1 Conflict-Access Counter register"]
+pub mod l1_ibus1_acs_conflict_cnt;
+#[doc = "L1_IBUS1_ACS_NXTLVL_CNT (r) register accessor: L1-ICache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus1_acs_nxtlvl_cnt`] module"]
+pub type L1_IBUS1_ACS_NXTLVL_CNT =
+    crate::Reg<l1_ibus1_acs_nxtlvl_cnt::L1_IBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-ICache bus1 Next-Level-Access Counter register"]
+pub mod l1_ibus1_acs_nxtlvl_cnt;
+#[doc = "L1_IBUS2_ACS_HIT_CNT (r) register accessor: L1-ICache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus2_acs_hit_cnt`] module"]
+pub type L1_IBUS2_ACS_HIT_CNT = crate::Reg<l1_ibus2_acs_hit_cnt::L1_IBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-ICache bus2 Hit-Access Counter register"]
+pub mod l1_ibus2_acs_hit_cnt;
+#[doc = "L1_IBUS2_ACS_MISS_CNT (r) register accessor: L1-ICache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus2_acs_miss_cnt`] module"]
+pub type L1_IBUS2_ACS_MISS_CNT = crate::Reg<l1_ibus2_acs_miss_cnt::L1_IBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-ICache bus2 Miss-Access Counter register"]
+pub mod l1_ibus2_acs_miss_cnt;
+#[doc = "L1_IBUS2_ACS_CONFLICT_CNT (r) register accessor: L1-ICache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus2_acs_conflict_cnt`] module"]
+pub type L1_IBUS2_ACS_CONFLICT_CNT =
+    crate::Reg<l1_ibus2_acs_conflict_cnt::L1_IBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-ICache bus2 Conflict-Access Counter register"]
+pub mod l1_ibus2_acs_conflict_cnt;
+#[doc = "L1_IBUS2_ACS_NXTLVL_CNT (r) register accessor: L1-ICache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus2_acs_nxtlvl_cnt`] module"]
+pub type L1_IBUS2_ACS_NXTLVL_CNT =
+    crate::Reg<l1_ibus2_acs_nxtlvl_cnt::L1_IBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-ICache bus2 Next-Level-Access Counter register"]
+pub mod l1_ibus2_acs_nxtlvl_cnt;
+#[doc = "L1_IBUS3_ACS_HIT_CNT (r) register accessor: L1-ICache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus3_acs_hit_cnt`] module"]
+pub type L1_IBUS3_ACS_HIT_CNT = crate::Reg<l1_ibus3_acs_hit_cnt::L1_IBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-ICache bus3 Hit-Access Counter register"]
+pub mod l1_ibus3_acs_hit_cnt;
+#[doc = "L1_IBUS3_ACS_MISS_CNT (r) register accessor: L1-ICache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus3_acs_miss_cnt`] module"]
+pub type L1_IBUS3_ACS_MISS_CNT = crate::Reg<l1_ibus3_acs_miss_cnt::L1_IBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-ICache bus3 Miss-Access Counter register"]
+pub mod l1_ibus3_acs_miss_cnt;
+#[doc = "L1_IBUS3_ACS_CONFLICT_CNT (r) register accessor: L1-ICache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus3_acs_conflict_cnt`] module"]
+pub type L1_IBUS3_ACS_CONFLICT_CNT =
+    crate::Reg<l1_ibus3_acs_conflict_cnt::L1_IBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-ICache bus3 Conflict-Access Counter register"]
+pub mod l1_ibus3_acs_conflict_cnt;
+#[doc = "L1_IBUS3_ACS_NXTLVL_CNT (r) register accessor: L1-ICache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_ibus3_acs_nxtlvl_cnt`] module"]
+pub type L1_IBUS3_ACS_NXTLVL_CNT =
+    crate::Reg<l1_ibus3_acs_nxtlvl_cnt::L1_IBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-ICache bus3 Next-Level-Access Counter register"]
+pub mod l1_ibus3_acs_nxtlvl_cnt;
+#[doc = "L1_BUS0_ACS_HIT_CNT (r) register accessor: L1-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus0_acs_hit_cnt`] module"]
+pub type L1_BUS0_ACS_HIT_CNT = crate::Reg<l1_bus0_acs_hit_cnt::L1_BUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-Cache bus0 Hit-Access Counter register"]
+pub mod l1_bus0_acs_hit_cnt;
+#[doc = "L1_BUS0_ACS_MISS_CNT (r) register accessor: L1-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus0_acs_miss_cnt`] module"]
+pub type L1_BUS0_ACS_MISS_CNT = crate::Reg<l1_bus0_acs_miss_cnt::L1_BUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-Cache bus0 Miss-Access Counter register"]
+pub mod l1_bus0_acs_miss_cnt;
+#[doc = "L1_BUS0_ACS_CONFLICT_CNT (r) register accessor: L1-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus0_acs_conflict_cnt`] module"]
+pub type L1_BUS0_ACS_CONFLICT_CNT =
+    crate::Reg<l1_bus0_acs_conflict_cnt::L1_BUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-Cache bus0 Conflict-Access Counter register"]
+pub mod l1_bus0_acs_conflict_cnt;
+#[doc = "L1_BUS0_ACS_NXTLVL_CNT (r) register accessor: L1-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus0_acs_nxtlvl_cnt`] module"]
+pub type L1_BUS0_ACS_NXTLVL_CNT = crate::Reg<l1_bus0_acs_nxtlvl_cnt::L1_BUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-Cache bus0 Next-Level-Access Counter register"]
+pub mod l1_bus0_acs_nxtlvl_cnt;
+#[doc = "L1_BUS1_ACS_HIT_CNT (r) register accessor: L1-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus1_acs_hit_cnt`] module"]
+pub type L1_BUS1_ACS_HIT_CNT = crate::Reg<l1_bus1_acs_hit_cnt::L1_BUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-Cache bus1 Hit-Access Counter register"]
+pub mod l1_bus1_acs_hit_cnt;
+#[doc = "L1_BUS1_ACS_MISS_CNT (r) register accessor: L1-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus1_acs_miss_cnt`] module"]
+pub type L1_BUS1_ACS_MISS_CNT = crate::Reg<l1_bus1_acs_miss_cnt::L1_BUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-Cache bus1 Miss-Access Counter register"]
+pub mod l1_bus1_acs_miss_cnt;
+#[doc = "L1_BUS1_ACS_CONFLICT_CNT (r) register accessor: L1-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus1_acs_conflict_cnt`] module"]
+pub type L1_BUS1_ACS_CONFLICT_CNT =
+    crate::Reg<l1_bus1_acs_conflict_cnt::L1_BUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-Cache bus1 Conflict-Access Counter register"]
+pub mod l1_bus1_acs_conflict_cnt;
+#[doc = "L1_BUS1_ACS_NXTLVL_CNT (r) register accessor: L1-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_bus1_acs_nxtlvl_cnt`] module"]
+pub type L1_BUS1_ACS_NXTLVL_CNT = crate::Reg<l1_bus1_acs_nxtlvl_cnt::L1_BUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-Cache bus1 Next-Level-Access Counter register"]
+pub mod l1_bus1_acs_nxtlvl_cnt;
+#[doc = "L1_DBUS2_ACS_HIT_CNT (r) register accessor: L1-DCache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus2_acs_hit_cnt`] module"]
+pub type L1_DBUS2_ACS_HIT_CNT = crate::Reg<l1_dbus2_acs_hit_cnt::L1_DBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-DCache bus2 Hit-Access Counter register"]
+pub mod l1_dbus2_acs_hit_cnt;
+#[doc = "L1_DBUS2_ACS_MISS_CNT (r) register accessor: L1-DCache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus2_acs_miss_cnt`] module"]
+pub type L1_DBUS2_ACS_MISS_CNT = crate::Reg<l1_dbus2_acs_miss_cnt::L1_DBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-DCache bus2 Miss-Access Counter register"]
+pub mod l1_dbus2_acs_miss_cnt;
+#[doc = "L1_DBUS2_ACS_CONFLICT_CNT (r) register accessor: L1-DCache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus2_acs_conflict_cnt`] module"]
+pub type L1_DBUS2_ACS_CONFLICT_CNT =
+    crate::Reg<l1_dbus2_acs_conflict_cnt::L1_DBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-DCache bus2 Conflict-Access Counter register"]
+pub mod l1_dbus2_acs_conflict_cnt;
+#[doc = "L1_DBUS2_ACS_NXTLVL_CNT (r) register accessor: L1-DCache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus2_acs_nxtlvl_cnt`] module"]
+pub type L1_DBUS2_ACS_NXTLVL_CNT =
+    crate::Reg<l1_dbus2_acs_nxtlvl_cnt::L1_DBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-DCache bus2 Next-Level-Access Counter register"]
+pub mod l1_dbus2_acs_nxtlvl_cnt;
+#[doc = "L1_DBUS3_ACS_HIT_CNT (r) register accessor: L1-DCache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus3_acs_hit_cnt`] module"]
+pub type L1_DBUS3_ACS_HIT_CNT = crate::Reg<l1_dbus3_acs_hit_cnt::L1_DBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "L1-DCache bus3 Hit-Access Counter register"]
+pub mod l1_dbus3_acs_hit_cnt;
+#[doc = "L1_DBUS3_ACS_MISS_CNT (r) register accessor: L1-DCache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus3_acs_miss_cnt`] module"]
+pub type L1_DBUS3_ACS_MISS_CNT = crate::Reg<l1_dbus3_acs_miss_cnt::L1_DBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "L1-DCache bus3 Miss-Access Counter register"]
+pub mod l1_dbus3_acs_miss_cnt;
+#[doc = "L1_DBUS3_ACS_CONFLICT_CNT (r) register accessor: L1-DCache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus3_acs_conflict_cnt`] module"]
+pub type L1_DBUS3_ACS_CONFLICT_CNT =
+    crate::Reg<l1_dbus3_acs_conflict_cnt::L1_DBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L1-DCache bus3 Conflict-Access Counter register"]
+pub mod l1_dbus3_acs_conflict_cnt;
+#[doc = "L1_DBUS3_ACS_NXTLVL_CNT (r) register accessor: L1-DCache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dbus3_acs_nxtlvl_cnt`] module"]
+pub type L1_DBUS3_ACS_NXTLVL_CNT =
+    crate::Reg<l1_dbus3_acs_nxtlvl_cnt::L1_DBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L1-DCache bus3 Next-Level-Access Counter register"]
+pub mod l1_dbus3_acs_nxtlvl_cnt;
+#[doc = "L1_ICACHE0_ACS_FAIL_ID_ATTR (r) register accessor: L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_acs_fail_id_attr`] module"]
+pub type L1_ICACHE0_ACS_FAIL_ID_ATTR =
+    crate::Reg<l1_icache0_acs_fail_id_attr::L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L1-ICache0 Access Fail ID/attribution information register"]
+pub mod l1_icache0_acs_fail_id_attr;
+#[doc = "L1_ICACHE0_ACS_FAIL_ADDR (r) register accessor: L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache0_acs_fail_addr`] module"]
+pub type L1_ICACHE0_ACS_FAIL_ADDR =
+    crate::Reg<l1_icache0_acs_fail_addr::L1_ICACHE0_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L1-ICache0 Access Fail Address information register"]
+pub mod l1_icache0_acs_fail_addr;
+#[doc = "L1_ICACHE1_ACS_FAIL_ID_ATTR (r) register accessor: L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_acs_fail_id_attr`] module"]
+pub type L1_ICACHE1_ACS_FAIL_ID_ATTR =
+    crate::Reg<l1_icache1_acs_fail_id_attr::L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L1-ICache0 Access Fail ID/attribution information register"]
+pub mod l1_icache1_acs_fail_id_attr;
+#[doc = "L1_ICACHE1_ACS_FAIL_ADDR (r) register accessor: L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache1_acs_fail_addr`] module"]
+pub type L1_ICACHE1_ACS_FAIL_ADDR =
+    crate::Reg<l1_icache1_acs_fail_addr::L1_ICACHE1_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L1-ICache0 Access Fail Address information register"]
+pub mod l1_icache1_acs_fail_addr;
+#[doc = "L1_ICACHE2_ACS_FAIL_ID_ATTR (r) register accessor: L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_acs_fail_id_attr`] module"]
+pub type L1_ICACHE2_ACS_FAIL_ID_ATTR =
+    crate::Reg<l1_icache2_acs_fail_id_attr::L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L1-ICache0 Access Fail ID/attribution information register"]
+pub mod l1_icache2_acs_fail_id_attr;
+#[doc = "L1_ICACHE2_ACS_FAIL_ADDR (r) register accessor: L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache2_acs_fail_addr`] module"]
+pub type L1_ICACHE2_ACS_FAIL_ADDR =
+    crate::Reg<l1_icache2_acs_fail_addr::L1_ICACHE2_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L1-ICache0 Access Fail Address information register"]
+pub mod l1_icache2_acs_fail_addr;
+#[doc = "L1_ICACHE3_ACS_FAIL_ID_ATTR (r) register accessor: L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_acs_fail_id_attr`] module"]
+pub type L1_ICACHE3_ACS_FAIL_ID_ATTR =
+    crate::Reg<l1_icache3_acs_fail_id_attr::L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L1-ICache0 Access Fail ID/attribution information register"]
+pub mod l1_icache3_acs_fail_id_attr;
+#[doc = "L1_ICACHE3_ACS_FAIL_ADDR (r) register accessor: L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_icache3_acs_fail_addr`] module"]
+pub type L1_ICACHE3_ACS_FAIL_ADDR =
+    crate::Reg<l1_icache3_acs_fail_addr::L1_ICACHE3_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L1-ICache0 Access Fail Address information register"]
+pub mod l1_icache3_acs_fail_addr;
+#[doc = "L1_CACHE_ACS_FAIL_ID_ATTR (r) register accessor: L1-Cache Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_acs_fail_id_attr`] module"]
+pub type L1_CACHE_ACS_FAIL_ID_ATTR =
+    crate::Reg<l1_cache_acs_fail_id_attr::L1_CACHE_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L1-Cache Access Fail ID/attribution information register"]
+pub mod l1_cache_acs_fail_id_attr;
+#[doc = "L1_DCACHE_ACS_FAIL_ADDR (r) register accessor: L1-Cache Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_dcache_acs_fail_addr`] module"]
+pub type L1_DCACHE_ACS_FAIL_ADDR =
+    crate::Reg<l1_dcache_acs_fail_addr::L1_DCACHE_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L1-Cache Access Fail Address information register"]
+pub mod l1_dcache_acs_fail_addr;
+#[doc = "L1_CACHE_SYNC_PRELOAD_INT_ENA (rw) register accessor: L1-Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_ena::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_ena::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_preload_int_ena`] module"]
+pub type L1_CACHE_SYNC_PRELOAD_INT_ENA =
+    crate::Reg<l1_cache_sync_preload_int_ena::L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt enable register"]
+pub mod l1_cache_sync_preload_int_ena;
+#[doc = "L1_CACHE_SYNC_PRELOAD_INT_CLR (rw) register accessor: Sync Preload operation Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_clr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_clr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_preload_int_clr`] module"]
+pub type L1_CACHE_SYNC_PRELOAD_INT_CLR =
+    crate::Reg<l1_cache_sync_preload_int_clr::L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC>;
+#[doc = "Sync Preload operation Interrupt clear register"]
+pub mod l1_cache_sync_preload_int_clr;
+#[doc = "L1_CACHE_SYNC_PRELOAD_INT_RAW (rw) register accessor: Sync Preload operation Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_preload_int_raw`] module"]
+pub type L1_CACHE_SYNC_PRELOAD_INT_RAW =
+    crate::Reg<l1_cache_sync_preload_int_raw::L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Sync Preload operation Interrupt raw register"]
+pub mod l1_cache_sync_preload_int_raw;
+#[doc = "L1_CACHE_SYNC_PRELOAD_INT_ST (r) register accessor: L1-Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_preload_int_st`] module"]
+pub type L1_CACHE_SYNC_PRELOAD_INT_ST =
+    crate::Reg<l1_cache_sync_preload_int_st::L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt status register"]
+pub mod l1_cache_sync_preload_int_st;
+#[doc = "L1_CACHE_SYNC_PRELOAD_EXCEPTION (r) register accessor: Cache Sync/Preload Operation exception register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_exception::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_preload_exception`] module"]
+pub type L1_CACHE_SYNC_PRELOAD_EXCEPTION =
+    crate::Reg<l1_cache_sync_preload_exception::L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC>;
+#[doc = "Cache Sync/Preload Operation exception register"]
+pub mod l1_cache_sync_preload_exception;
+#[doc = "L1_CACHE_SYNC_RST_CTRL (rw) register accessor: Cache Sync Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_rst_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_rst_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_sync_rst_ctrl`] module"]
+pub type L1_CACHE_SYNC_RST_CTRL = crate::Reg<l1_cache_sync_rst_ctrl::L1_CACHE_SYNC_RST_CTRL_SPEC>;
+#[doc = "Cache Sync Reset control register"]
+pub mod l1_cache_sync_rst_ctrl;
+#[doc = "L1_CACHE_PRELOAD_RST_CTRL (rw) register accessor: Cache Preload Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_preload_rst_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_preload_rst_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_preload_rst_ctrl`] module"]
+pub type L1_CACHE_PRELOAD_RST_CTRL =
+    crate::Reg<l1_cache_preload_rst_ctrl::L1_CACHE_PRELOAD_RST_CTRL_SPEC>;
+#[doc = "Cache Preload Reset control register"]
+pub mod l1_cache_preload_rst_ctrl;
+#[doc = "L1_CACHE_AUTOLOAD_BUF_CLR_CTRL (rw) register accessor: Cache Autoload buffer clear control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_buf_clr_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_buf_clr_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_autoload_buf_clr_ctrl`] module"]
+pub type L1_CACHE_AUTOLOAD_BUF_CLR_CTRL =
+    crate::Reg<l1_cache_autoload_buf_clr_ctrl::L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC>;
+#[doc = "Cache Autoload buffer clear control register"]
+pub mod l1_cache_autoload_buf_clr_ctrl;
+#[doc = "L1_UNALLOCATE_BUFFER_CLEAR (rw) register accessor: Unallocate request buffer clear registers\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_unallocate_buffer_clear::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_unallocate_buffer_clear::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_unallocate_buffer_clear`] module"]
+pub type L1_UNALLOCATE_BUFFER_CLEAR =
+    crate::Reg<l1_unallocate_buffer_clear::L1_UNALLOCATE_BUFFER_CLEAR_SPEC>;
+#[doc = "Unallocate request buffer clear registers"]
+pub mod l1_unallocate_buffer_clear;
+#[doc = "L1_CACHE_OBJECT_CTRL (rw) register accessor: Cache Tag and Data memory Object control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_object_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_object_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_object_ctrl`] module"]
+pub type L1_CACHE_OBJECT_CTRL = crate::Reg<l1_cache_object_ctrl::L1_CACHE_OBJECT_CTRL_SPEC>;
+#[doc = "Cache Tag and Data memory Object control register"]
+pub mod l1_cache_object_ctrl;
+#[doc = "L1_CACHE_WAY_OBJECT (rw) register accessor: Cache Tag and Data memory way register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_way_object::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_way_object::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_way_object`] module"]
+pub type L1_CACHE_WAY_OBJECT = crate::Reg<l1_cache_way_object::L1_CACHE_WAY_OBJECT_SPEC>;
+#[doc = "Cache Tag and Data memory way register"]
+pub mod l1_cache_way_object;
+#[doc = "L1_CACHE_VADDR (rw) register accessor: Cache Vaddr register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_vaddr::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_vaddr::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_vaddr`] module"]
+pub type L1_CACHE_VADDR = crate::Reg<l1_cache_vaddr::L1_CACHE_VADDR_SPEC>;
+#[doc = "Cache Vaddr register"]
+pub mod l1_cache_vaddr;
+#[doc = "L1_CACHE_DEBUG_BUS (rw) register accessor: Cache Tag/data memory content register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_debug_bus::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_debug_bus::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l1_cache_debug_bus`] module"]
+pub type L1_CACHE_DEBUG_BUS = crate::Reg<l1_cache_debug_bus::L1_CACHE_DEBUG_BUS_SPEC>;
+#[doc = "Cache Tag/data memory content register"]
+pub mod l1_cache_debug_bus;
+#[doc = "LEVEL_SPLIT0 (r) register accessor: USED TO SPLIT L1 CACHE AND L2 CACHE\n\nYou can [`read`](crate::Reg::read) this register and get [`level_split0::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@level_split0`] module"]
+pub type LEVEL_SPLIT0 = crate::Reg<level_split0::LEVEL_SPLIT0_SPEC>;
+#[doc = "USED TO SPLIT L1 CACHE AND L2 CACHE"]
+pub mod level_split0;
+#[doc = "L2_CACHE_CTRL (r) register accessor: L2 Cache(L2-Cache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_ctrl`] module"]
+pub type L2_CACHE_CTRL = crate::Reg<l2_cache_ctrl::L2_CACHE_CTRL_SPEC>;
+#[doc = "L2 Cache(L2-Cache) control register"]
+pub mod l2_cache_ctrl;
+#[doc = "L2_BYPASS_CACHE_CONF (r) register accessor: Bypass Cache configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_bypass_cache_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_bypass_cache_conf`] module"]
+pub type L2_BYPASS_CACHE_CONF = crate::Reg<l2_bypass_cache_conf::L2_BYPASS_CACHE_CONF_SPEC>;
+#[doc = "Bypass Cache configure register"]
+pub mod l2_bypass_cache_conf;
+#[doc = "L2_CACHE_CACHESIZE_CONF (r) register accessor: L2 Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_cachesize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_cachesize_conf`] module"]
+pub type L2_CACHE_CACHESIZE_CONF =
+    crate::Reg<l2_cache_cachesize_conf::L2_CACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "L2 Cache CacheSize mode configure register"]
+pub mod l2_cache_cachesize_conf;
+#[doc = "L2_CACHE_BLOCKSIZE_CONF (r) register accessor: L2 Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_blocksize_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_blocksize_conf`] module"]
+pub type L2_CACHE_BLOCKSIZE_CONF =
+    crate::Reg<l2_cache_blocksize_conf::L2_CACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "L2 Cache BlockSize mode configure register"]
+pub mod l2_cache_blocksize_conf;
+#[doc = "L2_CACHE_WRAP_AROUND_CTRL (r) register accessor: Cache wrap around control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_wrap_around_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_wrap_around_ctrl`] module"]
+pub type L2_CACHE_WRAP_AROUND_CTRL =
+    crate::Reg<l2_cache_wrap_around_ctrl::L2_CACHE_WRAP_AROUND_CTRL_SPEC>;
+#[doc = "Cache wrap around control register"]
+pub mod l2_cache_wrap_around_ctrl;
+#[doc = "L2_CACHE_TAG_MEM_POWER_CTRL (r) register accessor: Cache tag memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_tag_mem_power_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_tag_mem_power_ctrl`] module"]
+pub type L2_CACHE_TAG_MEM_POWER_CTRL =
+    crate::Reg<l2_cache_tag_mem_power_ctrl::L2_CACHE_TAG_MEM_POWER_CTRL_SPEC>;
+#[doc = "Cache tag memory power control register"]
+pub mod l2_cache_tag_mem_power_ctrl;
+#[doc = "L2_CACHE_DATA_MEM_POWER_CTRL (r) register accessor: Cache data memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_data_mem_power_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_data_mem_power_ctrl`] module"]
+pub type L2_CACHE_DATA_MEM_POWER_CTRL =
+    crate::Reg<l2_cache_data_mem_power_ctrl::L2_CACHE_DATA_MEM_POWER_CTRL_SPEC>;
+#[doc = "Cache data memory power control register"]
+pub mod l2_cache_data_mem_power_ctrl;
+#[doc = "L2_CACHE_FREEZE_CTRL (r) register accessor: Cache Freeze control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_freeze_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_freeze_ctrl`] module"]
+pub type L2_CACHE_FREEZE_CTRL = crate::Reg<l2_cache_freeze_ctrl::L2_CACHE_FREEZE_CTRL_SPEC>;
+#[doc = "Cache Freeze control register"]
+pub mod l2_cache_freeze_ctrl;
+#[doc = "L2_CACHE_DATA_MEM_ACS_CONF (r) register accessor: Cache data memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_data_mem_acs_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_data_mem_acs_conf`] module"]
+pub type L2_CACHE_DATA_MEM_ACS_CONF =
+    crate::Reg<l2_cache_data_mem_acs_conf::L2_CACHE_DATA_MEM_ACS_CONF_SPEC>;
+#[doc = "Cache data memory access configure register"]
+pub mod l2_cache_data_mem_acs_conf;
+#[doc = "L2_CACHE_TAG_MEM_ACS_CONF (r) register accessor: Cache tag memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_tag_mem_acs_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_tag_mem_acs_conf`] module"]
+pub type L2_CACHE_TAG_MEM_ACS_CONF =
+    crate::Reg<l2_cache_tag_mem_acs_conf::L2_CACHE_TAG_MEM_ACS_CONF_SPEC>;
+#[doc = "Cache tag memory access configure register"]
+pub mod l2_cache_tag_mem_acs_conf;
+#[doc = "L2_CACHE_PRELOCK_CONF (r) register accessor: L2 Cache prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_conf::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_prelock_conf`] module"]
+pub type L2_CACHE_PRELOCK_CONF = crate::Reg<l2_cache_prelock_conf::L2_CACHE_PRELOCK_CONF_SPEC>;
+#[doc = "L2 Cache prelock configure register"]
+pub mod l2_cache_prelock_conf;
+#[doc = "L2_CACHE_PRELOCK_SCT0_ADDR (r) register accessor: L2 Cache prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_prelock_sct0_addr`] module"]
+pub type L2_CACHE_PRELOCK_SCT0_ADDR =
+    crate::Reg<l2_cache_prelock_sct0_addr::L2_CACHE_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "L2 Cache prelock section0 address configure register"]
+pub mod l2_cache_prelock_sct0_addr;
+#[doc = "L2_CACHE_PRELOCK_SCT1_ADDR (r) register accessor: L2 Cache prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_prelock_sct1_addr`] module"]
+pub type L2_CACHE_PRELOCK_SCT1_ADDR =
+    crate::Reg<l2_cache_prelock_sct1_addr::L2_CACHE_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "L2 Cache prelock section1 address configure register"]
+pub mod l2_cache_prelock_sct1_addr;
+#[doc = "L2_CACHE_PRELOCK_SCT_SIZE (r) register accessor: L2 Cache prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_prelock_sct_size`] module"]
+pub type L2_CACHE_PRELOCK_SCT_SIZE =
+    crate::Reg<l2_cache_prelock_sct_size::L2_CACHE_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "L2 Cache prelock section size configure register"]
+pub mod l2_cache_prelock_sct_size;
+#[doc = "L2_CACHE_PRELOAD_CTRL (rw) register accessor: L2 Cache preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_preload_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_preload_ctrl`] module"]
+pub type L2_CACHE_PRELOAD_CTRL = crate::Reg<l2_cache_preload_ctrl::L2_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "L2 Cache preload-operation control register"]
+pub mod l2_cache_preload_ctrl;
+#[doc = "L2_CACHE_PRELOAD_ADDR (r) register accessor: L2 Cache preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_preload_addr`] module"]
+pub type L2_CACHE_PRELOAD_ADDR = crate::Reg<l2_cache_preload_addr::L2_CACHE_PRELOAD_ADDR_SPEC>;
+#[doc = "L2 Cache preload address configure register"]
+pub mod l2_cache_preload_addr;
+#[doc = "L2_CACHE_PRELOAD_SIZE (r) register accessor: L2 Cache preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_preload_size`] module"]
+pub type L2_CACHE_PRELOAD_SIZE = crate::Reg<l2_cache_preload_size::L2_CACHE_PRELOAD_SIZE_SPEC>;
+#[doc = "L2 Cache preload size configure register"]
+pub mod l2_cache_preload_size;
+#[doc = "L2_CACHE_AUTOLOAD_CTRL (r) register accessor: L2 Cache autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_ctrl`] module"]
+pub type L2_CACHE_AUTOLOAD_CTRL = crate::Reg<l2_cache_autoload_ctrl::L2_CACHE_AUTOLOAD_CTRL_SPEC>;
+#[doc = "L2 Cache autoload-operation control register"]
+pub mod l2_cache_autoload_ctrl;
+#[doc = "L2_CACHE_AUTOLOAD_SCT0_ADDR (r) register accessor: L2 Cache autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct0_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct0_addr`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT0_ADDR =
+    crate::Reg<l2_cache_autoload_sct0_addr::L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "L2 Cache autoload section 0 address configure register"]
+pub mod l2_cache_autoload_sct0_addr;
+#[doc = "L2_CACHE_AUTOLOAD_SCT0_SIZE (r) register accessor: L2 Cache autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct0_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct0_size`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT0_SIZE =
+    crate::Reg<l2_cache_autoload_sct0_size::L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "L2 Cache autoload section 0 size configure register"]
+pub mod l2_cache_autoload_sct0_size;
+#[doc = "L2_CACHE_AUTOLOAD_SCT1_ADDR (r) register accessor: L2 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct1_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct1_addr`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT1_ADDR =
+    crate::Reg<l2_cache_autoload_sct1_addr::L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "L2 Cache autoload section 1 address configure register"]
+pub mod l2_cache_autoload_sct1_addr;
+#[doc = "L2_CACHE_AUTOLOAD_SCT1_SIZE (r) register accessor: L2 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct1_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct1_size`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT1_SIZE =
+    crate::Reg<l2_cache_autoload_sct1_size::L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "L2 Cache autoload section 1 size configure register"]
+pub mod l2_cache_autoload_sct1_size;
+#[doc = "L2_CACHE_AUTOLOAD_SCT2_ADDR (r) register accessor: L2 Cache autoload section 2 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct2_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct2_addr`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT2_ADDR =
+    crate::Reg<l2_cache_autoload_sct2_addr::L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC>;
+#[doc = "L2 Cache autoload section 2 address configure register"]
+pub mod l2_cache_autoload_sct2_addr;
+#[doc = "L2_CACHE_AUTOLOAD_SCT2_SIZE (r) register accessor: L2 Cache autoload section 2 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct2_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct2_size`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT2_SIZE =
+    crate::Reg<l2_cache_autoload_sct2_size::L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC>;
+#[doc = "L2 Cache autoload section 2 size configure register"]
+pub mod l2_cache_autoload_sct2_size;
+#[doc = "L2_CACHE_AUTOLOAD_SCT3_ADDR (r) register accessor: L2 Cache autoload section 3 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct3_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct3_addr`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT3_ADDR =
+    crate::Reg<l2_cache_autoload_sct3_addr::L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC>;
+#[doc = "L2 Cache autoload section 3 address configure register"]
+pub mod l2_cache_autoload_sct3_addr;
+#[doc = "L2_CACHE_AUTOLOAD_SCT3_SIZE (r) register accessor: L2 Cache autoload section 3 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct3_size::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_sct3_size`] module"]
+pub type L2_CACHE_AUTOLOAD_SCT3_SIZE =
+    crate::Reg<l2_cache_autoload_sct3_size::L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC>;
+#[doc = "L2 Cache autoload section 3 size configure register"]
+pub mod l2_cache_autoload_sct3_size;
+#[doc = "L2_CACHE_ACS_CNT_INT_ENA (r) register accessor: Cache Access Counter Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_ena::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_cnt_int_ena`] module"]
+pub type L2_CACHE_ACS_CNT_INT_ENA =
+    crate::Reg<l2_cache_acs_cnt_int_ena::L2_CACHE_ACS_CNT_INT_ENA_SPEC>;
+#[doc = "Cache Access Counter Interrupt enable register"]
+pub mod l2_cache_acs_cnt_int_ena;
+#[doc = "L2_CACHE_ACS_CNT_INT_CLR (r) register accessor: Cache Access Counter Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_clr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_cnt_int_clr`] module"]
+pub type L2_CACHE_ACS_CNT_INT_CLR =
+    crate::Reg<l2_cache_acs_cnt_int_clr::L2_CACHE_ACS_CNT_INT_CLR_SPEC>;
+#[doc = "Cache Access Counter Interrupt clear register"]
+pub mod l2_cache_acs_cnt_int_clr;
+#[doc = "L2_CACHE_ACS_CNT_INT_RAW (rw) register accessor: Cache Access Counter Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_acs_cnt_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_cnt_int_raw`] module"]
+pub type L2_CACHE_ACS_CNT_INT_RAW =
+    crate::Reg<l2_cache_acs_cnt_int_raw::L2_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Cache Access Counter Interrupt raw register"]
+pub mod l2_cache_acs_cnt_int_raw;
+#[doc = "L2_CACHE_ACS_CNT_INT_ST (r) register accessor: Cache Access Counter Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_cnt_int_st`] module"]
+pub type L2_CACHE_ACS_CNT_INT_ST =
+    crate::Reg<l2_cache_acs_cnt_int_st::L2_CACHE_ACS_CNT_INT_ST_SPEC>;
+#[doc = "Cache Access Counter Interrupt status register"]
+pub mod l2_cache_acs_cnt_int_st;
+#[doc = "L2_CACHE_ACS_FAIL_INT_ENA (r) register accessor: Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_ena::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_int_ena`] module"]
+pub type L2_CACHE_ACS_FAIL_INT_ENA =
+    crate::Reg<l2_cache_acs_fail_int_ena::L2_CACHE_ACS_FAIL_INT_ENA_SPEC>;
+#[doc = "Cache Access Fail Interrupt enable register"]
+pub mod l2_cache_acs_fail_int_ena;
+#[doc = "L2_CACHE_ACS_FAIL_INT_CLR (r) register accessor: L1-Cache Access Fail Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_clr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_int_clr`] module"]
+pub type L2_CACHE_ACS_FAIL_INT_CLR =
+    crate::Reg<l2_cache_acs_fail_int_clr::L2_CACHE_ACS_FAIL_INT_CLR_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt clear register"]
+pub mod l2_cache_acs_fail_int_clr;
+#[doc = "L2_CACHE_ACS_FAIL_INT_RAW (rw) register accessor: Cache Access Fail Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_acs_fail_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_int_raw`] module"]
+pub type L2_CACHE_ACS_FAIL_INT_RAW =
+    crate::Reg<l2_cache_acs_fail_int_raw::L2_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Cache Access Fail Interrupt raw register"]
+pub mod l2_cache_acs_fail_int_raw;
+#[doc = "L2_CACHE_ACS_FAIL_INT_ST (r) register accessor: Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_int_st`] module"]
+pub type L2_CACHE_ACS_FAIL_INT_ST =
+    crate::Reg<l2_cache_acs_fail_int_st::L2_CACHE_ACS_FAIL_INT_ST_SPEC>;
+#[doc = "Cache Access Fail Interrupt status register"]
+pub mod l2_cache_acs_fail_int_st;
+#[doc = "L2_CACHE_ACS_CNT_CTRL (r) register accessor: Cache Access Counter enable and clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_cnt_ctrl`] module"]
+pub type L2_CACHE_ACS_CNT_CTRL = crate::Reg<l2_cache_acs_cnt_ctrl::L2_CACHE_ACS_CNT_CTRL_SPEC>;
+#[doc = "Cache Access Counter enable and clear register"]
+pub mod l2_cache_acs_cnt_ctrl;
+#[doc = "L2_IBUS0_ACS_HIT_CNT (r) register accessor: L2-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus0_acs_hit_cnt`] module"]
+pub type L2_IBUS0_ACS_HIT_CNT = crate::Reg<l2_ibus0_acs_hit_cnt::L2_IBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Hit-Access Counter register"]
+pub mod l2_ibus0_acs_hit_cnt;
+#[doc = "L2_IBUS0_ACS_MISS_CNT (r) register accessor: L2-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus0_acs_miss_cnt`] module"]
+pub type L2_IBUS0_ACS_MISS_CNT = crate::Reg<l2_ibus0_acs_miss_cnt::L2_IBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Miss-Access Counter register"]
+pub mod l2_ibus0_acs_miss_cnt;
+#[doc = "L2_IBUS0_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus0_acs_conflict_cnt`] module"]
+pub type L2_IBUS0_ACS_CONFLICT_CNT =
+    crate::Reg<l2_ibus0_acs_conflict_cnt::L2_IBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Conflict-Access Counter register"]
+pub mod l2_ibus0_acs_conflict_cnt;
+#[doc = "L2_IBUS0_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus0_acs_nxtlvl_cnt`] module"]
+pub type L2_IBUS0_ACS_NXTLVL_CNT =
+    crate::Reg<l2_ibus0_acs_nxtlvl_cnt::L2_IBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Next-Level-Access Counter register"]
+pub mod l2_ibus0_acs_nxtlvl_cnt;
+#[doc = "L2_IBUS1_ACS_HIT_CNT (r) register accessor: L2-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus1_acs_hit_cnt`] module"]
+pub type L2_IBUS1_ACS_HIT_CNT = crate::Reg<l2_ibus1_acs_hit_cnt::L2_IBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Hit-Access Counter register"]
+pub mod l2_ibus1_acs_hit_cnt;
+#[doc = "L2_IBUS1_ACS_MISS_CNT (r) register accessor: L2-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus1_acs_miss_cnt`] module"]
+pub type L2_IBUS1_ACS_MISS_CNT = crate::Reg<l2_ibus1_acs_miss_cnt::L2_IBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Miss-Access Counter register"]
+pub mod l2_ibus1_acs_miss_cnt;
+#[doc = "L2_IBUS1_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus1_acs_conflict_cnt`] module"]
+pub type L2_IBUS1_ACS_CONFLICT_CNT =
+    crate::Reg<l2_ibus1_acs_conflict_cnt::L2_IBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Conflict-Access Counter register"]
+pub mod l2_ibus1_acs_conflict_cnt;
+#[doc = "L2_IBUS1_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus1_acs_nxtlvl_cnt`] module"]
+pub type L2_IBUS1_ACS_NXTLVL_CNT =
+    crate::Reg<l2_ibus1_acs_nxtlvl_cnt::L2_IBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Next-Level-Access Counter register"]
+pub mod l2_ibus1_acs_nxtlvl_cnt;
+#[doc = "L2_IBUS2_ACS_HIT_CNT (r) register accessor: L2-Cache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus2_acs_hit_cnt`] module"]
+pub type L2_IBUS2_ACS_HIT_CNT = crate::Reg<l2_ibus2_acs_hit_cnt::L2_IBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Hit-Access Counter register"]
+pub mod l2_ibus2_acs_hit_cnt;
+#[doc = "L2_IBUS2_ACS_MISS_CNT (r) register accessor: L2-Cache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus2_acs_miss_cnt`] module"]
+pub type L2_IBUS2_ACS_MISS_CNT = crate::Reg<l2_ibus2_acs_miss_cnt::L2_IBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Miss-Access Counter register"]
+pub mod l2_ibus2_acs_miss_cnt;
+#[doc = "L2_IBUS2_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus2_acs_conflict_cnt`] module"]
+pub type L2_IBUS2_ACS_CONFLICT_CNT =
+    crate::Reg<l2_ibus2_acs_conflict_cnt::L2_IBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Conflict-Access Counter register"]
+pub mod l2_ibus2_acs_conflict_cnt;
+#[doc = "L2_IBUS2_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus2_acs_nxtlvl_cnt`] module"]
+pub type L2_IBUS2_ACS_NXTLVL_CNT =
+    crate::Reg<l2_ibus2_acs_nxtlvl_cnt::L2_IBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Next-Level-Access Counter register"]
+pub mod l2_ibus2_acs_nxtlvl_cnt;
+#[doc = "L2_IBUS3_ACS_HIT_CNT (r) register accessor: L2-Cache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus3_acs_hit_cnt`] module"]
+pub type L2_IBUS3_ACS_HIT_CNT = crate::Reg<l2_ibus3_acs_hit_cnt::L2_IBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Hit-Access Counter register"]
+pub mod l2_ibus3_acs_hit_cnt;
+#[doc = "L2_IBUS3_ACS_MISS_CNT (r) register accessor: L2-Cache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus3_acs_miss_cnt`] module"]
+pub type L2_IBUS3_ACS_MISS_CNT = crate::Reg<l2_ibus3_acs_miss_cnt::L2_IBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Miss-Access Counter register"]
+pub mod l2_ibus3_acs_miss_cnt;
+#[doc = "L2_IBUS3_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus3_acs_conflict_cnt`] module"]
+pub type L2_IBUS3_ACS_CONFLICT_CNT =
+    crate::Reg<l2_ibus3_acs_conflict_cnt::L2_IBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Conflict-Access Counter register"]
+pub mod l2_ibus3_acs_conflict_cnt;
+#[doc = "L2_IBUS3_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_ibus3_acs_nxtlvl_cnt`] module"]
+pub type L2_IBUS3_ACS_NXTLVL_CNT =
+    crate::Reg<l2_ibus3_acs_nxtlvl_cnt::L2_IBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Next-Level-Access Counter register"]
+pub mod l2_ibus3_acs_nxtlvl_cnt;
+#[doc = "L2_DBUS0_ACS_HIT_CNT (r) register accessor: L2-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus0_acs_hit_cnt`] module"]
+pub type L2_DBUS0_ACS_HIT_CNT = crate::Reg<l2_dbus0_acs_hit_cnt::L2_DBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Hit-Access Counter register"]
+pub mod l2_dbus0_acs_hit_cnt;
+#[doc = "L2_DBUS0_ACS_MISS_CNT (r) register accessor: L2-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus0_acs_miss_cnt`] module"]
+pub type L2_DBUS0_ACS_MISS_CNT = crate::Reg<l2_dbus0_acs_miss_cnt::L2_DBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Miss-Access Counter register"]
+pub mod l2_dbus0_acs_miss_cnt;
+#[doc = "L2_DBUS0_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus0_acs_conflict_cnt`] module"]
+pub type L2_DBUS0_ACS_CONFLICT_CNT =
+    crate::Reg<l2_dbus0_acs_conflict_cnt::L2_DBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Conflict-Access Counter register"]
+pub mod l2_dbus0_acs_conflict_cnt;
+#[doc = "L2_DBUS0_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus0_acs_nxtlvl_cnt`] module"]
+pub type L2_DBUS0_ACS_NXTLVL_CNT =
+    crate::Reg<l2_dbus0_acs_nxtlvl_cnt::L2_DBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus0 Next-Level-Access Counter register"]
+pub mod l2_dbus0_acs_nxtlvl_cnt;
+#[doc = "L2_DBUS1_ACS_HIT_CNT (r) register accessor: L2-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus1_acs_hit_cnt`] module"]
+pub type L2_DBUS1_ACS_HIT_CNT = crate::Reg<l2_dbus1_acs_hit_cnt::L2_DBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Hit-Access Counter register"]
+pub mod l2_dbus1_acs_hit_cnt;
+#[doc = "L2_DBUS1_ACS_MISS_CNT (r) register accessor: L2-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus1_acs_miss_cnt`] module"]
+pub type L2_DBUS1_ACS_MISS_CNT = crate::Reg<l2_dbus1_acs_miss_cnt::L2_DBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Miss-Access Counter register"]
+pub mod l2_dbus1_acs_miss_cnt;
+#[doc = "L2_DBUS1_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus1_acs_conflict_cnt`] module"]
+pub type L2_DBUS1_ACS_CONFLICT_CNT =
+    crate::Reg<l2_dbus1_acs_conflict_cnt::L2_DBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Conflict-Access Counter register"]
+pub mod l2_dbus1_acs_conflict_cnt;
+#[doc = "L2_DBUS1_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus1_acs_nxtlvl_cnt`] module"]
+pub type L2_DBUS1_ACS_NXTLVL_CNT =
+    crate::Reg<l2_dbus1_acs_nxtlvl_cnt::L2_DBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus1 Next-Level-Access Counter register"]
+pub mod l2_dbus1_acs_nxtlvl_cnt;
+#[doc = "L2_DBUS2_ACS_HIT_CNT (r) register accessor: L2-Cache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus2_acs_hit_cnt`] module"]
+pub type L2_DBUS2_ACS_HIT_CNT = crate::Reg<l2_dbus2_acs_hit_cnt::L2_DBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Hit-Access Counter register"]
+pub mod l2_dbus2_acs_hit_cnt;
+#[doc = "L2_DBUS2_ACS_MISS_CNT (r) register accessor: L2-Cache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus2_acs_miss_cnt`] module"]
+pub type L2_DBUS2_ACS_MISS_CNT = crate::Reg<l2_dbus2_acs_miss_cnt::L2_DBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Miss-Access Counter register"]
+pub mod l2_dbus2_acs_miss_cnt;
+#[doc = "L2_DBUS2_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus2_acs_conflict_cnt`] module"]
+pub type L2_DBUS2_ACS_CONFLICT_CNT =
+    crate::Reg<l2_dbus2_acs_conflict_cnt::L2_DBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Conflict-Access Counter register"]
+pub mod l2_dbus2_acs_conflict_cnt;
+#[doc = "L2_DBUS2_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus2_acs_nxtlvl_cnt`] module"]
+pub type L2_DBUS2_ACS_NXTLVL_CNT =
+    crate::Reg<l2_dbus2_acs_nxtlvl_cnt::L2_DBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus2 Next-Level-Access Counter register"]
+pub mod l2_dbus2_acs_nxtlvl_cnt;
+#[doc = "L2_DBUS3_ACS_HIT_CNT (r) register accessor: L2-Cache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_hit_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus3_acs_hit_cnt`] module"]
+pub type L2_DBUS3_ACS_HIT_CNT = crate::Reg<l2_dbus3_acs_hit_cnt::L2_DBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Hit-Access Counter register"]
+pub mod l2_dbus3_acs_hit_cnt;
+#[doc = "L2_DBUS3_ACS_MISS_CNT (r) register accessor: L2-Cache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_miss_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus3_acs_miss_cnt`] module"]
+pub type L2_DBUS3_ACS_MISS_CNT = crate::Reg<l2_dbus3_acs_miss_cnt::L2_DBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Miss-Access Counter register"]
+pub mod l2_dbus3_acs_miss_cnt;
+#[doc = "L2_DBUS3_ACS_CONFLICT_CNT (r) register accessor: L2-Cache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_conflict_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus3_acs_conflict_cnt`] module"]
+pub type L2_DBUS3_ACS_CONFLICT_CNT =
+    crate::Reg<l2_dbus3_acs_conflict_cnt::L2_DBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Conflict-Access Counter register"]
+pub mod l2_dbus3_acs_conflict_cnt;
+#[doc = "L2_DBUS3_ACS_NXTLVL_CNT (r) register accessor: L2-Cache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_nxtlvl_cnt::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_dbus3_acs_nxtlvl_cnt`] module"]
+pub type L2_DBUS3_ACS_NXTLVL_CNT =
+    crate::Reg<l2_dbus3_acs_nxtlvl_cnt::L2_DBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "L2-Cache bus3 Next-Level-Access Counter register"]
+pub mod l2_dbus3_acs_nxtlvl_cnt;
+#[doc = "L2_CACHE_ACS_FAIL_ID_ATTR (r) register accessor: L2-Cache Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_id_attr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_id_attr`] module"]
+pub type L2_CACHE_ACS_FAIL_ID_ATTR =
+    crate::Reg<l2_cache_acs_fail_id_attr::L2_CACHE_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "L2-Cache Access Fail ID/attribution information register"]
+pub mod l2_cache_acs_fail_id_attr;
+#[doc = "L2_CACHE_ACS_FAIL_ADDR (r) register accessor: L2-Cache Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_addr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_acs_fail_addr`] module"]
+pub type L2_CACHE_ACS_FAIL_ADDR = crate::Reg<l2_cache_acs_fail_addr::L2_CACHE_ACS_FAIL_ADDR_SPEC>;
+#[doc = "L2-Cache Access Fail Address information register"]
+pub mod l2_cache_acs_fail_addr;
+#[doc = "L2_CACHE_SYNC_PRELOAD_INT_ENA (r) register accessor: L1-Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_ena::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_preload_int_ena`] module"]
+pub type L2_CACHE_SYNC_PRELOAD_INT_ENA =
+    crate::Reg<l2_cache_sync_preload_int_ena::L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt enable register"]
+pub mod l2_cache_sync_preload_int_ena;
+#[doc = "L2_CACHE_SYNC_PRELOAD_INT_CLR (r) register accessor: Sync Preload operation Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_clr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_preload_int_clr`] module"]
+pub type L2_CACHE_SYNC_PRELOAD_INT_CLR =
+    crate::Reg<l2_cache_sync_preload_int_clr::L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC>;
+#[doc = "Sync Preload operation Interrupt clear register"]
+pub mod l2_cache_sync_preload_int_clr;
+#[doc = "L2_CACHE_SYNC_PRELOAD_INT_RAW (rw) register accessor: Sync Preload operation Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_raw::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_sync_preload_int_raw::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_preload_int_raw`] module"]
+pub type L2_CACHE_SYNC_PRELOAD_INT_RAW =
+    crate::Reg<l2_cache_sync_preload_int_raw::L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Sync Preload operation Interrupt raw register"]
+pub mod l2_cache_sync_preload_int_raw;
+#[doc = "L2_CACHE_SYNC_PRELOAD_INT_ST (r) register accessor: L1-Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_st::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_preload_int_st`] module"]
+pub type L2_CACHE_SYNC_PRELOAD_INT_ST =
+    crate::Reg<l2_cache_sync_preload_int_st::L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC>;
+#[doc = "L1-Cache Access Fail Interrupt status register"]
+pub mod l2_cache_sync_preload_int_st;
+#[doc = "L2_CACHE_SYNC_PRELOAD_EXCEPTION (r) register accessor: Cache Sync/Preload Operation exception register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_exception::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_preload_exception`] module"]
+pub type L2_CACHE_SYNC_PRELOAD_EXCEPTION =
+    crate::Reg<l2_cache_sync_preload_exception::L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC>;
+#[doc = "Cache Sync/Preload Operation exception register"]
+pub mod l2_cache_sync_preload_exception;
+#[doc = "L2_CACHE_SYNC_RST_CTRL (r) register accessor: Cache Sync Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_rst_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_sync_rst_ctrl`] module"]
+pub type L2_CACHE_SYNC_RST_CTRL = crate::Reg<l2_cache_sync_rst_ctrl::L2_CACHE_SYNC_RST_CTRL_SPEC>;
+#[doc = "Cache Sync Reset control register"]
+pub mod l2_cache_sync_rst_ctrl;
+#[doc = "L2_CACHE_PRELOAD_RST_CTRL (r) register accessor: Cache Preload Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_rst_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_preload_rst_ctrl`] module"]
+pub type L2_CACHE_PRELOAD_RST_CTRL =
+    crate::Reg<l2_cache_preload_rst_ctrl::L2_CACHE_PRELOAD_RST_CTRL_SPEC>;
+#[doc = "Cache Preload Reset control register"]
+pub mod l2_cache_preload_rst_ctrl;
+#[doc = "L2_CACHE_AUTOLOAD_BUF_CLR_CTRL (r) register accessor: Cache Autoload buffer clear control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_buf_clr_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_autoload_buf_clr_ctrl`] module"]
+pub type L2_CACHE_AUTOLOAD_BUF_CLR_CTRL =
+    crate::Reg<l2_cache_autoload_buf_clr_ctrl::L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC>;
+#[doc = "Cache Autoload buffer clear control register"]
+pub mod l2_cache_autoload_buf_clr_ctrl;
+#[doc = "L2_UNALLOCATE_BUFFER_CLEAR (r) register accessor: Unallocate request buffer clear registers\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_unallocate_buffer_clear::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_unallocate_buffer_clear`] module"]
+pub type L2_UNALLOCATE_BUFFER_CLEAR =
+    crate::Reg<l2_unallocate_buffer_clear::L2_UNALLOCATE_BUFFER_CLEAR_SPEC>;
+#[doc = "Unallocate request buffer clear registers"]
+pub mod l2_unallocate_buffer_clear;
+#[doc = "L2_CACHE_ACCESS_ATTR_CTRL (r) register accessor: L1 Cache access Attribute propagation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_access_attr_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_access_attr_ctrl`] module"]
+pub type L2_CACHE_ACCESS_ATTR_CTRL =
+    crate::Reg<l2_cache_access_attr_ctrl::L2_CACHE_ACCESS_ATTR_CTRL_SPEC>;
+#[doc = "L1 Cache access Attribute propagation control register"]
+pub mod l2_cache_access_attr_ctrl;
+#[doc = "L2_CACHE_OBJECT_CTRL (r) register accessor: Cache Tag and Data memory Object control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_object_ctrl::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_object_ctrl`] module"]
+pub type L2_CACHE_OBJECT_CTRL = crate::Reg<l2_cache_object_ctrl::L2_CACHE_OBJECT_CTRL_SPEC>;
+#[doc = "Cache Tag and Data memory Object control register"]
+pub mod l2_cache_object_ctrl;
+#[doc = "L2_CACHE_WAY_OBJECT (r) register accessor: Cache Tag and Data memory way register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_way_object::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_way_object`] module"]
+pub type L2_CACHE_WAY_OBJECT = crate::Reg<l2_cache_way_object::L2_CACHE_WAY_OBJECT_SPEC>;
+#[doc = "Cache Tag and Data memory way register"]
+pub mod l2_cache_way_object;
+#[doc = "L2_CACHE_VADDR (r) register accessor: Cache Vaddr register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_vaddr::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_vaddr`] module"]
+pub type L2_CACHE_VADDR = crate::Reg<l2_cache_vaddr::L2_CACHE_VADDR_SPEC>;
+#[doc = "Cache Vaddr register"]
+pub mod l2_cache_vaddr;
+#[doc = "L2_CACHE_DEBUG_BUS (r) register accessor: Cache Tag/data memory content register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_debug_bus::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@l2_cache_debug_bus`] module"]
+pub type L2_CACHE_DEBUG_BUS = crate::Reg<l2_cache_debug_bus::L2_CACHE_DEBUG_BUS_SPEC>;
+#[doc = "Cache Tag/data memory content register"]
+pub mod l2_cache_debug_bus;
+#[doc = "LEVEL_SPLIT1 (r) register accessor: USED TO SPLIT L1 CACHE AND L2 CACHE\n\nYou can [`read`](crate::Reg::read) this register and get [`level_split1::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@level_split1`] module"]
+pub type LEVEL_SPLIT1 = crate::Reg<level_split1::LEVEL_SPLIT1_SPEC>;
+#[doc = "USED TO SPLIT L1 CACHE AND L2 CACHE"]
+pub mod level_split1;
+#[doc = "CLOCK_GATE (rw) register accessor: Clock gate control register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clock_gate`] module"]
+pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
+#[doc = "Clock gate control register"]
+pub mod clock_gate;
+#[doc = "REDUNDANCY_SIG0 (rw) register accessor: Cache redundancy signal 0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig0::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig0::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@redundancy_sig0`] module"]
+pub type REDUNDANCY_SIG0 = crate::Reg<redundancy_sig0::REDUNDANCY_SIG0_SPEC>;
+#[doc = "Cache redundancy signal 0 register"]
+pub mod redundancy_sig0;
+#[doc = "REDUNDANCY_SIG1 (rw) register accessor: Cache redundancy signal 1 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig1::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig1::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@redundancy_sig1`] module"]
+pub type REDUNDANCY_SIG1 = crate::Reg<redundancy_sig1::REDUNDANCY_SIG1_SPEC>;
+#[doc = "Cache redundancy signal 1 register"]
+pub mod redundancy_sig1;
+#[doc = "REDUNDANCY_SIG2 (rw) register accessor: Cache redundancy signal 2 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig2::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig2::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@redundancy_sig2`] module"]
+pub type REDUNDANCY_SIG2 = crate::Reg<redundancy_sig2::REDUNDANCY_SIG2_SPEC>;
+#[doc = "Cache redundancy signal 2 register"]
+pub mod redundancy_sig2;
+#[doc = "REDUNDANCY_SIG3 (rw) register accessor: Cache redundancy signal 3 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig3::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig3::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@redundancy_sig3`] module"]
+pub type REDUNDANCY_SIG3 = crate::Reg<redundancy_sig3::REDUNDANCY_SIG3_SPEC>;
+#[doc = "Cache redundancy signal 3 register"]
+pub mod redundancy_sig3;
+#[doc = "REDUNDANCY_SIG4 (r) register accessor: Cache redundancy signal 0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig4::R`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@redundancy_sig4`] module"]
+pub type REDUNDANCY_SIG4 = crate::Reg<redundancy_sig4::REDUNDANCY_SIG4_SPEC>;
+#[doc = "Cache redundancy signal 0 register"]
+pub mod redundancy_sig4;
+pub use crate::dma::{date, DATE};

--- a/esp32h2/src/cache/cache_lock_addr.rs
+++ b/esp32h2/src/cache/cache_lock_addr.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `CACHE_LOCK_ADDR` reader"]
+pub type R = crate::R<CACHE_LOCK_ADDR_SPEC>;
+#[doc = "Register `CACHE_LOCK_ADDR` writer"]
+pub type W = crate::W<CACHE_LOCK_ADDR_SPEC>;
+#[doc = "Field `CACHE_LOCK_ADDR` reader - Those bits are used to configure the start virtual address of the lock/unlock operation, which should be used together with CACHE_LOCK_SIZE_REG"]
+pub type CACHE_LOCK_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_LOCK_ADDR` writer - Those bits are used to configure the start virtual address of the lock/unlock operation, which should be used together with CACHE_LOCK_SIZE_REG"]
+pub type CACHE_LOCK_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the lock/unlock operation, which should be used together with CACHE_LOCK_SIZE_REG"]
+    #[inline(always)]
+    pub fn cache_lock_addr(&self) -> CACHE_LOCK_ADDR_R {
+        CACHE_LOCK_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_LOCK_ADDR")
+            .field("cache_lock_addr", &self.cache_lock_addr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the lock/unlock operation, which should be used together with CACHE_LOCK_SIZE_REG"]
+    #[inline(always)]
+    pub fn cache_lock_addr(&mut self) -> CACHE_LOCK_ADDR_W<'_, CACHE_LOCK_ADDR_SPEC> {
+        CACHE_LOCK_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "Lock (manual lock) address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_LOCK_ADDR_SPEC;
+impl crate::RegisterSpec for CACHE_LOCK_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_lock_addr::R`](R) reader structure"]
+impl crate::Readable for CACHE_LOCK_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_lock_addr::W`](W) writer structure"]
+impl crate::Writable for CACHE_LOCK_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_LOCK_ADDR to value 0"]
+impl crate::Resettable for CACHE_LOCK_ADDR_SPEC {}

--- a/esp32h2/src/cache/cache_lock_ctrl.rs
+++ b/esp32h2/src/cache/cache_lock_ctrl.rs
@@ -1,0 +1,76 @@
+#[doc = "Register `CACHE_LOCK_CTRL` reader"]
+pub type R = crate::R<CACHE_LOCK_CTRL_SPEC>;
+#[doc = "Register `CACHE_LOCK_CTRL` writer"]
+pub type W = crate::W<CACHE_LOCK_CTRL_SPEC>;
+#[doc = "Field `CACHE_LOCK_ENA` reader - The bit is used to enable lock operation. It will be cleared by hardware after lock operation done"]
+pub type CACHE_LOCK_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_LOCK_ENA` writer - The bit is used to enable lock operation. It will be cleared by hardware after lock operation done"]
+pub type CACHE_LOCK_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_UNLOCK_ENA` reader - The bit is used to enable unlock operation. It will be cleared by hardware after unlock operation done"]
+pub type CACHE_UNLOCK_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_UNLOCK_ENA` writer - The bit is used to enable unlock operation. It will be cleared by hardware after unlock operation done"]
+pub type CACHE_UNLOCK_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_LOCK_DONE` reader - The bit is used to indicate whether unlock/lock operation is finished or not. 0: not finished. 1: finished."]
+pub type CACHE_LOCK_DONE_R = crate::BitReader;
+#[doc = "Field `CACHE_LOCK_RGID` reader - The bit is used to set the gid of cache lock/unlock."]
+pub type CACHE_LOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable lock operation. It will be cleared by hardware after lock operation done"]
+    #[inline(always)]
+    pub fn cache_lock_ena(&self) -> CACHE_LOCK_ENA_R {
+        CACHE_LOCK_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable unlock operation. It will be cleared by hardware after unlock operation done"]
+    #[inline(always)]
+    pub fn cache_unlock_ena(&self) -> CACHE_UNLOCK_ENA_R {
+        CACHE_UNLOCK_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to indicate whether unlock/lock operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn cache_lock_done(&self) -> CACHE_LOCK_DONE_R {
+        CACHE_LOCK_DONE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of cache lock/unlock."]
+    #[inline(always)]
+    pub fn cache_lock_rgid(&self) -> CACHE_LOCK_RGID_R {
+        CACHE_LOCK_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_LOCK_CTRL")
+            .field("cache_lock_ena", &self.cache_lock_ena())
+            .field("cache_unlock_ena", &self.cache_unlock_ena())
+            .field("cache_lock_done", &self.cache_lock_done())
+            .field("cache_lock_rgid", &self.cache_lock_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable lock operation. It will be cleared by hardware after lock operation done"]
+    #[inline(always)]
+    pub fn cache_lock_ena(&mut self) -> CACHE_LOCK_ENA_W<'_, CACHE_LOCK_CTRL_SPEC> {
+        CACHE_LOCK_ENA_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable unlock operation. It will be cleared by hardware after unlock operation done"]
+    #[inline(always)]
+    pub fn cache_unlock_ena(&mut self) -> CACHE_UNLOCK_ENA_W<'_, CACHE_LOCK_CTRL_SPEC> {
+        CACHE_UNLOCK_ENA_W::new(self, 1)
+    }
+}
+#[doc = "Lock-class (manual lock) operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_LOCK_CTRL_SPEC;
+impl crate::RegisterSpec for CACHE_LOCK_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_lock_ctrl::R`](R) reader structure"]
+impl crate::Readable for CACHE_LOCK_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_lock_ctrl::W`](W) writer structure"]
+impl crate::Writable for CACHE_LOCK_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_LOCK_CTRL to value 0x04"]
+impl crate::Resettable for CACHE_LOCK_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x04;
+}

--- a/esp32h2/src/cache/cache_lock_map.rs
+++ b/esp32h2/src/cache/cache_lock_map.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `CACHE_LOCK_MAP` reader"]
+pub type R = crate::R<CACHE_LOCK_MAP_SPEC>;
+#[doc = "Register `CACHE_LOCK_MAP` writer"]
+pub type W = crate::W<CACHE_LOCK_MAP_SPEC>;
+#[doc = "Field `CACHE_LOCK_MAP` reader - Those bits are used to indicate which caches in the two-level cache structure will apply this lock/unlock operation. \\[4\\]: L1-Cache"]
+pub type CACHE_LOCK_MAP_R = crate::FieldReader;
+#[doc = "Field `CACHE_LOCK_MAP` writer - Those bits are used to indicate which caches in the two-level cache structure will apply this lock/unlock operation. \\[4\\]: L1-Cache"]
+pub type CACHE_LOCK_MAP_W<'a, REG> = crate::FieldWriter<'a, REG, 6>;
+impl R {
+    #[doc = "Bits 0:5 - Those bits are used to indicate which caches in the two-level cache structure will apply this lock/unlock operation. \\[4\\]: L1-Cache"]
+    #[inline(always)]
+    pub fn cache_lock_map(&self) -> CACHE_LOCK_MAP_R {
+        CACHE_LOCK_MAP_R::new((self.bits & 0x3f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_LOCK_MAP")
+            .field("cache_lock_map", &self.cache_lock_map())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Those bits are used to indicate which caches in the two-level cache structure will apply this lock/unlock operation. \\[4\\]: L1-Cache"]
+    #[inline(always)]
+    pub fn cache_lock_map(&mut self) -> CACHE_LOCK_MAP_W<'_, CACHE_LOCK_MAP_SPEC> {
+        CACHE_LOCK_MAP_W::new(self, 0)
+    }
+}
+#[doc = "Lock (manual lock) map configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_map::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_map::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_LOCK_MAP_SPEC;
+impl crate::RegisterSpec for CACHE_LOCK_MAP_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_lock_map::R`](R) reader structure"]
+impl crate::Readable for CACHE_LOCK_MAP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_lock_map::W`](W) writer structure"]
+impl crate::Writable for CACHE_LOCK_MAP_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_LOCK_MAP to value 0"]
+impl crate::Resettable for CACHE_LOCK_MAP_SPEC {}

--- a/esp32h2/src/cache/cache_lock_size.rs
+++ b/esp32h2/src/cache/cache_lock_size.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `CACHE_LOCK_SIZE` reader"]
+pub type R = crate::R<CACHE_LOCK_SIZE_SPEC>;
+#[doc = "Register `CACHE_LOCK_SIZE` writer"]
+pub type W = crate::W<CACHE_LOCK_SIZE_SPEC>;
+#[doc = "Field `CACHE_LOCK_SIZE` reader - Those bits are used to configure the size of the lock/unlock operation, which should be used together with CACHE_LOCK_ADDR_REG"]
+pub type CACHE_LOCK_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `CACHE_LOCK_SIZE` writer - Those bits are used to configure the size of the lock/unlock operation, which should be used together with CACHE_LOCK_ADDR_REG"]
+pub type CACHE_LOCK_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Those bits are used to configure the size of the lock/unlock operation, which should be used together with CACHE_LOCK_ADDR_REG"]
+    #[inline(always)]
+    pub fn cache_lock_size(&self) -> CACHE_LOCK_SIZE_R {
+        CACHE_LOCK_SIZE_R::new((self.bits & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_LOCK_SIZE")
+            .field("cache_lock_size", &self.cache_lock_size())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Those bits are used to configure the size of the lock/unlock operation, which should be used together with CACHE_LOCK_ADDR_REG"]
+    #[inline(always)]
+    pub fn cache_lock_size(&mut self) -> CACHE_LOCK_SIZE_W<'_, CACHE_LOCK_SIZE_SPEC> {
+        CACHE_LOCK_SIZE_W::new(self, 0)
+    }
+}
+#[doc = "Lock (manual lock) size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_lock_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_lock_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_LOCK_SIZE_SPEC;
+impl crate::RegisterSpec for CACHE_LOCK_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_lock_size::R`](R) reader structure"]
+impl crate::Readable for CACHE_LOCK_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_lock_size::W`](W) writer structure"]
+impl crate::Writable for CACHE_LOCK_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_LOCK_SIZE to value 0"]
+impl crate::Resettable for CACHE_LOCK_SIZE_SPEC {}

--- a/esp32h2/src/cache/cache_sync_addr.rs
+++ b/esp32h2/src/cache/cache_sync_addr.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `CACHE_SYNC_ADDR` reader"]
+pub type R = crate::R<CACHE_SYNC_ADDR_SPEC>;
+#[doc = "Register `CACHE_SYNC_ADDR` writer"]
+pub type W = crate::W<CACHE_SYNC_ADDR_SPEC>;
+#[doc = "Field `CACHE_SYNC_ADDR` reader - Those bits are used to configure the start virtual address of the sync operation, which should be used together with CACHE_SYNC_SIZE_REG"]
+pub type CACHE_SYNC_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_SYNC_ADDR` writer - Those bits are used to configure the start virtual address of the sync operation, which should be used together with CACHE_SYNC_SIZE_REG"]
+pub type CACHE_SYNC_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the sync operation, which should be used together with CACHE_SYNC_SIZE_REG"]
+    #[inline(always)]
+    pub fn cache_sync_addr(&self) -> CACHE_SYNC_ADDR_R {
+        CACHE_SYNC_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_SYNC_ADDR")
+            .field("cache_sync_addr", &self.cache_sync_addr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the sync operation, which should be used together with CACHE_SYNC_SIZE_REG"]
+    #[inline(always)]
+    pub fn cache_sync_addr(&mut self) -> CACHE_SYNC_ADDR_W<'_, CACHE_SYNC_ADDR_SPEC> {
+        CACHE_SYNC_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "Sync address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_SYNC_ADDR_SPEC;
+impl crate::RegisterSpec for CACHE_SYNC_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_sync_addr::R`](R) reader structure"]
+impl crate::Readable for CACHE_SYNC_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_sync_addr::W`](W) writer structure"]
+impl crate::Writable for CACHE_SYNC_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_SYNC_ADDR to value 0"]
+impl crate::Resettable for CACHE_SYNC_ADDR_SPEC {}

--- a/esp32h2/src/cache/cache_sync_ctrl.rs
+++ b/esp32h2/src/cache/cache_sync_ctrl.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `CACHE_SYNC_CTRL` reader"]
+pub type R = crate::R<CACHE_SYNC_CTRL_SPEC>;
+#[doc = "Register `CACHE_SYNC_CTRL` writer"]
+pub type W = crate::W<CACHE_SYNC_CTRL_SPEC>;
+#[doc = "Field `CACHE_INVALIDATE_ENA` reader - The bit is used to enable invalidate operation. It will be cleared by hardware after invalidate operation done. Note that this bit and the other sync-bits (clean_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_INVALIDATE_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_INVALIDATE_ENA` writer - The bit is used to enable invalidate operation. It will be cleared by hardware after invalidate operation done. Note that this bit and the other sync-bits (clean_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_INVALIDATE_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_CLEAN_ENA` reader - The bit is used to enable clean operation. It will be cleared by hardware after clean operation done. Note that this bit and the other sync-bits (invalidate_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_CLEAN_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_CLEAN_ENA` writer - The bit is used to enable clean operation. It will be cleared by hardware after clean operation done. Note that this bit and the other sync-bits (invalidate_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_CLEAN_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_WRITEBACK_ENA` reader - The bit is used to enable writeback operation. It will be cleared by hardware after writeback operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_WRITEBACK_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_WRITEBACK_ENA` writer - The bit is used to enable writeback operation. It will be cleared by hardware after writeback operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_WRITEBACK_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_WRITEBACK_INVALIDATE_ENA` reader - The bit is used to enable writeback-invalidate operation. It will be cleared by hardware after writeback-invalidate operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_WRITEBACK_INVALIDATE_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_WRITEBACK_INVALIDATE_ENA` writer - The bit is used to enable writeback-invalidate operation. It will be cleared by hardware after writeback-invalidate operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+pub type CACHE_WRITEBACK_INVALIDATE_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_DONE` reader - The bit is used to indicate whether sync operation (invalidate, clean, writeback, writeback_invalidate) is finished or not. 0: not finished. 1: finished."]
+pub type CACHE_SYNC_DONE_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_RGID` reader - The bit is used to set the gid of cache sync operation (invalidate, clean, writeback, writeback_invalidate)"]
+pub type CACHE_SYNC_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable invalidate operation. It will be cleared by hardware after invalidate operation done. Note that this bit and the other sync-bits (clean_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_invalidate_ena(&self) -> CACHE_INVALIDATE_ENA_R {
+        CACHE_INVALIDATE_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable clean operation. It will be cleared by hardware after clean operation done. Note that this bit and the other sync-bits (invalidate_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_clean_ena(&self) -> CACHE_CLEAN_ENA_R {
+        CACHE_CLEAN_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to enable writeback operation. It will be cleared by hardware after writeback operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_writeback_ena(&self) -> CACHE_WRITEBACK_ENA_R {
+        CACHE_WRITEBACK_ENA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The bit is used to enable writeback-invalidate operation. It will be cleared by hardware after writeback-invalidate operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_writeback_invalidate_ena(&self) -> CACHE_WRITEBACK_INVALIDATE_ENA_R {
+        CACHE_WRITEBACK_INVALIDATE_ENA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to indicate whether sync operation (invalidate, clean, writeback, writeback_invalidate) is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn cache_sync_done(&self) -> CACHE_SYNC_DONE_R {
+        CACHE_SYNC_DONE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bits 5:8 - The bit is used to set the gid of cache sync operation (invalidate, clean, writeback, writeback_invalidate)"]
+    #[inline(always)]
+    pub fn cache_sync_rgid(&self) -> CACHE_SYNC_RGID_R {
+        CACHE_SYNC_RGID_R::new(((self.bits >> 5) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_SYNC_CTRL")
+            .field("cache_invalidate_ena", &self.cache_invalidate_ena())
+            .field("cache_clean_ena", &self.cache_clean_ena())
+            .field("cache_writeback_ena", &self.cache_writeback_ena())
+            .field(
+                "cache_writeback_invalidate_ena",
+                &self.cache_writeback_invalidate_ena(),
+            )
+            .field("cache_sync_done", &self.cache_sync_done())
+            .field("cache_sync_rgid", &self.cache_sync_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable invalidate operation. It will be cleared by hardware after invalidate operation done. Note that this bit and the other sync-bits (clean_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_invalidate_ena(&mut self) -> CACHE_INVALIDATE_ENA_W<'_, CACHE_SYNC_CTRL_SPEC> {
+        CACHE_INVALIDATE_ENA_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable clean operation. It will be cleared by hardware after clean operation done. Note that this bit and the other sync-bits (invalidate_ena, writeback_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_clean_ena(&mut self) -> CACHE_CLEAN_ENA_W<'_, CACHE_SYNC_CTRL_SPEC> {
+        CACHE_CLEAN_ENA_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - The bit is used to enable writeback operation. It will be cleared by hardware after writeback operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_invalidate_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_writeback_ena(&mut self) -> CACHE_WRITEBACK_ENA_W<'_, CACHE_SYNC_CTRL_SPEC> {
+        CACHE_WRITEBACK_ENA_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - The bit is used to enable writeback-invalidate operation. It will be cleared by hardware after writeback-invalidate operation done. Note that this bit and the other sync-bits (invalidate_ena, clean_ena, writeback_ena) are mutually exclusive, that is, those bits can not be set to 1 at the same time."]
+    #[inline(always)]
+    pub fn cache_writeback_invalidate_ena(
+        &mut self,
+    ) -> CACHE_WRITEBACK_INVALIDATE_ENA_W<'_, CACHE_SYNC_CTRL_SPEC> {
+        CACHE_WRITEBACK_INVALIDATE_ENA_W::new(self, 3)
+    }
+}
+#[doc = "Sync-class operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_SYNC_CTRL_SPEC;
+impl crate::RegisterSpec for CACHE_SYNC_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_sync_ctrl::R`](R) reader structure"]
+impl crate::Readable for CACHE_SYNC_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_sync_ctrl::W`](W) writer structure"]
+impl crate::Writable for CACHE_SYNC_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_SYNC_CTRL to value 0x01"]
+impl crate::Resettable for CACHE_SYNC_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x01;
+}

--- a/esp32h2/src/cache/cache_sync_map.rs
+++ b/esp32h2/src/cache/cache_sync_map.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `CACHE_SYNC_MAP` reader"]
+pub type R = crate::R<CACHE_SYNC_MAP_SPEC>;
+#[doc = "Register `CACHE_SYNC_MAP` writer"]
+pub type W = crate::W<CACHE_SYNC_MAP_SPEC>;
+#[doc = "Field `CACHE_SYNC_MAP` reader - Those bits are used to indicate which caches in the two-level cache structure will apply the sync operation. \\[4\\]: L1-Cache"]
+pub type CACHE_SYNC_MAP_R = crate::FieldReader;
+#[doc = "Field `CACHE_SYNC_MAP` writer - Those bits are used to indicate which caches in the two-level cache structure will apply the sync operation. \\[4\\]: L1-Cache"]
+pub type CACHE_SYNC_MAP_W<'a, REG> = crate::FieldWriter<'a, REG, 6>;
+impl R {
+    #[doc = "Bits 0:5 - Those bits are used to indicate which caches in the two-level cache structure will apply the sync operation. \\[4\\]: L1-Cache"]
+    #[inline(always)]
+    pub fn cache_sync_map(&self) -> CACHE_SYNC_MAP_R {
+        CACHE_SYNC_MAP_R::new((self.bits & 0x3f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_SYNC_MAP")
+            .field("cache_sync_map", &self.cache_sync_map())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Those bits are used to indicate which caches in the two-level cache structure will apply the sync operation. \\[4\\]: L1-Cache"]
+    #[inline(always)]
+    pub fn cache_sync_map(&mut self) -> CACHE_SYNC_MAP_W<'_, CACHE_SYNC_MAP_SPEC> {
+        CACHE_SYNC_MAP_W::new(self, 0)
+    }
+}
+#[doc = "Sync map configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_map::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_map::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_SYNC_MAP_SPEC;
+impl crate::RegisterSpec for CACHE_SYNC_MAP_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_sync_map::R`](R) reader structure"]
+impl crate::Readable for CACHE_SYNC_MAP_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_sync_map::W`](W) writer structure"]
+impl crate::Writable for CACHE_SYNC_MAP_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_SYNC_MAP to value 0x3f"]
+impl crate::Resettable for CACHE_SYNC_MAP_SPEC {
+    const RESET_VALUE: u32 = 0x3f;
+}

--- a/esp32h2/src/cache/cache_sync_size.rs
+++ b/esp32h2/src/cache/cache_sync_size.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `CACHE_SYNC_SIZE` reader"]
+pub type R = crate::R<CACHE_SYNC_SIZE_SPEC>;
+#[doc = "Register `CACHE_SYNC_SIZE` writer"]
+pub type W = crate::W<CACHE_SYNC_SIZE_SPEC>;
+#[doc = "Field `CACHE_SYNC_SIZE` reader - Those bits are used to configure the size of the sync operation, which should be used together with CACHE_SYNC_ADDR_REG"]
+pub type CACHE_SYNC_SIZE_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_SYNC_SIZE` writer - Those bits are used to configure the size of the sync operation, which should be used together with CACHE_SYNC_ADDR_REG"]
+pub type CACHE_SYNC_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 24, u32>;
+impl R {
+    #[doc = "Bits 0:23 - Those bits are used to configure the size of the sync operation, which should be used together with CACHE_SYNC_ADDR_REG"]
+    #[inline(always)]
+    pub fn cache_sync_size(&self) -> CACHE_SYNC_SIZE_R {
+        CACHE_SYNC_SIZE_R::new(self.bits & 0x00ff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE_SYNC_SIZE")
+            .field("cache_sync_size", &self.cache_sync_size())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Those bits are used to configure the size of the sync operation, which should be used together with CACHE_SYNC_ADDR_REG"]
+    #[inline(always)]
+    pub fn cache_sync_size(&mut self) -> CACHE_SYNC_SIZE_W<'_, CACHE_SYNC_SIZE_SPEC> {
+        CACHE_SYNC_SIZE_W::new(self, 0)
+    }
+}
+#[doc = "Sync size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`cache_sync_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`cache_sync_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CACHE_SYNC_SIZE_SPEC;
+impl crate::RegisterSpec for CACHE_SYNC_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cache_sync_size::R`](R) reader structure"]
+impl crate::Readable for CACHE_SYNC_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cache_sync_size::W`](W) writer structure"]
+impl crate::Writable for CACHE_SYNC_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CACHE_SYNC_SIZE to value 0"]
+impl crate::Resettable for CACHE_SYNC_SIZE_SPEC {}

--- a/esp32h2/src/cache/clock_gate.rs
+++ b/esp32h2/src/cache/clock_gate.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `CLOCK_GATE` reader"]
+pub type R = crate::R<CLOCK_GATE_SPEC>;
+#[doc = "Register `CLOCK_GATE` writer"]
+pub type W = crate::W<CLOCK_GATE_SPEC>;
+#[doc = "Field `CLK_EN` reader - The bit is used to enable clock gate when access all registers in this module."]
+pub type CLK_EN_R = crate::BitReader;
+#[doc = "Field `CLK_EN` writer - The bit is used to enable clock gate when access all registers in this module."]
+pub type CLK_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable clock gate when access all registers in this module."]
+    #[inline(always)]
+    pub fn clk_en(&self) -> CLK_EN_R {
+        CLK_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLOCK_GATE")
+            .field("clk_en", &self.clk_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable clock gate when access all registers in this module."]
+    #[inline(always)]
+    pub fn clk_en(&mut self) -> CLK_EN_W<'_, CLOCK_GATE_SPEC> {
+        CLK_EN_W::new(self, 0)
+    }
+}
+#[doc = "Clock gate control register\n\nYou can [`read`](crate::Reg::read) this register and get [`clock_gate::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`clock_gate::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CLOCK_GATE_SPEC;
+impl crate::RegisterSpec for CLOCK_GATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`clock_gate::R`](R) reader structure"]
+impl crate::Readable for CLOCK_GATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`clock_gate::W`](W) writer structure"]
+impl crate::Writable for CLOCK_GATE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CLOCK_GATE to value 0x01"]
+impl crate::Resettable for CLOCK_GATE_SPEC {
+    const RESET_VALUE: u32 = 0x01;
+}

--- a/esp32h2/src/cache/l1_bus0_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_bus0_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS0_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_BUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_BUS0_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus0 accesses L1-Cache."]
+pub type L1_BUS0_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus0 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus0_conflict_cnt(&self) -> L1_BUS0_CONFLICT_CNT_R {
+        L1_BUS0_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS0_ACS_CONFLICT_CNT")
+            .field("l1_bus0_conflict_cnt", &self.l1_bus0_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS0_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS0_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus0_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS0_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS0_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_BUS0_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus0_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_bus0_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS0_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_BUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_BUS0_HIT_CNT` reader - The register records the number of hits when bus0 accesses L1-Cache."]
+pub type L1_BUS0_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus0 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus0_hit_cnt(&self) -> L1_BUS0_HIT_CNT_R {
+        L1_BUS0_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS0_ACS_HIT_CNT")
+            .field("l1_bus0_hit_cnt", &self.l1_bus0_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS0_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS0_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus0_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS0_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS0_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_BUS0_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus0_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_bus0_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS0_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_BUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_BUS0_MISS_CNT` reader - The register records the number of missing when bus0 accesses L1-Cache."]
+pub type L1_BUS0_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus0 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus0_miss_cnt(&self) -> L1_BUS0_MISS_CNT_R {
+        L1_BUS0_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS0_ACS_MISS_CNT")
+            .field("l1_bus0_miss_cnt", &self.l1_bus0_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS0_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS0_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus0_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS0_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS0_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_BUS0_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus0_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_bus0_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS0_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_BUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_BUS0_NXTLVL_CNT` reader - The register records the number of times that L1-Cache accesses L2-Cache due to bus0 accessing L1-Cache."]
+pub type L1_BUS0_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-Cache accesses L2-Cache due to bus0 accessing L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus0_nxtlvl_cnt(&self) -> L1_BUS0_NXTLVL_CNT_R {
+        L1_BUS0_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS0_ACS_NXTLVL_CNT")
+            .field("l1_bus0_nxtlvl_cnt", &self.l1_bus0_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus0_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS0_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS0_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus0_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS0_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS0_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_BUS0_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus1_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_bus1_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS1_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_BUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_BUS1_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus1 accesses L1-Cache."]
+pub type L1_BUS1_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus1 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus1_conflict_cnt(&self) -> L1_BUS1_CONFLICT_CNT_R {
+        L1_BUS1_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS1_ACS_CONFLICT_CNT")
+            .field("l1_bus1_conflict_cnt", &self.l1_bus1_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS1_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS1_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus1_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS1_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS1_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_BUS1_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus1_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_bus1_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS1_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_BUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_BUS1_HIT_CNT` reader - The register records the number of hits when bus1 accesses L1-Cache."]
+pub type L1_BUS1_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus1 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus1_hit_cnt(&self) -> L1_BUS1_HIT_CNT_R {
+        L1_BUS1_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS1_ACS_HIT_CNT")
+            .field("l1_bus1_hit_cnt", &self.l1_bus1_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS1_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS1_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus1_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS1_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS1_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_BUS1_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus1_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_bus1_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS1_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_BUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_BUS1_MISS_CNT` reader - The register records the number of missing when bus1 accesses L1-Cache."]
+pub type L1_BUS1_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus1 accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus1_miss_cnt(&self) -> L1_BUS1_MISS_CNT_R {
+        L1_BUS1_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS1_ACS_MISS_CNT")
+            .field("l1_bus1_miss_cnt", &self.l1_bus1_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS1_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS1_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus1_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS1_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS1_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_BUS1_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bus1_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_bus1_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_BUS1_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_BUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_BUS1_NXTLVL_CNT` reader - The register records the number of times that L1-Cache accesses L2-Cache due to bus1 accessing L1-Cache."]
+pub type L1_BUS1_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-Cache accesses L2-Cache due to bus1 accessing L1-Cache."]
+    #[inline(always)]
+    pub fn l1_bus1_nxtlvl_cnt(&self) -> L1_BUS1_NXTLVL_CNT_R {
+        L1_BUS1_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BUS1_ACS_NXTLVL_CNT")
+            .field("l1_bus1_nxtlvl_cnt", &self.l1_bus1_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bus1_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BUS1_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_BUS1_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bus1_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_BUS1_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_BUS1_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_BUS1_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_bypass_cache_conf.rs
+++ b/esp32h2/src/cache/l1_bypass_cache_conf.rs
@@ -1,0 +1,60 @@
+#[doc = "Register `L1_BYPASS_CACHE_CONF` reader"]
+pub type R = crate::R<L1_BYPASS_CACHE_CONF_SPEC>;
+#[doc = "Field `BYPASS_L1_ICACHE0_EN` reader - The bit is used to enable bypass L1-ICache0. 0: disable bypass, 1: enable bypass."]
+pub type BYPASS_L1_ICACHE0_EN_R = crate::BitReader;
+#[doc = "Field `BYPASS_L1_ICACHE1_EN` reader - The bit is used to enable bypass L1-ICache1. 0: disable bypass, 1: enable bypass."]
+pub type BYPASS_L1_ICACHE1_EN_R = crate::BitReader;
+#[doc = "Field `BYPASS_L1_ICACHE2_EN` reader - Reserved"]
+pub type BYPASS_L1_ICACHE2_EN_R = crate::BitReader;
+#[doc = "Field `BYPASS_L1_ICACHE3_EN` reader - Reserved"]
+pub type BYPASS_L1_ICACHE3_EN_R = crate::BitReader;
+#[doc = "Field `BYPASS_L1_DCACHE_EN` reader - The bit is used to enable bypass L1-DCache. 0: disable bypass, 1: enable bypass."]
+pub type BYPASS_L1_DCACHE_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable bypass L1-ICache0. 0: disable bypass, 1: enable bypass."]
+    #[inline(always)]
+    pub fn bypass_l1_icache0_en(&self) -> BYPASS_L1_ICACHE0_EN_R {
+        BYPASS_L1_ICACHE0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable bypass L1-ICache1. 0: disable bypass, 1: enable bypass."]
+    #[inline(always)]
+    pub fn bypass_l1_icache1_en(&self) -> BYPASS_L1_ICACHE1_EN_R {
+        BYPASS_L1_ICACHE1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn bypass_l1_icache2_en(&self) -> BYPASS_L1_ICACHE2_EN_R {
+        BYPASS_L1_ICACHE2_EN_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn bypass_l1_icache3_en(&self) -> BYPASS_L1_ICACHE3_EN_R {
+        BYPASS_L1_ICACHE3_EN_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable bypass L1-DCache. 0: disable bypass, 1: enable bypass."]
+    #[inline(always)]
+    pub fn bypass_l1_dcache_en(&self) -> BYPASS_L1_DCACHE_EN_R {
+        BYPASS_L1_DCACHE_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_BYPASS_CACHE_CONF")
+            .field("bypass_l1_icache0_en", &self.bypass_l1_icache0_en())
+            .field("bypass_l1_icache1_en", &self.bypass_l1_icache1_en())
+            .field("bypass_l1_icache2_en", &self.bypass_l1_icache2_en())
+            .field("bypass_l1_icache3_en", &self.bypass_l1_icache3_en())
+            .field("bypass_l1_dcache_en", &self.bypass_l1_dcache_en())
+            .finish()
+    }
+}
+#[doc = "Bypass Cache configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_bypass_cache_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_BYPASS_CACHE_CONF_SPEC;
+impl crate::RegisterSpec for L1_BYPASS_CACHE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_bypass_cache_conf::R`](R) reader structure"]
+impl crate::Readable for L1_BYPASS_CACHE_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_BYPASS_CACHE_CONF to value 0"]
+impl crate::Resettable for L1_BYPASS_CACHE_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_cnt_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_acs_cnt_ctrl.rs
@@ -1,0 +1,168 @@
+#[doc = "Register `L1_CACHE_ACS_CNT_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_ACS_CNT_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_CNT_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_ACS_CNT_CTRL_SPEC>;
+#[doc = "Field `L1_IBUS0_CNT_ENA` reader - The bit is used to enable ibus0 counter in L1-ICache0."]
+pub type L1_IBUS0_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_CNT_ENA` reader - The bit is used to enable ibus1 counter in L1-ICache1."]
+pub type L1_IBUS1_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_CNT_ENA` reader - Reserved"]
+pub type L1_IBUS2_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_CNT_ENA` reader - Reserved"]
+pub type L1_IBUS3_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_CNT_ENA` reader - The bit is used to enable dbus0 counter in L1-DCache."]
+pub type L1_BUS0_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_CNT_ENA` writer - The bit is used to enable dbus0 counter in L1-DCache."]
+pub type L1_BUS0_CNT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS1_CNT_ENA` reader - The bit is used to enable dbus1 counter in L1-DCache."]
+pub type L1_BUS1_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS1_CNT_ENA` writer - The bit is used to enable dbus1 counter in L1-DCache."]
+pub type L1_BUS1_CNT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS2_CNT_ENA` reader - Reserved"]
+pub type L1_DBUS2_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_CNT_ENA` reader - Reserved"]
+pub type L1_DBUS3_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS0_CNT_CLR` reader - The bit is used to clear ibus0 counter in L1-ICache0."]
+pub type L1_IBUS0_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_CNT_CLR` reader - The bit is used to clear ibus1 counter in L1-ICache1."]
+pub type L1_IBUS1_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_CNT_CLR` reader - Reserved"]
+pub type L1_IBUS2_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_CNT_CLR` reader - Reserved"]
+pub type L1_IBUS3_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_CNT_CLR` writer - The bit is used to clear dbus0 counter in L1-DCache."]
+pub type L1_BUS0_CNT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS1_CNT_CLR` writer - The bit is used to clear dbus1 counter in L1-DCache."]
+pub type L1_BUS1_CNT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS2_CNT_CLR` reader - Reserved"]
+pub type L1_DBUS2_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_CNT_CLR` reader - Reserved"]
+pub type L1_DBUS3_CNT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable ibus0 counter in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_cnt_ena(&self) -> L1_IBUS0_CNT_ENA_R {
+        L1_IBUS0_CNT_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable ibus1 counter in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_cnt_ena(&self) -> L1_IBUS1_CNT_ENA_R {
+        L1_IBUS1_CNT_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus2_cnt_ena(&self) -> L1_IBUS2_CNT_ENA_R {
+        L1_IBUS2_CNT_ENA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus3_cnt_ena(&self) -> L1_IBUS3_CNT_ENA_R {
+        L1_IBUS3_CNT_ENA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable dbus0 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_cnt_ena(&self) -> L1_BUS0_CNT_ENA_R {
+        L1_BUS0_CNT_ENA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to enable dbus1 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_cnt_ena(&self) -> L1_BUS1_CNT_ENA_R {
+        L1_BUS1_CNT_ENA_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus2_cnt_ena(&self) -> L1_DBUS2_CNT_ENA_R {
+        L1_DBUS2_CNT_ENA_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus3_cnt_ena(&self) -> L1_DBUS3_CNT_ENA_R {
+        L1_DBUS3_CNT_ENA_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to clear ibus0 counter in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_cnt_clr(&self) -> L1_IBUS0_CNT_CLR_R {
+        L1_IBUS0_CNT_CLR_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to clear ibus1 counter in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_cnt_clr(&self) -> L1_IBUS1_CNT_CLR_R {
+        L1_IBUS1_CNT_CLR_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus2_cnt_clr(&self) -> L1_IBUS2_CNT_CLR_R {
+        L1_IBUS2_CNT_CLR_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus3_cnt_clr(&self) -> L1_IBUS3_CNT_CLR_R {
+        L1_IBUS3_CNT_CLR_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 22 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus2_cnt_clr(&self) -> L1_DBUS2_CNT_CLR_R {
+        L1_DBUS2_CNT_CLR_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus3_cnt_clr(&self) -> L1_DBUS3_CNT_CLR_R {
+        L1_DBUS3_CNT_CLR_R::new(((self.bits >> 23) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_CNT_CTRL")
+            .field("l1_ibus0_cnt_ena", &self.l1_ibus0_cnt_ena())
+            .field("l1_ibus1_cnt_ena", &self.l1_ibus1_cnt_ena())
+            .field("l1_ibus2_cnt_ena", &self.l1_ibus2_cnt_ena())
+            .field("l1_ibus3_cnt_ena", &self.l1_ibus3_cnt_ena())
+            .field("l1_bus0_cnt_ena", &self.l1_bus0_cnt_ena())
+            .field("l1_bus1_cnt_ena", &self.l1_bus1_cnt_ena())
+            .field("l1_dbus2_cnt_ena", &self.l1_dbus2_cnt_ena())
+            .field("l1_dbus3_cnt_ena", &self.l1_dbus3_cnt_ena())
+            .field("l1_ibus0_cnt_clr", &self.l1_ibus0_cnt_clr())
+            .field("l1_ibus1_cnt_clr", &self.l1_ibus1_cnt_clr())
+            .field("l1_ibus2_cnt_clr", &self.l1_ibus2_cnt_clr())
+            .field("l1_ibus3_cnt_clr", &self.l1_ibus3_cnt_clr())
+            .field("l1_dbus2_cnt_clr", &self.l1_dbus2_cnt_clr())
+            .field("l1_dbus3_cnt_clr", &self.l1_dbus3_cnt_clr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to enable dbus0 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_cnt_ena(&mut self) -> L1_BUS0_CNT_ENA_W<'_, L1_CACHE_ACS_CNT_CTRL_SPEC> {
+        L1_BUS0_CNT_ENA_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - The bit is used to enable dbus1 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_cnt_ena(&mut self) -> L1_BUS1_CNT_ENA_W<'_, L1_CACHE_ACS_CNT_CTRL_SPEC> {
+        L1_BUS1_CNT_ENA_W::new(self, 5)
+    }
+    #[doc = "Bit 20 - The bit is used to clear dbus0 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_cnt_clr(&mut self) -> L1_BUS0_CNT_CLR_W<'_, L1_CACHE_ACS_CNT_CTRL_SPEC> {
+        L1_BUS0_CNT_CLR_W::new(self, 20)
+    }
+    #[doc = "Bit 21 - The bit is used to clear dbus1 counter in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_cnt_clr(&mut self) -> L1_BUS1_CNT_CLR_W<'_, L1_CACHE_ACS_CNT_CTRL_SPEC> {
+        L1_BUS1_CNT_CLR_W::new(self, 21)
+    }
+}
+#[doc = "Cache Access Counter enable and clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_CNT_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_CNT_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_cnt_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_CNT_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_cnt_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_CNT_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_CNT_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_CNT_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_cnt_int_clr.rs
+++ b/esp32h2/src/cache/l1_cache_acs_cnt_int_clr.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_CLR` reader"]
+pub type R = crate::R<L1_CACHE_ACS_CNT_INT_CLR_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_CLR` writer"]
+pub type W = crate::W<L1_CACHE_ACS_CNT_INT_CLR_SPEC>;
+#[doc = "Field `L1_IBUS0_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L1-ICache0 due to bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L1-ICache1 due to bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_OVF_INT_CLR` reader - Reserved"]
+pub type L1_IBUS2_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_OVF_INT_CLR` reader - Reserved"]
+pub type L1_IBUS3_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_OVF_INT_CLR` writer - The bit is used to clear counters overflow interrupt and counters in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS1_OVF_INT_CLR` writer - The bit is used to clear counters overflow interrupt and counters in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS2_OVF_INT_CLR` reader - Reserved"]
+pub type L1_DBUS2_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_OVF_INT_CLR` reader - Reserved"]
+pub type L1_DBUS3_OVF_INT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to clear counters overflow interrupt and counters in L1-ICache0 due to bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_ovf_int_clr(&self) -> L1_IBUS0_OVF_INT_CLR_R {
+        L1_IBUS0_OVF_INT_CLR_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to clear counters overflow interrupt and counters in L1-ICache1 due to bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_ovf_int_clr(&self) -> L1_IBUS1_OVF_INT_CLR_R {
+        L1_IBUS1_OVF_INT_CLR_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus2_ovf_int_clr(&self) -> L1_IBUS2_OVF_INT_CLR_R {
+        L1_IBUS2_OVF_INT_CLR_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus3_ovf_int_clr(&self) -> L1_IBUS3_OVF_INT_CLR_R {
+        L1_IBUS3_OVF_INT_CLR_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus2_ovf_int_clr(&self) -> L1_DBUS2_OVF_INT_CLR_R {
+        L1_DBUS2_OVF_INT_CLR_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus3_ovf_int_clr(&self) -> L1_DBUS3_OVF_INT_CLR_R {
+        L1_DBUS3_OVF_INT_CLR_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_CNT_INT_CLR")
+            .field("l1_ibus0_ovf_int_clr", &self.l1_ibus0_ovf_int_clr())
+            .field("l1_ibus1_ovf_int_clr", &self.l1_ibus1_ovf_int_clr())
+            .field("l1_ibus2_ovf_int_clr", &self.l1_ibus2_ovf_int_clr())
+            .field("l1_ibus3_ovf_int_clr", &self.l1_ibus3_ovf_int_clr())
+            .field("l1_dbus2_ovf_int_clr", &self.l1_dbus2_ovf_int_clr())
+            .field("l1_dbus3_ovf_int_clr", &self.l1_dbus3_ovf_int_clr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to clear counters overflow interrupt and counters in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_clr(
+        &mut self,
+    ) -> L1_BUS0_OVF_INT_CLR_W<'_, L1_CACHE_ACS_CNT_INT_CLR_SPEC> {
+        L1_BUS0_OVF_INT_CLR_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - The bit is used to clear counters overflow interrupt and counters in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_clr(
+        &mut self,
+    ) -> L1_BUS1_OVF_INT_CLR_W<'_, L1_CACHE_ACS_CNT_INT_CLR_SPEC> {
+        L1_BUS1_OVF_INT_CLR_W::new(self, 5)
+    }
+}
+#[doc = "Cache Access Counter Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_clr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_clr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_CNT_INT_CLR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_CNT_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_cnt_int_clr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_CNT_INT_CLR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_cnt_int_clr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_CNT_INT_CLR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_CNT_INT_CLR to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_CNT_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_cnt_int_ena.rs
+++ b/esp32h2/src/cache/l1_cache_acs_cnt_int_ena.rs
@@ -1,0 +1,110 @@
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_ENA` reader"]
+pub type R = crate::R<L1_CACHE_ACS_CNT_INT_ENA_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_ENA` writer"]
+pub type W = crate::W<L1_CACHE_ACS_CNT_INT_ENA_SPEC>;
+#[doc = "Field `L1_IBUS0_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_OVF_INT_ENA` reader - Reserved"]
+pub type L1_IBUS2_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_OVF_INT_ENA` reader - Reserved"]
+pub type L1_IBUS3_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_OVF_INT_ENA` writer - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS1_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_BUS1_OVF_INT_ENA` writer - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS2_OVF_INT_ENA` reader - Reserved"]
+pub type L1_DBUS2_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_OVF_INT_ENA` reader - Reserved"]
+pub type L1_DBUS3_OVF_INT_ENA_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_ovf_int_ena(&self) -> L1_IBUS0_OVF_INT_ENA_R {
+        L1_IBUS0_OVF_INT_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_ovf_int_ena(&self) -> L1_IBUS1_OVF_INT_ENA_R {
+        L1_IBUS1_OVF_INT_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus2_ovf_int_ena(&self) -> L1_IBUS2_OVF_INT_ENA_R {
+        L1_IBUS2_OVF_INT_ENA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus3_ovf_int_ena(&self) -> L1_IBUS3_OVF_INT_ENA_R {
+        L1_IBUS3_OVF_INT_ENA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_ena(&self) -> L1_BUS0_OVF_INT_ENA_R {
+        L1_BUS0_OVF_INT_ENA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_ena(&self) -> L1_BUS1_OVF_INT_ENA_R {
+        L1_BUS1_OVF_INT_ENA_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus2_ovf_int_ena(&self) -> L1_DBUS2_OVF_INT_ENA_R {
+        L1_DBUS2_OVF_INT_ENA_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus3_ovf_int_ena(&self) -> L1_DBUS3_OVF_INT_ENA_R {
+        L1_DBUS3_OVF_INT_ENA_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_CNT_INT_ENA")
+            .field("l1_ibus0_ovf_int_ena", &self.l1_ibus0_ovf_int_ena())
+            .field("l1_ibus1_ovf_int_ena", &self.l1_ibus1_ovf_int_ena())
+            .field("l1_ibus2_ovf_int_ena", &self.l1_ibus2_ovf_int_ena())
+            .field("l1_ibus3_ovf_int_ena", &self.l1_ibus3_ovf_int_ena())
+            .field("l1_bus0_ovf_int_ena", &self.l1_bus0_ovf_int_ena())
+            .field("l1_bus1_ovf_int_ena", &self.l1_bus1_ovf_int_ena())
+            .field("l1_dbus2_ovf_int_ena", &self.l1_dbus2_ovf_int_ena())
+            .field("l1_dbus3_ovf_int_ena", &self.l1_dbus3_ovf_int_ena())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_ena(
+        &mut self,
+    ) -> L1_BUS0_OVF_INT_ENA_W<'_, L1_CACHE_ACS_CNT_INT_ENA_SPEC> {
+        L1_BUS0_OVF_INT_ENA_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - The bit is used to enable interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_ena(
+        &mut self,
+    ) -> L1_BUS1_OVF_INT_ENA_W<'_, L1_CACHE_ACS_CNT_INT_ENA_SPEC> {
+        L1_BUS1_OVF_INT_ENA_W::new(self, 5)
+    }
+}
+#[doc = "Cache Access Counter Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_ena::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_ena::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_CNT_INT_ENA_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_CNT_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_cnt_int_ena::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_CNT_INT_ENA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_cnt_int_ena::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_CNT_INT_ENA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_CNT_INT_ENA to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_CNT_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_cnt_int_raw.rs
+++ b/esp32h2/src/cache/l1_cache_acs_cnt_int_raw.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_RAW` reader"]
+pub type R = crate::R<L1_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_RAW` writer"]
+pub type W = crate::W<L1_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Field `L1_IBUS0_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_IBUS0_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_IBUS1_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_IBUS2_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache2 due to bus2 accesses L1-ICache2."]
+pub type L1_IBUS2_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache2 due to bus2 accesses L1-ICache2."]
+pub type L1_IBUS2_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_IBUS3_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache3 due to bus3 accesses L1-ICache3."]
+pub type L1_IBUS3_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache3 due to bus3 accesses L1-ICache3."]
+pub type L1_IBUS3_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS0_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_BUS1_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_BUS1_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS2_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus2 accesses L1-DCache."]
+pub type L1_DBUS2_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_DBUS2_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus2 accesses L1-DCache."]
+pub type L1_DBUS2_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_DBUS3_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus3 accesses L1-DCache."]
+pub type L1_DBUS3_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus3 accesses L1-DCache."]
+pub type L1_DBUS3_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_ovf_int_raw(&self) -> L1_IBUS0_OVF_INT_RAW_R {
+        L1_IBUS0_OVF_INT_RAW_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_ovf_int_raw(&self) -> L1_IBUS1_OVF_INT_RAW_R {
+        L1_IBUS1_OVF_INT_RAW_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache2 due to bus2 accesses L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_ovf_int_raw(&self) -> L1_IBUS2_OVF_INT_RAW_R {
+        L1_IBUS2_OVF_INT_RAW_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache3 due to bus3 accesses L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_ovf_int_raw(&self) -> L1_IBUS3_OVF_INT_RAW_R {
+        L1_IBUS3_OVF_INT_RAW_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_raw(&self) -> L1_BUS0_OVF_INT_RAW_R {
+        L1_BUS0_OVF_INT_RAW_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_raw(&self) -> L1_BUS1_OVF_INT_RAW_R {
+        L1_BUS1_OVF_INT_RAW_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus2 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_ovf_int_raw(&self) -> L1_DBUS2_OVF_INT_RAW_R {
+        L1_DBUS2_OVF_INT_RAW_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus3 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_ovf_int_raw(&self) -> L1_DBUS3_OVF_INT_RAW_R {
+        L1_DBUS3_OVF_INT_RAW_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_CNT_INT_RAW")
+            .field("l1_ibus0_ovf_int_raw", &self.l1_ibus0_ovf_int_raw())
+            .field("l1_ibus1_ovf_int_raw", &self.l1_ibus1_ovf_int_raw())
+            .field("l1_ibus2_ovf_int_raw", &self.l1_ibus2_ovf_int_raw())
+            .field("l1_ibus3_ovf_int_raw", &self.l1_ibus3_ovf_int_raw())
+            .field("l1_bus0_ovf_int_raw", &self.l1_bus0_ovf_int_raw())
+            .field("l1_bus1_ovf_int_raw", &self.l1_bus1_ovf_int_raw())
+            .field("l1_dbus2_ovf_int_raw", &self.l1_dbus2_ovf_int_raw())
+            .field("l1_dbus3_ovf_int_raw", &self.l1_dbus3_ovf_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_ovf_int_raw(
+        &mut self,
+    ) -> L1_IBUS0_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_IBUS0_OVF_INT_RAW_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_ovf_int_raw(
+        &mut self,
+    ) -> L1_IBUS1_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_IBUS1_OVF_INT_RAW_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache2 due to bus2 accesses L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_ovf_int_raw(
+        &mut self,
+    ) -> L1_IBUS2_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_IBUS2_OVF_INT_RAW_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - The raw bit of the interrupt of one of counters overflow that occurs in L1-ICache3 due to bus3 accesses L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_ovf_int_raw(
+        &mut self,
+    ) -> L1_IBUS3_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_IBUS3_OVF_INT_RAW_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_raw(
+        &mut self,
+    ) -> L1_BUS0_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_BUS0_OVF_INT_RAW_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_raw(
+        &mut self,
+    ) -> L1_BUS1_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_BUS1_OVF_INT_RAW_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus2 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_ovf_int_raw(
+        &mut self,
+    ) -> L1_DBUS2_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_DBUS2_OVF_INT_RAW_W::new(self, 6)
+    }
+    #[doc = "Bit 7 - The raw bit of the interrupt of one of counters overflow that occurs in L1-DCache due to bus3 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_ovf_int_raw(
+        &mut self,
+    ) -> L1_DBUS3_OVF_INT_RAW_W<'_, L1_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L1_DBUS3_OVF_INT_RAW_W::new(self, 7)
+    }
+}
+#[doc = "Cache Access Counter Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_cnt_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_CNT_INT_RAW_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_CNT_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_cnt_int_raw::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_CNT_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_cnt_int_raw::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_CNT_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_CNT_INT_RAW to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_CNT_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_cnt_int_st.rs
+++ b/esp32h2/src/cache/l1_cache_acs_cnt_int_st.rs
@@ -1,0 +1,84 @@
+#[doc = "Register `L1_CACHE_ACS_CNT_INT_ST` reader"]
+pub type R = crate::R<L1_CACHE_ACS_CNT_INT_ST_SPEC>;
+#[doc = "Field `L1_IBUS0_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_IBUS1_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_IBUS2_OVF_INT_ST` reader - Reserved"]
+pub type L1_IBUS2_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_IBUS3_OVF_INT_ST` reader - Reserved"]
+pub type L1_IBUS3_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_BUS0_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+pub type L1_BUS0_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_BUS1_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+pub type L1_BUS1_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_DBUS2_OVF_INT_ST` reader - Reserved"]
+pub type L1_DBUS2_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_DBUS3_OVF_INT_ST` reader - Reserved"]
+pub type L1_DBUS3_OVF_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit indicates the interrupt status of one of counters overflow that occurs in L1-ICache0 due to bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_ovf_int_st(&self) -> L1_IBUS0_OVF_INT_ST_R {
+        L1_IBUS0_OVF_INT_ST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit indicates the interrupt status of one of counters overflow that occurs in L1-ICache1 due to bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_ovf_int_st(&self) -> L1_IBUS1_OVF_INT_ST_R {
+        L1_IBUS1_OVF_INT_ST_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus2_ovf_int_st(&self) -> L1_IBUS2_OVF_INT_ST_R {
+        L1_IBUS2_OVF_INT_ST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_ibus3_ovf_int_st(&self) -> L1_IBUS3_OVF_INT_ST_R {
+        L1_IBUS3_OVF_INT_ST_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit indicates the interrupt status of one of counters overflow that occurs in L1-DCache due to bus0 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus0_ovf_int_st(&self) -> L1_BUS0_OVF_INT_ST_R {
+        L1_BUS0_OVF_INT_ST_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit indicates the interrupt status of one of counters overflow that occurs in L1-DCache due to bus1 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_bus1_ovf_int_st(&self) -> L1_BUS1_OVF_INT_ST_R {
+        L1_BUS1_OVF_INT_ST_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus2_ovf_int_st(&self) -> L1_DBUS2_OVF_INT_ST_R {
+        L1_DBUS2_OVF_INT_ST_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_dbus3_ovf_int_st(&self) -> L1_DBUS3_OVF_INT_ST_R {
+        L1_DBUS3_OVF_INT_ST_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_CNT_INT_ST")
+            .field("l1_ibus0_ovf_int_st", &self.l1_ibus0_ovf_int_st())
+            .field("l1_ibus1_ovf_int_st", &self.l1_ibus1_ovf_int_st())
+            .field("l1_ibus2_ovf_int_st", &self.l1_ibus2_ovf_int_st())
+            .field("l1_ibus3_ovf_int_st", &self.l1_ibus3_ovf_int_st())
+            .field("l1_bus0_ovf_int_st", &self.l1_bus0_ovf_int_st())
+            .field("l1_bus1_ovf_int_st", &self.l1_bus1_ovf_int_st())
+            .field("l1_dbus2_ovf_int_st", &self.l1_dbus2_ovf_int_st())
+            .field("l1_dbus3_ovf_int_st", &self.l1_dbus3_ovf_int_st())
+            .finish()
+    }
+}
+#[doc = "Cache Access Counter Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_cnt_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_CNT_INT_ST_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_CNT_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_cnt_int_st::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_CNT_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_ACS_CNT_INT_ST to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_CNT_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l1_cache_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L1_CACHE_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L1_CACHE_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L1_CACHE_FAIL_ID` reader - The register records the ID of fail-access when cache accesses L1-Cache."]
+pub type L1_CACHE_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_CACHE_FAIL_ATTR` reader - The register records the attribution of fail-access when cache accesses L1-Cache."]
+pub type L1_CACHE_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when cache accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_id(&self) -> L1_CACHE_FAIL_ID_R {
+        L1_CACHE_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when cache accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_attr(&self) -> L1_CACHE_FAIL_ATTR_R {
+        L1_CACHE_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_FAIL_ID_ATTR")
+            .field("l1_cache_fail_id", &self.l1_cache_fail_id())
+            .field("l1_cache_fail_attr", &self.l1_cache_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_fail_int_clr.rs
+++ b/esp32h2/src/cache/l1_cache_acs_fail_int_clr.rs
@@ -1,0 +1,69 @@
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_CLR` reader"]
+pub type R = crate::R<L1_CACHE_ACS_FAIL_INT_CLR_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_CLR` writer"]
+pub type W = crate::W<L1_CACHE_ACS_FAIL_INT_CLR_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_INT_CLR` reader - The bit is used to clear interrupt of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache0."]
+pub type L1_ICACHE0_FAIL_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FAIL_INT_CLR` reader - The bit is used to clear interrupt of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache1."]
+pub type L1_ICACHE1_FAIL_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FAIL_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE2_FAIL_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FAIL_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE3_FAIL_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FAIL_INT_CLR` writer - The bit is used to clear interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+pub type L1_CACHE_FAIL_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to clear interrupt of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_int_clr(&self) -> L1_ICACHE0_FAIL_INT_CLR_R {
+        L1_ICACHE0_FAIL_INT_CLR_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to clear interrupt of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_int_clr(&self) -> L1_ICACHE1_FAIL_INT_CLR_R {
+        L1_ICACHE1_FAIL_INT_CLR_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_fail_int_clr(&self) -> L1_ICACHE2_FAIL_INT_CLR_R {
+        L1_ICACHE2_FAIL_INT_CLR_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_fail_int_clr(&self) -> L1_ICACHE3_FAIL_INT_CLR_R {
+        L1_ICACHE3_FAIL_INT_CLR_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_FAIL_INT_CLR")
+            .field("l1_icache0_fail_int_clr", &self.l1_icache0_fail_int_clr())
+            .field("l1_icache1_fail_int_clr", &self.l1_icache1_fail_int_clr())
+            .field("l1_icache2_fail_int_clr", &self.l1_icache2_fail_int_clr())
+            .field("l1_icache3_fail_int_clr", &self.l1_icache3_fail_int_clr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to clear interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_clr(
+        &mut self,
+    ) -> L1_CACHE_FAIL_INT_CLR_W<'_, L1_CACHE_ACS_FAIL_INT_CLR_SPEC> {
+        L1_CACHE_FAIL_INT_CLR_W::new(self, 4)
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_clr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_clr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_FAIL_INT_CLR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_FAIL_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_fail_int_clr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_FAIL_INT_CLR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_fail_int_clr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_FAIL_INT_CLR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_FAIL_INT_CLR to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_FAIL_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_fail_int_ena.rs
+++ b/esp32h2/src/cache/l1_cache_acs_fail_int_ena.rs
@@ -1,0 +1,77 @@
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_ENA` reader"]
+pub type R = crate::R<L1_CACHE_ACS_FAIL_INT_ENA_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_ENA` writer"]
+pub type W = crate::W<L1_CACHE_ACS_FAIL_INT_ENA_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_INT_ENA` reader - The bit is used to enable interrupt of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache0."]
+pub type L1_ICACHE0_FAIL_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FAIL_INT_ENA` reader - The bit is used to enable interrupt of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache1."]
+pub type L1_ICACHE1_FAIL_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FAIL_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE2_FAIL_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FAIL_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE3_FAIL_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FAIL_INT_ENA` reader - The bit is used to enable interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+pub type L1_CACHE_FAIL_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FAIL_INT_ENA` writer - The bit is used to enable interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+pub type L1_CACHE_FAIL_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable interrupt of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_int_ena(&self) -> L1_ICACHE0_FAIL_INT_ENA_R {
+        L1_ICACHE0_FAIL_INT_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable interrupt of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_int_ena(&self) -> L1_ICACHE1_FAIL_INT_ENA_R {
+        L1_ICACHE1_FAIL_INT_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_fail_int_ena(&self) -> L1_ICACHE2_FAIL_INT_ENA_R {
+        L1_ICACHE2_FAIL_INT_ENA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_fail_int_ena(&self) -> L1_ICACHE3_FAIL_INT_ENA_R {
+        L1_ICACHE3_FAIL_INT_ENA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_ena(&self) -> L1_CACHE_FAIL_INT_ENA_R {
+        L1_CACHE_FAIL_INT_ENA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_FAIL_INT_ENA")
+            .field("l1_icache0_fail_int_ena", &self.l1_icache0_fail_int_ena())
+            .field("l1_icache1_fail_int_ena", &self.l1_icache1_fail_int_ena())
+            .field("l1_icache2_fail_int_ena", &self.l1_icache2_fail_int_ena())
+            .field("l1_icache3_fail_int_ena", &self.l1_icache3_fail_int_ena())
+            .field("l1_cache_fail_int_ena", &self.l1_cache_fail_int_ena())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to enable interrupt of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_ena(
+        &mut self,
+    ) -> L1_CACHE_FAIL_INT_ENA_W<'_, L1_CACHE_ACS_FAIL_INT_ENA_SPEC> {
+        L1_CACHE_FAIL_INT_ENA_W::new(self, 4)
+    }
+}
+#[doc = "Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_ena::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_ena::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_FAIL_INT_ENA_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_FAIL_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_fail_int_ena::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_FAIL_INT_ENA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_fail_int_ena::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_FAIL_INT_ENA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_FAIL_INT_ENA to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_FAIL_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_fail_int_raw.rs
+++ b/esp32h2/src/cache/l1_cache_acs_fail_int_raw.rs
@@ -1,0 +1,113 @@
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_RAW` reader"]
+pub type R = crate::R<L1_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_RAW` writer"]
+pub type W = crate::W<L1_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L1-ICache0."]
+pub type L1_ICACHE0_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L1-ICache0."]
+pub type L1_ICACHE0_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE1_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L1-ICache1."]
+pub type L1_ICACHE1_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L1-ICache1."]
+pub type L1_ICACHE1_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE2_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L1-ICache2."]
+pub type L1_ICACHE2_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L1-ICache2."]
+pub type L1_ICACHE2_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE3_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L1-ICache3."]
+pub type L1_ICACHE3_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L1-ICache3."]
+pub type L1_ICACHE3_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L1-DCache."]
+pub type L1_CACHE_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L1-DCache."]
+pub type L1_CACHE_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The raw bit of the interrupt of access fail that occurs in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_int_raw(&self) -> L1_ICACHE0_FAIL_INT_RAW_R {
+        L1_ICACHE0_FAIL_INT_RAW_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt of access fail that occurs in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_int_raw(&self) -> L1_ICACHE1_FAIL_INT_RAW_R {
+        L1_ICACHE1_FAIL_INT_RAW_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The raw bit of the interrupt of access fail that occurs in L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_fail_int_raw(&self) -> L1_ICACHE2_FAIL_INT_RAW_R {
+        L1_ICACHE2_FAIL_INT_RAW_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The raw bit of the interrupt of access fail that occurs in L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_fail_int_raw(&self) -> L1_ICACHE3_FAIL_INT_RAW_R {
+        L1_ICACHE3_FAIL_INT_RAW_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt of access fail that occurs in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_raw(&self) -> L1_CACHE_FAIL_INT_RAW_R {
+        L1_CACHE_FAIL_INT_RAW_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_FAIL_INT_RAW")
+            .field("l1_icache0_fail_int_raw", &self.l1_icache0_fail_int_raw())
+            .field("l1_icache1_fail_int_raw", &self.l1_icache1_fail_int_raw())
+            .field("l1_icache2_fail_int_raw", &self.l1_icache2_fail_int_raw())
+            .field("l1_icache3_fail_int_raw", &self.l1_icache3_fail_int_raw())
+            .field("l1_cache_fail_int_raw", &self.l1_cache_fail_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The raw bit of the interrupt of access fail that occurs in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_int_raw(
+        &mut self,
+    ) -> L1_ICACHE0_FAIL_INT_RAW_W<'_, L1_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L1_ICACHE0_FAIL_INT_RAW_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt of access fail that occurs in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_int_raw(
+        &mut self,
+    ) -> L1_ICACHE1_FAIL_INT_RAW_W<'_, L1_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L1_ICACHE1_FAIL_INT_RAW_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - The raw bit of the interrupt of access fail that occurs in L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_fail_int_raw(
+        &mut self,
+    ) -> L1_ICACHE2_FAIL_INT_RAW_W<'_, L1_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L1_ICACHE2_FAIL_INT_RAW_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - The raw bit of the interrupt of access fail that occurs in L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_fail_int_raw(
+        &mut self,
+    ) -> L1_ICACHE3_FAIL_INT_RAW_W<'_, L1_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L1_ICACHE3_FAIL_INT_RAW_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt of access fail that occurs in L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_raw(
+        &mut self,
+    ) -> L1_CACHE_FAIL_INT_RAW_W<'_, L1_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L1_CACHE_FAIL_INT_RAW_W::new(self, 4)
+    }
+}
+#[doc = "Cache Access Fail Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_acs_fail_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_FAIL_INT_RAW_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_FAIL_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_fail_int_raw::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_FAIL_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_acs_fail_int_raw::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_ACS_FAIL_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_ACS_FAIL_INT_RAW to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_FAIL_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l1_cache_acs_fail_int_st.rs
+++ b/esp32h2/src/cache/l1_cache_acs_fail_int_st.rs
@@ -1,0 +1,60 @@
+#[doc = "Register `L1_CACHE_ACS_FAIL_INT_ST` reader"]
+pub type R = crate::R<L1_CACHE_ACS_FAIL_INT_ST_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_INT_ST` reader - The bit indicates the interrupt status of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache."]
+pub type L1_ICACHE0_FAIL_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FAIL_INT_ST` reader - The bit indicates the interrupt status of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache."]
+pub type L1_ICACHE1_FAIL_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FAIL_INT_ST` reader - Reserved"]
+pub type L1_ICACHE2_FAIL_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FAIL_INT_ST` reader - Reserved"]
+pub type L1_ICACHE3_FAIL_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FAIL_INT_ST` reader - The bit indicates the interrupt status of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+pub type L1_CACHE_FAIL_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit indicates the interrupt status of access fail that occurs in L1-ICache0 due to cpu accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_int_st(&self) -> L1_ICACHE0_FAIL_INT_ST_R {
+        L1_ICACHE0_FAIL_INT_ST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit indicates the interrupt status of access fail that occurs in L1-ICache1 due to cpu accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_int_st(&self) -> L1_ICACHE1_FAIL_INT_ST_R {
+        L1_ICACHE1_FAIL_INT_ST_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_fail_int_st(&self) -> L1_ICACHE2_FAIL_INT_ST_R {
+        L1_ICACHE2_FAIL_INT_ST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_fail_int_st(&self) -> L1_ICACHE3_FAIL_INT_ST_R {
+        L1_ICACHE3_FAIL_INT_ST_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit indicates the interrupt status of access fail that occurs in L1-DCache due to cpu accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_int_st(&self) -> L1_CACHE_FAIL_INT_ST_R {
+        L1_CACHE_FAIL_INT_ST_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ACS_FAIL_INT_ST")
+            .field("l1_icache0_fail_int_st", &self.l1_icache0_fail_int_st())
+            .field("l1_icache1_fail_int_st", &self.l1_icache1_fail_int_st())
+            .field("l1_icache2_fail_int_st", &self.l1_icache2_fail_int_st())
+            .field("l1_icache3_fail_int_st", &self.l1_icache3_fail_int_st())
+            .field("l1_cache_fail_int_st", &self.l1_cache_fail_int_st())
+            .finish()
+    }
+}
+#[doc = "Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_acs_fail_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ACS_FAIL_INT_ST_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ACS_FAIL_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_acs_fail_int_st::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ACS_FAIL_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_ACS_FAIL_INT_ST to value 0"]
+impl crate::Resettable for L1_CACHE_ACS_FAIL_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l1_cache_atomic_conf.rs
+++ b/esp32h2/src/cache/l1_cache_atomic_conf.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_CACHE_ATOMIC_CONF` reader"]
+pub type R = crate::R<L1_CACHE_ATOMIC_CONF_SPEC>;
+#[doc = "Field `L1_CACHE_ATOMIC_EN` reader - The bit is used to enable atomic feature on L1-Cache when multiple cores access L1-Cache. 1: disable, 1: enable."]
+pub type L1_CACHE_ATOMIC_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable atomic feature on L1-Cache when multiple cores access L1-Cache. 1: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_atomic_en(&self) -> L1_CACHE_ATOMIC_EN_R {
+        L1_CACHE_ATOMIC_EN_R::new((self.bits & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_ATOMIC_CONF")
+            .field("l1_cache_atomic_en", &self.l1_cache_atomic_en())
+            .finish()
+    }
+}
+#[doc = "L1 Cache atomic feature configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_atomic_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_ATOMIC_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_ATOMIC_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_atomic_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_ATOMIC_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_ATOMIC_CONF to value 0"]
+impl crate::Resettable for L1_CACHE_ATOMIC_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_buf_clr_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_buf_clr_ctrl.rs
@@ -1,0 +1,77 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_BUF_CLR_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_BUF_CLR_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_ALD_BUF_CLR` reader - set this bit to clear autoload-buffer inside L1-ICache0. If this bit is active, autoload will not work in L1-ICache0. This bit should not be active when autoload works in L1-ICache0."]
+pub type L1_ICACHE0_ALD_BUF_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_ALD_BUF_CLR` reader - set this bit to clear autoload-buffer inside L1-ICache1. If this bit is active, autoload will not work in L1-ICache1. This bit should not be active when autoload works in L1-ICache1."]
+pub type L1_ICACHE1_ALD_BUF_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_ALD_BUF_CLR` reader - Reserved"]
+pub type L1_ICACHE2_ALD_BUF_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_ALD_BUF_CLR` reader - Reserved"]
+pub type L1_ICACHE3_ALD_BUF_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_ALD_BUF_CLR` reader - set this bit to clear autoload-buffer inside L1-Cache. If this bit is active, autoload will not work in L1-Cache. This bit should not be active when autoload works in L1-Cache."]
+pub type L1_CACHE_ALD_BUF_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_ALD_BUF_CLR` writer - set this bit to clear autoload-buffer inside L1-Cache. If this bit is active, autoload will not work in L1-Cache. This bit should not be active when autoload works in L1-Cache."]
+pub type L1_CACHE_ALD_BUF_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - set this bit to clear autoload-buffer inside L1-ICache0. If this bit is active, autoload will not work in L1-ICache0. This bit should not be active when autoload works in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_ald_buf_clr(&self) -> L1_ICACHE0_ALD_BUF_CLR_R {
+        L1_ICACHE0_ALD_BUF_CLR_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - set this bit to clear autoload-buffer inside L1-ICache1. If this bit is active, autoload will not work in L1-ICache1. This bit should not be active when autoload works in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_ald_buf_clr(&self) -> L1_ICACHE1_ALD_BUF_CLR_R {
+        L1_ICACHE1_ALD_BUF_CLR_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_ald_buf_clr(&self) -> L1_ICACHE2_ALD_BUF_CLR_R {
+        L1_ICACHE2_ALD_BUF_CLR_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_ald_buf_clr(&self) -> L1_ICACHE3_ALD_BUF_CLR_R {
+        L1_ICACHE3_ALD_BUF_CLR_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - set this bit to clear autoload-buffer inside L1-Cache. If this bit is active, autoload will not work in L1-Cache. This bit should not be active when autoload works in L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_ald_buf_clr(&self) -> L1_CACHE_ALD_BUF_CLR_R {
+        L1_CACHE_ALD_BUF_CLR_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_BUF_CLR_CTRL")
+            .field("l1_icache0_ald_buf_clr", &self.l1_icache0_ald_buf_clr())
+            .field("l1_icache1_ald_buf_clr", &self.l1_icache1_ald_buf_clr())
+            .field("l1_icache2_ald_buf_clr", &self.l1_icache2_ald_buf_clr())
+            .field("l1_icache3_ald_buf_clr", &self.l1_icache3_ald_buf_clr())
+            .field("l1_cache_ald_buf_clr", &self.l1_cache_ald_buf_clr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - set this bit to clear autoload-buffer inside L1-Cache. If this bit is active, autoload will not work in L1-Cache. This bit should not be active when autoload works in L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_ald_buf_clr(
+        &mut self,
+    ) -> L1_CACHE_ALD_BUF_CLR_W<'_, L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC> {
+        L1_CACHE_ALD_BUF_CLR_W::new(self, 4)
+    }
+}
+#[doc = "Cache Autoload buffer clear control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_buf_clr_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_buf_clr_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_buf_clr_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_buf_clr_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_BUF_CLR_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_ctrl.rs
@@ -1,0 +1,162 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L1-Cache. 1: enable, 0: disable."]
+pub type L1_CACHE_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_ENA` writer - The bit is used to enable and disable autoload operation on L1-Cache. 1: enable, 0: disable."]
+pub type L1_CACHE_AUTOLOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L1-Cache is finished or not. 0: not finished. 1: finished."]
+pub type L1_CACHE_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L1-Cache. 0: ascending. 1: descending."]
+pub type L1_CACHE_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_ORDER` writer - The bit is used to configure the direction of autoload operation on L1-Cache. 0: ascending. 1: descending."]
+pub type L1_CACHE_AUTOLOAD_ORDER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L1-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_CACHE_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_TRIGGER_MODE` writer - The field is used to configure trigger mode of autoload operation on L1-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_CACHE_AUTOLOAD_TRIGGER_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_ENA` writer - The bit is used to enable the first section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT0_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_ENA` writer - The bit is used to enable the second section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT1_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT2_ENA` reader - The bit is used to enable the third section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT2_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT3_ENA` reader - The bit is used to enable the fourth section for autoload operation on L1-Cache."]
+pub type L1_CACHE_AUTOLOAD_SCT3_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_AUTOLOAD_RGID` reader - The bit is used to set the gid of l1 cache autoload."]
+pub type L1_CACHE_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-Cache. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_ena(&self) -> L1_CACHE_AUTOLOAD_ENA_R {
+        L1_CACHE_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L1-Cache is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_done(&self) -> L1_CACHE_AUTOLOAD_DONE_R {
+        L1_CACHE_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-Cache. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_order(&self) -> L1_CACHE_AUTOLOAD_ORDER_R {
+        L1_CACHE_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_trigger_mode(&self) -> L1_CACHE_AUTOLOAD_TRIGGER_MODE_R {
+        L1_CACHE_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_ena(&self) -> L1_CACHE_AUTOLOAD_SCT0_ENA_R {
+        L1_CACHE_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_ena(&self) -> L1_CACHE_AUTOLOAD_SCT1_ENA_R {
+        L1_CACHE_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The bit is used to enable the third section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct2_ena(&self) -> L1_CACHE_AUTOLOAD_SCT2_ENA_R {
+        L1_CACHE_AUTOLOAD_SCT2_ENA_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The bit is used to enable the fourth section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct3_ena(&self) -> L1_CACHE_AUTOLOAD_SCT3_ENA_R {
+        L1_CACHE_AUTOLOAD_SCT3_ENA_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bits 12:15 - The bit is used to set the gid of l1 cache autoload."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_rgid(&self) -> L1_CACHE_AUTOLOAD_RGID_R {
+        L1_CACHE_AUTOLOAD_RGID_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_CTRL")
+            .field("l1_cache_autoload_ena", &self.l1_cache_autoload_ena())
+            .field("l1_cache_autoload_done", &self.l1_cache_autoload_done())
+            .field("l1_cache_autoload_order", &self.l1_cache_autoload_order())
+            .field(
+                "l1_cache_autoload_trigger_mode",
+                &self.l1_cache_autoload_trigger_mode(),
+            )
+            .field(
+                "l1_cache_autoload_sct0_ena",
+                &self.l1_cache_autoload_sct0_ena(),
+            )
+            .field(
+                "l1_cache_autoload_sct1_ena",
+                &self.l1_cache_autoload_sct1_ena(),
+            )
+            .field(
+                "l1_cache_autoload_sct2_ena",
+                &self.l1_cache_autoload_sct2_ena(),
+            )
+            .field(
+                "l1_cache_autoload_sct3_ena",
+                &self.l1_cache_autoload_sct3_ena(),
+            )
+            .field("l1_cache_autoload_rgid", &self.l1_cache_autoload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-Cache. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_ena(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_ENA_W<'_, L1_CACHE_AUTOLOAD_CTRL_SPEC> {
+        L1_CACHE_AUTOLOAD_ENA_W::new(self, 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-Cache. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_order(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_ORDER_W<'_, L1_CACHE_AUTOLOAD_CTRL_SPEC> {
+        L1_CACHE_AUTOLOAD_ORDER_W::new(self, 2)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_trigger_mode(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_TRIGGER_MODE_W<'_, L1_CACHE_AUTOLOAD_CTRL_SPEC> {
+        L1_CACHE_AUTOLOAD_TRIGGER_MODE_W::new(self, 3)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_ena(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT0_ENA_W<'_, L1_CACHE_AUTOLOAD_CTRL_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT0_ENA_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_ena(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT1_ENA_W<'_, L1_CACHE_AUTOLOAD_CTRL_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT1_ENA_W::new(self, 9)
+    }
+}
+#[doc = "L1 Cache autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_cache_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct0_addr.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT0_ADDR` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_SIZE and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_ADDR` writer - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_SIZE and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT0_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_SIZE and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_addr(&self) -> L1_CACHE_AUTOLOAD_SCT0_ADDR_R {
+        L1_CACHE_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l1_cache_autoload_sct0_addr",
+                &self.l1_cache_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_SIZE and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_addr(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT0_ADDR_W<'_, L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT0_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct0_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct0_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_sct0_addr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct0_size.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT0_SIZE` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_ADDR and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT0_SIZE` writer - Those bits are used to configure the size of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_ADDR and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT0_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 28, u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_ADDR and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_size(&self) -> L1_CACHE_AUTOLOAD_SCT0_SIZE_R {
+        L1_CACHE_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l1_cache_autoload_sct0_size",
+                &self.l1_cache_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT0_ADDR and L1_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct0_size(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT0_SIZE_W<'_, L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT0_SIZE_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct0_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct0_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_sct0_size::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct1_addr.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT1_ADDR` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_SIZE and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_ADDR` writer - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_SIZE and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT1_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_SIZE and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_addr(&self) -> L1_CACHE_AUTOLOAD_SCT1_ADDR_R {
+        L1_CACHE_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l1_cache_autoload_sct1_addr",
+                &self.l1_cache_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_SIZE and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_addr(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT1_ADDR_W<'_, L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT1_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct1_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct1_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_sct1_addr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct1_size.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT1_SIZE` writer"]
+pub type W = crate::W<L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_SIZE` reader - Those bits are used to configure the size of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_ADDR and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT1_SIZE` writer - Those bits are used to configure the size of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_ADDR and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT1_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 28, u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_ADDR and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_size(&self) -> L1_CACHE_AUTOLOAD_SCT1_SIZE_R {
+        L1_CACHE_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l1_cache_autoload_sct1_size",
+                &self.l1_cache_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT1_ADDR and L1_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct1_size(
+        &mut self,
+    ) -> L1_CACHE_AUTOLOAD_SCT1_SIZE_W<'_, L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC> {
+        L1_CACHE_AUTOLOAD_SCT1_SIZE_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct1_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_autoload_sct1_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_autoload_sct1_size::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct2_addr.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct2_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT2_ADDR` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT2_ADDR` reader - Those bits are used to configure the start virtual address of the third section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT2_SIZE and L1_CACHE_AUTOLOAD_SCT2_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT2_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the third section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT2_SIZE and L1_CACHE_AUTOLOAD_SCT2_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct2_addr(&self) -> L1_CACHE_AUTOLOAD_SCT2_ADDR_R {
+        L1_CACHE_AUTOLOAD_SCT2_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT2_ADDR")
+            .field(
+                "l1_cache_autoload_sct2_addr",
+                &self.l1_cache_autoload_sct2_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 Cache autoload section 2 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct2_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct2_addr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT2_ADDR to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct2_size.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct2_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT2_SIZE` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT2_SIZE` reader - Those bits are used to configure the size of the third section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT2_ADDR and L1_CACHE_AUTOLOAD_SCT2_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT2_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the third section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT2_ADDR and L1_CACHE_AUTOLOAD_SCT2_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct2_size(&self) -> L1_CACHE_AUTOLOAD_SCT2_SIZE_R {
+        L1_CACHE_AUTOLOAD_SCT2_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT2_SIZE")
+            .field(
+                "l1_cache_autoload_sct2_size",
+                &self.l1_cache_autoload_sct2_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 Cache autoload section 2 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct2_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct2_size::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT2_SIZE to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct3_addr.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct3_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT3_ADDR` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT3_ADDR` reader - Those bits are used to configure the start virtual address of the fourth section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT3_SIZE and L1_CACHE_AUTOLOAD_SCT3_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT3_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the fourth section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT3_SIZE and L1_CACHE_AUTOLOAD_SCT3_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct3_addr(&self) -> L1_CACHE_AUTOLOAD_SCT3_ADDR_R {
+        L1_CACHE_AUTOLOAD_SCT3_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT3_ADDR")
+            .field(
+                "l1_cache_autoload_sct3_addr",
+                &self.l1_cache_autoload_sct3_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct3_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct3_addr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT3_ADDR to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_autoload_sct3_size.rs
+++ b/esp32h2/src/cache/l1_cache_autoload_sct3_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_CACHE_AUTOLOAD_SCT3_SIZE` reader"]
+pub type R = crate::R<L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_AUTOLOAD_SCT3_SIZE` reader - Those bits are used to configure the size of the fourth section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT3_ADDR and L1_CACHE_AUTOLOAD_SCT3_ENA."]
+pub type L1_CACHE_AUTOLOAD_SCT3_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the fourth section for autoload operation on L1-Cache. Note that it should be used together with L1_CACHE_AUTOLOAD_SCT3_ADDR and L1_CACHE_AUTOLOAD_SCT3_ENA."]
+    #[inline(always)]
+    pub fn l1_cache_autoload_sct3_size(&self) -> L1_CACHE_AUTOLOAD_SCT3_SIZE_R {
+        L1_CACHE_AUTOLOAD_SCT3_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_AUTOLOAD_SCT3_SIZE")
+            .field(
+                "l1_cache_autoload_sct3_size",
+                &self.l1_cache_autoload_sct3_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_autoload_sct3_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC;
+impl crate::RegisterSpec for L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_autoload_sct3_size::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_AUTOLOAD_SCT3_SIZE to value 0"]
+impl crate::Resettable for L1_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_cache_blocksize_conf.rs
+++ b/esp32h2/src/cache/l1_cache_blocksize_conf.rs
@@ -1,0 +1,70 @@
+#[doc = "Register `L1_CACHE_BLOCKSIZE_CONF` reader"]
+pub type R = crate::R<L1_CACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_8` reader - The field is used to configureblocksize of L1-DCache as 8 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_8_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_16` reader - The field is used to configureblocksize of L1-DCache as 16 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_16_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_32` reader - The field is used to configureblocksize of L1-DCache as 32 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_32_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_64` reader - The field is used to configureblocksize of L1-DCache as 64 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_64_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_128` reader - The field is used to configureblocksize of L1-DCache as 128 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_128_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_BLOCKSIZE_256` reader - The field is used to configureblocksize of L1-DCache as 256 bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_BLOCKSIZE_256_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configureblocksize of L1-DCache as 8 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_8(&self) -> L1_CACHE_BLOCKSIZE_8_R {
+        L1_CACHE_BLOCKSIZE_8_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configureblocksize of L1-DCache as 16 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_16(&self) -> L1_CACHE_BLOCKSIZE_16_R {
+        L1_CACHE_BLOCKSIZE_16_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configureblocksize of L1-DCache as 32 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_32(&self) -> L1_CACHE_BLOCKSIZE_32_R {
+        L1_CACHE_BLOCKSIZE_32_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configureblocksize of L1-DCache as 64 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_64(&self) -> L1_CACHE_BLOCKSIZE_64_R {
+        L1_CACHE_BLOCKSIZE_64_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configureblocksize of L1-DCache as 128 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_128(&self) -> L1_CACHE_BLOCKSIZE_128_R {
+        L1_CACHE_BLOCKSIZE_128_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configureblocksize of L1-DCache as 256 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_blocksize_256(&self) -> L1_CACHE_BLOCKSIZE_256_R {
+        L1_CACHE_BLOCKSIZE_256_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_BLOCKSIZE_CONF")
+            .field("l1_cache_blocksize_8", &self.l1_cache_blocksize_8())
+            .field("l1_cache_blocksize_16", &self.l1_cache_blocksize_16())
+            .field("l1_cache_blocksize_32", &self.l1_cache_blocksize_32())
+            .field("l1_cache_blocksize_64", &self.l1_cache_blocksize_64())
+            .field("l1_cache_blocksize_128", &self.l1_cache_blocksize_128())
+            .field("l1_cache_blocksize_256", &self.l1_cache_blocksize_256())
+            .finish()
+    }
+}
+#[doc = "L1 data Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_blocksize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_BLOCKSIZE_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_BLOCKSIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_blocksize_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_BLOCKSIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_BLOCKSIZE_CONF to value 0x04"]
+impl crate::Resettable for L1_CACHE_BLOCKSIZE_CONF_SPEC {
+    const RESET_VALUE: u32 = 0x04;
+}

--- a/esp32h2/src/cache/l1_cache_cachesize_conf.rs
+++ b/esp32h2/src/cache/l1_cache_cachesize_conf.rs
@@ -1,0 +1,126 @@
+#[doc = "Register `L1_CACHE_CACHESIZE_CONF` reader"]
+pub type R = crate::R<L1_CACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "Field `L1_CACHE_CACHESIZE_1K` reader - The field is used to configure cachesize of L1-Cache as 1k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_1K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_2K` reader - The field is used to configure cachesize of L1-Cache as 2k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_2K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_4K` reader - The field is used to configure cachesize of L1-Cache as 4k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_4K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_8K` reader - The field is used to configure cachesize of L1-Cache as 8k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_8K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_16K` reader - The field is used to configure cachesize of L1-Cache as 16k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_16K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_32K` reader - The field is used to configure cachesize of L1-Cache as 32k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_32K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_64K` reader - The field is used to configure cachesize of L1-Cache as 64k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_64K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_128K` reader - The field is used to configure cachesize of L1-Cache as 128k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_128K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_256K` reader - The field is used to configure cachesize of L1-Cache as 256k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_256K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_512K` reader - The field is used to configure cachesize of L1-Cache as 512k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_512K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_1024K` reader - The field is used to configure cachesize of L1-Cache as 1024k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_1024K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_2048K` reader - The field is used to configure cachesize of L1-Cache as 2048k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_2048K_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_CACHESIZE_4096K` reader - The field is used to configure cachesize of L1-Cache as 4096k bytes. This field and all other fields within this register is onehot."]
+pub type L1_CACHE_CACHESIZE_4096K_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configure cachesize of L1-Cache as 1k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_1k(&self) -> L1_CACHE_CACHESIZE_1K_R {
+        L1_CACHE_CACHESIZE_1K_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configure cachesize of L1-Cache as 2k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_2k(&self) -> L1_CACHE_CACHESIZE_2K_R {
+        L1_CACHE_CACHESIZE_2K_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configure cachesize of L1-Cache as 4k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_4k(&self) -> L1_CACHE_CACHESIZE_4K_R {
+        L1_CACHE_CACHESIZE_4K_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configure cachesize of L1-Cache as 8k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_8k(&self) -> L1_CACHE_CACHESIZE_8K_R {
+        L1_CACHE_CACHESIZE_8K_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configure cachesize of L1-Cache as 16k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_16k(&self) -> L1_CACHE_CACHESIZE_16K_R {
+        L1_CACHE_CACHESIZE_16K_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configure cachesize of L1-Cache as 32k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_32k(&self) -> L1_CACHE_CACHESIZE_32K_R {
+        L1_CACHE_CACHESIZE_32K_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The field is used to configure cachesize of L1-Cache as 64k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_64k(&self) -> L1_CACHE_CACHESIZE_64K_R {
+        L1_CACHE_CACHESIZE_64K_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The field is used to configure cachesize of L1-Cache as 128k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_128k(&self) -> L1_CACHE_CACHESIZE_128K_R {
+        L1_CACHE_CACHESIZE_128K_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The field is used to configure cachesize of L1-Cache as 256k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_256k(&self) -> L1_CACHE_CACHESIZE_256K_R {
+        L1_CACHE_CACHESIZE_256K_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The field is used to configure cachesize of L1-Cache as 512k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_512k(&self) -> L1_CACHE_CACHESIZE_512K_R {
+        L1_CACHE_CACHESIZE_512K_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The field is used to configure cachesize of L1-Cache as 1024k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_1024k(&self) -> L1_CACHE_CACHESIZE_1024K_R {
+        L1_CACHE_CACHESIZE_1024K_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The field is used to configure cachesize of L1-Cache as 2048k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_2048k(&self) -> L1_CACHE_CACHESIZE_2048K_R {
+        L1_CACHE_CACHESIZE_2048K_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The field is used to configure cachesize of L1-Cache as 4096k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_cache_cachesize_4096k(&self) -> L1_CACHE_CACHESIZE_4096K_R {
+        L1_CACHE_CACHESIZE_4096K_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_CACHESIZE_CONF")
+            .field("l1_cache_cachesize_1k", &self.l1_cache_cachesize_1k())
+            .field("l1_cache_cachesize_2k", &self.l1_cache_cachesize_2k())
+            .field("l1_cache_cachesize_4k", &self.l1_cache_cachesize_4k())
+            .field("l1_cache_cachesize_8k", &self.l1_cache_cachesize_8k())
+            .field("l1_cache_cachesize_16k", &self.l1_cache_cachesize_16k())
+            .field("l1_cache_cachesize_32k", &self.l1_cache_cachesize_32k())
+            .field("l1_cache_cachesize_64k", &self.l1_cache_cachesize_64k())
+            .field("l1_cache_cachesize_128k", &self.l1_cache_cachesize_128k())
+            .field("l1_cache_cachesize_256k", &self.l1_cache_cachesize_256k())
+            .field("l1_cache_cachesize_512k", &self.l1_cache_cachesize_512k())
+            .field("l1_cache_cachesize_1024k", &self.l1_cache_cachesize_1024k())
+            .field("l1_cache_cachesize_2048k", &self.l1_cache_cachesize_2048k())
+            .field("l1_cache_cachesize_4096k", &self.l1_cache_cachesize_4096k())
+            .finish()
+    }
+}
+#[doc = "L1 data Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_cachesize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_CACHESIZE_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_CACHESIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_cachesize_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_CACHESIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_CACHESIZE_CONF to value 0x20"]
+impl crate::Resettable for L1_CACHE_CACHESIZE_CONF_SPEC {
+    const RESET_VALUE: u32 = 0x20;
+}

--- a/esp32h2/src/cache/l1_cache_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_ctrl.rs
@@ -1,0 +1,97 @@
+#[doc = "Register `L1_CACHE_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_CTRL_SPEC>;
+#[doc = "Field `L1_CACHE_SHUT_BUS0` reader - The bit is used to disable core0 dbus access L1-Cache, 0: enable, 1: disable"]
+pub type L1_CACHE_SHUT_BUS0_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SHUT_BUS0` writer - The bit is used to disable core0 dbus access L1-Cache, 0: enable, 1: disable"]
+pub type L1_CACHE_SHUT_BUS0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_SHUT_BUS1` reader - The bit is used to disable core1 dbus access L1-Cache, 0: enable, 1: disable"]
+pub type L1_CACHE_SHUT_BUS1_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SHUT_BUS1` writer - The bit is used to disable core1 dbus access L1-Cache, 0: enable, 1: disable"]
+pub type L1_CACHE_SHUT_BUS1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_SHUT_DBUS2` reader - Reserved"]
+pub type L1_CACHE_SHUT_DBUS2_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SHUT_DBUS3` reader - Reserved"]
+pub type L1_CACHE_SHUT_DBUS3_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SHUT_DMA` reader - The bit is used to disable DMA access L1-Cache, 0: enable, 1: disable"]
+pub type L1_CACHE_SHUT_DMA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_UNDEF_OP` reader - Reserved"]
+pub type L1_CACHE_UNDEF_OP_R = crate::FieldReader;
+#[doc = "Field `L1_CACHE_UNDEF_OP` writer - Reserved"]
+pub type L1_CACHE_UNDEF_OP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to disable core0 dbus access L1-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_cache_shut_bus0(&self) -> L1_CACHE_SHUT_BUS0_R {
+        L1_CACHE_SHUT_BUS0_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to disable core1 dbus access L1-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_cache_shut_bus1(&self) -> L1_CACHE_SHUT_BUS1_R {
+        L1_CACHE_SHUT_BUS1_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_cache_shut_dbus2(&self) -> L1_CACHE_SHUT_DBUS2_R {
+        L1_CACHE_SHUT_DBUS2_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_cache_shut_dbus3(&self) -> L1_CACHE_SHUT_DBUS3_R {
+        L1_CACHE_SHUT_DBUS3_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to disable DMA access L1-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_cache_shut_dma(&self) -> L1_CACHE_SHUT_DMA_R {
+        L1_CACHE_SHUT_DMA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bits 8:11 - Reserved"]
+    #[inline(always)]
+    pub fn l1_cache_undef_op(&self) -> L1_CACHE_UNDEF_OP_R {
+        L1_CACHE_UNDEF_OP_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_CTRL")
+            .field("l1_cache_shut_bus0", &self.l1_cache_shut_bus0())
+            .field("l1_cache_shut_bus1", &self.l1_cache_shut_bus1())
+            .field("l1_cache_shut_dbus2", &self.l1_cache_shut_dbus2())
+            .field("l1_cache_shut_dbus3", &self.l1_cache_shut_dbus3())
+            .field("l1_cache_shut_dma", &self.l1_cache_shut_dma())
+            .field("l1_cache_undef_op", &self.l1_cache_undef_op())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to disable core0 dbus access L1-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_cache_shut_bus0(&mut self) -> L1_CACHE_SHUT_BUS0_W<'_, L1_CACHE_CTRL_SPEC> {
+        L1_CACHE_SHUT_BUS0_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The bit is used to disable core1 dbus access L1-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_cache_shut_bus1(&mut self) -> L1_CACHE_SHUT_BUS1_W<'_, L1_CACHE_CTRL_SPEC> {
+        L1_CACHE_SHUT_BUS1_W::new(self, 1)
+    }
+    #[doc = "Bits 8:11 - Reserved"]
+    #[inline(always)]
+    pub fn l1_cache_undef_op(&mut self) -> L1_CACHE_UNDEF_OP_W<'_, L1_CACHE_CTRL_SPEC> {
+        L1_CACHE_UNDEF_OP_W::new(self, 8)
+    }
+}
+#[doc = "L1 data Cache(L1-Cache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_data_mem_acs_conf.rs
+++ b/esp32h2/src/cache/l1_cache_data_mem_acs_conf.rs
@@ -1,0 +1,152 @@
+#[doc = "Register `L1_CACHE_DATA_MEM_ACS_CONF` reader"]
+pub type R = crate::R<L1_CACHE_DATA_MEM_ACS_CONF_SPEC>;
+#[doc = "Register `L1_CACHE_DATA_MEM_ACS_CONF` writer"]
+pub type W = crate::W<L1_CACHE_DATA_MEM_ACS_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE0_DATA_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-ICache0 data memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE0_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_DATA_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-ICache0 data memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE0_DATA_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_DATA_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-ICache1 data memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE1_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_DATA_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-ICache1 data memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE1_DATA_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_DATA_MEM_RD_EN` reader - Reserved"]
+pub type L1_ICACHE2_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_DATA_MEM_WR_EN` reader - Reserved"]
+pub type L1_ICACHE2_DATA_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_DATA_MEM_RD_EN` reader - Reserved"]
+pub type L1_ICACHE3_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_DATA_MEM_WR_EN` reader - Reserved"]
+pub type L1_ICACHE3_DATA_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-Cache data memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_RD_EN` writer - The bit is used to enable config-bus read L1-Cache data memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_DATA_MEM_RD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_DATA_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-Cache data memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_DATA_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_WR_EN` writer - The bit is used to enable config-bus write L1-Cache data memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_DATA_MEM_WR_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable config-bus read L1-ICache0 data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache0_data_mem_rd_en(&self) -> L1_ICACHE0_DATA_MEM_RD_EN_R {
+        L1_ICACHE0_DATA_MEM_RD_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable config-bus write L1-ICache0 data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache0_data_mem_wr_en(&self) -> L1_ICACHE0_DATA_MEM_WR_EN_R {
+        L1_ICACHE0_DATA_MEM_WR_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable config-bus read L1-ICache1 data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache1_data_mem_rd_en(&self) -> L1_ICACHE1_DATA_MEM_RD_EN_R {
+        L1_ICACHE1_DATA_MEM_RD_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to enable config-bus write L1-ICache1 data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache1_data_mem_wr_en(&self) -> L1_ICACHE1_DATA_MEM_WR_EN_R {
+        L1_ICACHE1_DATA_MEM_WR_EN_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_data_mem_rd_en(&self) -> L1_ICACHE2_DATA_MEM_RD_EN_R {
+        L1_ICACHE2_DATA_MEM_RD_EN_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_data_mem_wr_en(&self) -> L1_ICACHE2_DATA_MEM_WR_EN_R {
+        L1_ICACHE2_DATA_MEM_WR_EN_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_data_mem_rd_en(&self) -> L1_ICACHE3_DATA_MEM_RD_EN_R {
+        L1_ICACHE3_DATA_MEM_RD_EN_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_data_mem_wr_en(&self) -> L1_ICACHE3_DATA_MEM_WR_EN_R {
+        L1_ICACHE3_DATA_MEM_WR_EN_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to enable config-bus read L1-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_rd_en(&self) -> L1_CACHE_DATA_MEM_RD_EN_R {
+        L1_CACHE_DATA_MEM_RD_EN_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to enable config-bus write L1-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_wr_en(&self) -> L1_CACHE_DATA_MEM_WR_EN_R {
+        L1_CACHE_DATA_MEM_WR_EN_R::new(((self.bits >> 17) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_DATA_MEM_ACS_CONF")
+            .field(
+                "l1_icache0_data_mem_rd_en",
+                &self.l1_icache0_data_mem_rd_en(),
+            )
+            .field(
+                "l1_icache0_data_mem_wr_en",
+                &self.l1_icache0_data_mem_wr_en(),
+            )
+            .field(
+                "l1_icache1_data_mem_rd_en",
+                &self.l1_icache1_data_mem_rd_en(),
+            )
+            .field(
+                "l1_icache1_data_mem_wr_en",
+                &self.l1_icache1_data_mem_wr_en(),
+            )
+            .field(
+                "l1_icache2_data_mem_rd_en",
+                &self.l1_icache2_data_mem_rd_en(),
+            )
+            .field(
+                "l1_icache2_data_mem_wr_en",
+                &self.l1_icache2_data_mem_wr_en(),
+            )
+            .field(
+                "l1_icache3_data_mem_rd_en",
+                &self.l1_icache3_data_mem_rd_en(),
+            )
+            .field(
+                "l1_icache3_data_mem_wr_en",
+                &self.l1_icache3_data_mem_wr_en(),
+            )
+            .field("l1_cache_data_mem_rd_en", &self.l1_cache_data_mem_rd_en())
+            .field("l1_cache_data_mem_wr_en", &self.l1_cache_data_mem_wr_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 16 - The bit is used to enable config-bus read L1-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_rd_en(
+        &mut self,
+    ) -> L1_CACHE_DATA_MEM_RD_EN_W<'_, L1_CACHE_DATA_MEM_ACS_CONF_SPEC> {
+        L1_CACHE_DATA_MEM_RD_EN_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - The bit is used to enable config-bus write L1-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_wr_en(
+        &mut self,
+    ) -> L1_CACHE_DATA_MEM_WR_EN_W<'_, L1_CACHE_DATA_MEM_ACS_CONF_SPEC> {
+        L1_CACHE_DATA_MEM_WR_EN_W::new(self, 17)
+    }
+}
+#[doc = "Cache data memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_data_mem_acs_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_data_mem_acs_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_DATA_MEM_ACS_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_DATA_MEM_ACS_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_data_mem_acs_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_DATA_MEM_ACS_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_data_mem_acs_conf::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_DATA_MEM_ACS_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_DATA_MEM_ACS_CONF to value 0x0003_3333"]
+impl crate::Resettable for L1_CACHE_DATA_MEM_ACS_CONF_SPEC {
+    const RESET_VALUE: u32 = 0x0003_3333;
+}

--- a/esp32h2/src/cache/l1_cache_data_mem_power_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_data_mem_power_ctrl.rs
@@ -1,0 +1,222 @@
+#[doc = "Register `L1_CACHE_DATA_MEM_POWER_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_DATA_MEM_POWER_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_DATA_MEM_POWER_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_DATA_MEM_POWER_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_DATA_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-ICache0 data memory. 1: close gating, 0: open clock gating."]
+pub type L1_ICACHE0_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_DATA_MEM_FORCE_PD` reader - The bit is used to power L1-ICache0 data memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_ICACHE0_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_DATA_MEM_FORCE_PU` reader - The bit is used to power L1-ICache0 data memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_ICACHE0_DATA_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_DATA_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-ICache1 data memory. 1: close gating, 0: open clock gating."]
+pub type L1_ICACHE1_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_DATA_MEM_FORCE_PD` reader - The bit is used to power L1-ICache1 data memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_ICACHE1_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_DATA_MEM_FORCE_PU` reader - The bit is used to power L1-ICache1 data memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_ICACHE1_DATA_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_DATA_MEM_FORCE_ON` reader - Reserved"]
+pub type L1_ICACHE2_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_DATA_MEM_FORCE_PD` reader - Reserved"]
+pub type L1_ICACHE2_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_DATA_MEM_FORCE_PU` reader - Reserved"]
+pub type L1_ICACHE2_DATA_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_DATA_MEM_FORCE_ON` reader - Reserved"]
+pub type L1_ICACHE3_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_DATA_MEM_FORCE_PD` reader - Reserved"]
+pub type L1_ICACHE3_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_DATA_MEM_FORCE_PU` reader - Reserved"]
+pub type L1_ICACHE3_DATA_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-Cache data memory. 1: close gating, 0: open clock gating."]
+pub type L1_CACHE_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_ON` writer - The bit is used to close clock gating of L1-Cache data memory. 1: close gating, 0: open clock gating."]
+pub type L1_CACHE_DATA_MEM_FORCE_ON_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_PD` reader - The bit is used to power L1-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_CACHE_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_PD` writer - The bit is used to power L1-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_CACHE_DATA_MEM_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_PU` reader - The bit is used to power L1-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_CACHE_DATA_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_DATA_MEM_FORCE_PU` writer - The bit is used to power L1-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_CACHE_DATA_MEM_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to close clock gating of L1-ICache0 data memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_icache0_data_mem_force_on(&self) -> L1_ICACHE0_DATA_MEM_FORCE_ON_R {
+        L1_ICACHE0_DATA_MEM_FORCE_ON_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to power L1-ICache0 data memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_icache0_data_mem_force_pd(&self) -> L1_ICACHE0_DATA_MEM_FORCE_PD_R {
+        L1_ICACHE0_DATA_MEM_FORCE_PD_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to power L1-ICache0 data memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_icache0_data_mem_force_pu(&self) -> L1_ICACHE0_DATA_MEM_FORCE_PU_R {
+        L1_ICACHE0_DATA_MEM_FORCE_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to close clock gating of L1-ICache1 data memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_icache1_data_mem_force_on(&self) -> L1_ICACHE1_DATA_MEM_FORCE_ON_R {
+        L1_ICACHE1_DATA_MEM_FORCE_ON_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to power L1-ICache1 data memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_icache1_data_mem_force_pd(&self) -> L1_ICACHE1_DATA_MEM_FORCE_PD_R {
+        L1_ICACHE1_DATA_MEM_FORCE_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The bit is used to power L1-ICache1 data memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_icache1_data_mem_force_pu(&self) -> L1_ICACHE1_DATA_MEM_FORCE_PU_R {
+        L1_ICACHE1_DATA_MEM_FORCE_PU_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_data_mem_force_on(&self) -> L1_ICACHE2_DATA_MEM_FORCE_ON_R {
+        L1_ICACHE2_DATA_MEM_FORCE_ON_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_data_mem_force_pd(&self) -> L1_ICACHE2_DATA_MEM_FORCE_PD_R {
+        L1_ICACHE2_DATA_MEM_FORCE_PD_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_data_mem_force_pu(&self) -> L1_ICACHE2_DATA_MEM_FORCE_PU_R {
+        L1_ICACHE2_DATA_MEM_FORCE_PU_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_data_mem_force_on(&self) -> L1_ICACHE3_DATA_MEM_FORCE_ON_R {
+        L1_ICACHE3_DATA_MEM_FORCE_ON_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_data_mem_force_pd(&self) -> L1_ICACHE3_DATA_MEM_FORCE_PD_R {
+        L1_ICACHE3_DATA_MEM_FORCE_PD_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_data_mem_force_pu(&self) -> L1_ICACHE3_DATA_MEM_FORCE_PU_R {
+        L1_ICACHE3_DATA_MEM_FORCE_PU_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to close clock gating of L1-Cache data memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_on(&self) -> L1_CACHE_DATA_MEM_FORCE_ON_R {
+        L1_CACHE_DATA_MEM_FORCE_ON_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to power L1-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_pd(&self) -> L1_CACHE_DATA_MEM_FORCE_PD_R {
+        L1_CACHE_DATA_MEM_FORCE_PD_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - The bit is used to power L1-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_pu(&self) -> L1_CACHE_DATA_MEM_FORCE_PU_R {
+        L1_CACHE_DATA_MEM_FORCE_PU_R::new(((self.bits >> 18) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_DATA_MEM_POWER_CTRL")
+            .field(
+                "l1_icache0_data_mem_force_on",
+                &self.l1_icache0_data_mem_force_on(),
+            )
+            .field(
+                "l1_icache0_data_mem_force_pd",
+                &self.l1_icache0_data_mem_force_pd(),
+            )
+            .field(
+                "l1_icache0_data_mem_force_pu",
+                &self.l1_icache0_data_mem_force_pu(),
+            )
+            .field(
+                "l1_icache1_data_mem_force_on",
+                &self.l1_icache1_data_mem_force_on(),
+            )
+            .field(
+                "l1_icache1_data_mem_force_pd",
+                &self.l1_icache1_data_mem_force_pd(),
+            )
+            .field(
+                "l1_icache1_data_mem_force_pu",
+                &self.l1_icache1_data_mem_force_pu(),
+            )
+            .field(
+                "l1_icache2_data_mem_force_on",
+                &self.l1_icache2_data_mem_force_on(),
+            )
+            .field(
+                "l1_icache2_data_mem_force_pd",
+                &self.l1_icache2_data_mem_force_pd(),
+            )
+            .field(
+                "l1_icache2_data_mem_force_pu",
+                &self.l1_icache2_data_mem_force_pu(),
+            )
+            .field(
+                "l1_icache3_data_mem_force_on",
+                &self.l1_icache3_data_mem_force_on(),
+            )
+            .field(
+                "l1_icache3_data_mem_force_pd",
+                &self.l1_icache3_data_mem_force_pd(),
+            )
+            .field(
+                "l1_icache3_data_mem_force_pu",
+                &self.l1_icache3_data_mem_force_pu(),
+            )
+            .field(
+                "l1_cache_data_mem_force_on",
+                &self.l1_cache_data_mem_force_on(),
+            )
+            .field(
+                "l1_cache_data_mem_force_pd",
+                &self.l1_cache_data_mem_force_pd(),
+            )
+            .field(
+                "l1_cache_data_mem_force_pu",
+                &self.l1_cache_data_mem_force_pu(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 16 - The bit is used to close clock gating of L1-Cache data memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_on(
+        &mut self,
+    ) -> L1_CACHE_DATA_MEM_FORCE_ON_W<'_, L1_CACHE_DATA_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_DATA_MEM_FORCE_ON_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - The bit is used to power L1-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_pd(
+        &mut self,
+    ) -> L1_CACHE_DATA_MEM_FORCE_PD_W<'_, L1_CACHE_DATA_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_DATA_MEM_FORCE_PD_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - The bit is used to power L1-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_cache_data_mem_force_pu(
+        &mut self,
+    ) -> L1_CACHE_DATA_MEM_FORCE_PU_W<'_, L1_CACHE_DATA_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_DATA_MEM_FORCE_PU_W::new(self, 18)
+    }
+}
+#[doc = "Cache data memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_data_mem_power_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_data_mem_power_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_DATA_MEM_POWER_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_DATA_MEM_POWER_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_data_mem_power_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_DATA_MEM_POWER_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_data_mem_power_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_DATA_MEM_POWER_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_DATA_MEM_POWER_CTRL to value 0x0005_5555"]
+impl crate::Resettable for L1_CACHE_DATA_MEM_POWER_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x0005_5555;
+}

--- a/esp32h2/src/cache/l1_cache_debug_bus.rs
+++ b/esp32h2/src/cache/l1_cache_debug_bus.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `L1_CACHE_DEBUG_BUS` reader"]
+pub type R = crate::R<L1_CACHE_DEBUG_BUS_SPEC>;
+#[doc = "Register `L1_CACHE_DEBUG_BUS` writer"]
+pub type W = crate::W<L1_CACHE_DEBUG_BUS_SPEC>;
+#[doc = "Field `L1_CACHE_DEBUG_BUS` reader - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+pub type L1_CACHE_DEBUG_BUS_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_DEBUG_BUS` writer - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+pub type L1_CACHE_DEBUG_BUS_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+    #[inline(always)]
+    pub fn l1_cache_debug_bus(&self) -> L1_CACHE_DEBUG_BUS_R {
+        L1_CACHE_DEBUG_BUS_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_DEBUG_BUS")
+            .field("l1_cache_debug_bus", &self.l1_cache_debug_bus())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+    #[inline(always)]
+    pub fn l1_cache_debug_bus(&mut self) -> L1_CACHE_DEBUG_BUS_W<'_, L1_CACHE_DEBUG_BUS_SPEC> {
+        L1_CACHE_DEBUG_BUS_W::new(self, 0)
+    }
+}
+#[doc = "Cache Tag/data memory content register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_debug_bus::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_debug_bus::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_DEBUG_BUS_SPEC;
+impl crate::RegisterSpec for L1_CACHE_DEBUG_BUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_debug_bus::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_DEBUG_BUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_debug_bus::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_DEBUG_BUS_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_DEBUG_BUS to value 0x0254"]
+impl crate::Resettable for L1_CACHE_DEBUG_BUS_SPEC {
+    const RESET_VALUE: u32 = 0x0254;
+}

--- a/esp32h2/src/cache/l1_cache_freeze_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_freeze_ctrl.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `L1_CACHE_FREEZE_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_FREEZE_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_FREEZE_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_FREEZE_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_FREEZE_EN` reader - The bit is used to enable freeze operation on L1-ICache0. It can be cleared by software."]
+pub type L1_ICACHE0_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_FREEZE_MODE` reader - The bit is used to configure mode of freeze operation L1-ICache0. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+pub type L1_ICACHE0_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_FREEZE_DONE` reader - The bit is used to indicate whether freeze operation on L1-ICache0 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE0_FREEZE_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FREEZE_EN` reader - The bit is used to enable freeze operation on L1-ICache1. It can be cleared by software."]
+pub type L1_ICACHE1_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FREEZE_MODE` reader - The bit is used to configure mode of freeze operation L1-ICache1. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+pub type L1_ICACHE1_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_FREEZE_DONE` reader - The bit is used to indicate whether freeze operation on L1-ICache1 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE1_FREEZE_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FREEZE_EN` reader - Reserved"]
+pub type L1_ICACHE2_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FREEZE_MODE` reader - Reserved"]
+pub type L1_ICACHE2_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_FREEZE_DONE` reader - Reserved"]
+pub type L1_ICACHE2_FREEZE_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FREEZE_EN` reader - Reserved"]
+pub type L1_ICACHE3_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FREEZE_MODE` reader - Reserved"]
+pub type L1_ICACHE3_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_FREEZE_DONE` reader - Reserved"]
+pub type L1_ICACHE3_FREEZE_DONE_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FREEZE_EN` reader - The bit is used to enable freeze operation on L1-Cache. It can be cleared by software."]
+pub type L1_CACHE_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FREEZE_EN` writer - The bit is used to enable freeze operation on L1-Cache. It can be cleared by software."]
+pub type L1_CACHE_FREEZE_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_FREEZE_MODE` reader - The bit is used to configure mode of freeze operation L1-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+pub type L1_CACHE_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_FREEZE_MODE` writer - The bit is used to configure mode of freeze operation L1-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+pub type L1_CACHE_FREEZE_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_FREEZE_DONE` reader - The bit is used to indicate whether freeze operation on L1-Cache is finished or not. 0: not finished. 1: finished."]
+pub type L1_CACHE_FREEZE_DONE_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable freeze operation on L1-ICache0. It can be cleared by software."]
+    #[inline(always)]
+    pub fn l1_icache0_freeze_en(&self) -> L1_ICACHE0_FREEZE_EN_R {
+        L1_ICACHE0_FREEZE_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to configure mode of freeze operation L1-ICache0. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+    #[inline(always)]
+    pub fn l1_icache0_freeze_mode(&self) -> L1_ICACHE0_FREEZE_MODE_R {
+        L1_ICACHE0_FREEZE_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to indicate whether freeze operation on L1-ICache0 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache0_freeze_done(&self) -> L1_ICACHE0_FREEZE_DONE_R {
+        L1_ICACHE0_FREEZE_DONE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable freeze operation on L1-ICache1. It can be cleared by software."]
+    #[inline(always)]
+    pub fn l1_icache1_freeze_en(&self) -> L1_ICACHE1_FREEZE_EN_R {
+        L1_ICACHE1_FREEZE_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to configure mode of freeze operation L1-ICache1. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+    #[inline(always)]
+    pub fn l1_icache1_freeze_mode(&self) -> L1_ICACHE1_FREEZE_MODE_R {
+        L1_ICACHE1_FREEZE_MODE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The bit is used to indicate whether freeze operation on L1-ICache1 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache1_freeze_done(&self) -> L1_ICACHE1_FREEZE_DONE_R {
+        L1_ICACHE1_FREEZE_DONE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_freeze_en(&self) -> L1_ICACHE2_FREEZE_EN_R {
+        L1_ICACHE2_FREEZE_EN_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_freeze_mode(&self) -> L1_ICACHE2_FREEZE_MODE_R {
+        L1_ICACHE2_FREEZE_MODE_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_freeze_done(&self) -> L1_ICACHE2_FREEZE_DONE_R {
+        L1_ICACHE2_FREEZE_DONE_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_freeze_en(&self) -> L1_ICACHE3_FREEZE_EN_R {
+        L1_ICACHE3_FREEZE_EN_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_freeze_mode(&self) -> L1_ICACHE3_FREEZE_MODE_R {
+        L1_ICACHE3_FREEZE_MODE_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_freeze_done(&self) -> L1_ICACHE3_FREEZE_DONE_R {
+        L1_ICACHE3_FREEZE_DONE_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to enable freeze operation on L1-Cache. It can be cleared by software."]
+    #[inline(always)]
+    pub fn l1_cache_freeze_en(&self) -> L1_CACHE_FREEZE_EN_R {
+        L1_CACHE_FREEZE_EN_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to configure mode of freeze operation L1-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+    #[inline(always)]
+    pub fn l1_cache_freeze_mode(&self) -> L1_CACHE_FREEZE_MODE_R {
+        L1_CACHE_FREEZE_MODE_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - The bit is used to indicate whether freeze operation on L1-Cache is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_cache_freeze_done(&self) -> L1_CACHE_FREEZE_DONE_R {
+        L1_CACHE_FREEZE_DONE_R::new(((self.bits >> 18) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_FREEZE_CTRL")
+            .field("l1_icache0_freeze_en", &self.l1_icache0_freeze_en())
+            .field("l1_icache0_freeze_mode", &self.l1_icache0_freeze_mode())
+            .field("l1_icache0_freeze_done", &self.l1_icache0_freeze_done())
+            .field("l1_icache1_freeze_en", &self.l1_icache1_freeze_en())
+            .field("l1_icache1_freeze_mode", &self.l1_icache1_freeze_mode())
+            .field("l1_icache1_freeze_done", &self.l1_icache1_freeze_done())
+            .field("l1_icache2_freeze_en", &self.l1_icache2_freeze_en())
+            .field("l1_icache2_freeze_mode", &self.l1_icache2_freeze_mode())
+            .field("l1_icache2_freeze_done", &self.l1_icache2_freeze_done())
+            .field("l1_icache3_freeze_en", &self.l1_icache3_freeze_en())
+            .field("l1_icache3_freeze_mode", &self.l1_icache3_freeze_mode())
+            .field("l1_icache3_freeze_done", &self.l1_icache3_freeze_done())
+            .field("l1_cache_freeze_en", &self.l1_cache_freeze_en())
+            .field("l1_cache_freeze_mode", &self.l1_cache_freeze_mode())
+            .field("l1_cache_freeze_done", &self.l1_cache_freeze_done())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 16 - The bit is used to enable freeze operation on L1-Cache. It can be cleared by software."]
+    #[inline(always)]
+    pub fn l1_cache_freeze_en(&mut self) -> L1_CACHE_FREEZE_EN_W<'_, L1_CACHE_FREEZE_CTRL_SPEC> {
+        L1_CACHE_FREEZE_EN_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - The bit is used to configure mode of freeze operation L1-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+    #[inline(always)]
+    pub fn l1_cache_freeze_mode(
+        &mut self,
+    ) -> L1_CACHE_FREEZE_MODE_W<'_, L1_CACHE_FREEZE_CTRL_SPEC> {
+        L1_CACHE_FREEZE_MODE_W::new(self, 17)
+    }
+}
+#[doc = "Cache Freeze control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_freeze_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_freeze_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_FREEZE_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_FREEZE_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_freeze_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_FREEZE_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_freeze_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_FREEZE_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_FREEZE_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_FREEZE_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_object_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_object_ctrl.rs
@@ -1,0 +1,122 @@
+#[doc = "Register `L1_CACHE_OBJECT_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_OBJECT_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_OBJECT_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_OBJECT_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_TAG_OBJECT` reader - Set this bit to set L1-ICache0 tag memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_ICACHE0_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_OBJECT` reader - Set this bit to set L1-ICache1 tag memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_ICACHE1_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_OBJECT` reader - Reserved"]
+pub type L1_ICACHE2_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_OBJECT` reader - Reserved"]
+pub type L1_ICACHE3_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_OBJECT` reader - Set this bit to set L1-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_CACHE_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_OBJECT` writer - Set this bit to set L1-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_CACHE_TAG_OBJECT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE0_MEM_OBJECT` reader - Set this bit to set L1-ICache0 data memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_ICACHE0_MEM_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_MEM_OBJECT` reader - Set this bit to set L1-ICache1 data memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_ICACHE1_MEM_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_MEM_OBJECT` reader - Reserved"]
+pub type L1_ICACHE2_MEM_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_MEM_OBJECT` reader - Reserved"]
+pub type L1_ICACHE3_MEM_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_MEM_OBJECT` reader - Set this bit to set L1-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_CACHE_MEM_OBJECT_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_MEM_OBJECT` writer - Set this bit to set L1-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L1_CACHE_MEM_OBJECT_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Set this bit to set L1-ICache0 tag memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_icache0_tag_object(&self) -> L1_ICACHE0_TAG_OBJECT_R {
+        L1_ICACHE0_TAG_OBJECT_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Set this bit to set L1-ICache1 tag memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_icache1_tag_object(&self) -> L1_ICACHE1_TAG_OBJECT_R {
+        L1_ICACHE1_TAG_OBJECT_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_object(&self) -> L1_ICACHE2_TAG_OBJECT_R {
+        L1_ICACHE2_TAG_OBJECT_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_object(&self) -> L1_ICACHE3_TAG_OBJECT_R {
+        L1_ICACHE3_TAG_OBJECT_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Set this bit to set L1-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_cache_tag_object(&self) -> L1_CACHE_TAG_OBJECT_R {
+        L1_CACHE_TAG_OBJECT_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Set this bit to set L1-ICache0 data memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_icache0_mem_object(&self) -> L1_ICACHE0_MEM_OBJECT_R {
+        L1_ICACHE0_MEM_OBJECT_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Set this bit to set L1-ICache1 data memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_icache1_mem_object(&self) -> L1_ICACHE1_MEM_OBJECT_R {
+        L1_ICACHE1_MEM_OBJECT_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_mem_object(&self) -> L1_ICACHE2_MEM_OBJECT_R {
+        L1_ICACHE2_MEM_OBJECT_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_mem_object(&self) -> L1_ICACHE3_MEM_OBJECT_R {
+        L1_ICACHE3_MEM_OBJECT_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Set this bit to set L1-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_cache_mem_object(&self) -> L1_CACHE_MEM_OBJECT_R {
+        L1_CACHE_MEM_OBJECT_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_OBJECT_CTRL")
+            .field("l1_icache0_tag_object", &self.l1_icache0_tag_object())
+            .field("l1_icache1_tag_object", &self.l1_icache1_tag_object())
+            .field("l1_icache2_tag_object", &self.l1_icache2_tag_object())
+            .field("l1_icache3_tag_object", &self.l1_icache3_tag_object())
+            .field("l1_cache_tag_object", &self.l1_cache_tag_object())
+            .field("l1_icache0_mem_object", &self.l1_icache0_mem_object())
+            .field("l1_icache1_mem_object", &self.l1_icache1_mem_object())
+            .field("l1_icache2_mem_object", &self.l1_icache2_mem_object())
+            .field("l1_icache3_mem_object", &self.l1_icache3_mem_object())
+            .field("l1_cache_mem_object", &self.l1_cache_mem_object())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - Set this bit to set L1-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_cache_tag_object(&mut self) -> L1_CACHE_TAG_OBJECT_W<'_, L1_CACHE_OBJECT_CTRL_SPEC> {
+        L1_CACHE_TAG_OBJECT_W::new(self, 4)
+    }
+    #[doc = "Bit 10 - Set this bit to set L1-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l1_cache_mem_object(&mut self) -> L1_CACHE_MEM_OBJECT_W<'_, L1_CACHE_OBJECT_CTRL_SPEC> {
+        L1_CACHE_MEM_OBJECT_W::new(self, 10)
+    }
+}
+#[doc = "Cache Tag and Data memory Object control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_object_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_object_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_OBJECT_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_OBJECT_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_object_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_OBJECT_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_object_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_OBJECT_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_OBJECT_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_OBJECT_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_preload_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_preload_ctrl.rs
@@ -1,0 +1,80 @@
+#[doc = "Register `L1_CACHE_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOAD_ENA` reader - The bit is used to enable preload operation on L1-Cache. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_CACHE_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PRELOAD_ENA` writer - The bit is used to enable preload operation on L1-Cache. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_CACHE_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L1_CACHE_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_CACHE_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PRELOAD_ORDER` writer - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_CACHE_PRELOAD_ORDER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PRELOAD_RGID` reader - The bit is used to set the gid of l1 cache preload."]
+pub type L1_CACHE_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-Cache. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_preload_ena(&self) -> L1_CACHE_PRELOAD_ENA_R {
+        L1_CACHE_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_cache_preload_done(&self) -> L1_CACHE_PRELOAD_DONE_R {
+        L1_CACHE_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_cache_preload_order(&self) -> L1_CACHE_PRELOAD_ORDER_R {
+        L1_CACHE_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l1 cache preload."]
+    #[inline(always)]
+    pub fn l1_cache_preload_rgid(&self) -> L1_CACHE_PRELOAD_RGID_R {
+        L1_CACHE_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_PRELOAD_CTRL")
+            .field("l1_cache_preload_ena", &self.l1_cache_preload_ena())
+            .field("l1_cache_preload_done", &self.l1_cache_preload_done())
+            .field("l1_cache_preload_order", &self.l1_cache_preload_order())
+            .field("l1_cache_preload_rgid", &self.l1_cache_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-Cache. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_preload_ena(
+        &mut self,
+    ) -> L1_CACHE_PRELOAD_ENA_W<'_, L1_CACHE_PRELOAD_CTRL_SPEC> {
+        L1_CACHE_PRELOAD_ENA_W::new(self, 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_cache_preload_order(
+        &mut self,
+    ) -> L1_CACHE_PRELOAD_ORDER_W<'_, L1_CACHE_PRELOAD_CTRL_SPEC> {
+        L1_CACHE_PRELOAD_ORDER_W::new(self, 2)
+    }
+}
+#[doc = "L1 Cache preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_CACHE_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_cache_preload_rst_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_preload_rst_ctrl.rs
@@ -1,0 +1,75 @@
+#[doc = "Register `L1_CACHE_PRELOAD_RST_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_PRELOAD_RST_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_PRELOAD_RST_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_PRELOAD_RST_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_RST` reader - set this bit to reset preload-logic inside L1-ICache0. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+pub type L1_ICACHE0_PLD_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_RST` reader - set this bit to reset preload-logic inside L1-ICache1. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+pub type L1_ICACHE1_PLD_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_RST` reader - Reserved"]
+pub type L1_ICACHE2_PLD_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_RST` reader - Reserved"]
+pub type L1_ICACHE3_PLD_RST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_RST` reader - set this bit to reset preload-logic inside L1-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+pub type L1_CACHE_PLD_RST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_RST` writer - set this bit to reset preload-logic inside L1-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+pub type L1_CACHE_PLD_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - set this bit to reset preload-logic inside L1-ICache0. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_rst(&self) -> L1_ICACHE0_PLD_RST_R {
+        L1_ICACHE0_PLD_RST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - set this bit to reset preload-logic inside L1-ICache1. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_rst(&self) -> L1_ICACHE1_PLD_RST_R {
+        L1_ICACHE1_PLD_RST_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_rst(&self) -> L1_ICACHE2_PLD_RST_R {
+        L1_ICACHE2_PLD_RST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_rst(&self) -> L1_ICACHE3_PLD_RST_R {
+        L1_ICACHE3_PLD_RST_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - set this bit to reset preload-logic inside L1-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_rst(&self) -> L1_CACHE_PLD_RST_R {
+        L1_CACHE_PLD_RST_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_PRELOAD_RST_CTRL")
+            .field("l1_icache0_pld_rst", &self.l1_icache0_pld_rst())
+            .field("l1_icache1_pld_rst", &self.l1_icache1_pld_rst())
+            .field("l1_icache2_pld_rst", &self.l1_icache2_pld_rst())
+            .field("l1_icache3_pld_rst", &self.l1_icache3_pld_rst())
+            .field("l1_cache_pld_rst", &self.l1_cache_pld_rst())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - set this bit to reset preload-logic inside L1-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_rst(&mut self) -> L1_CACHE_PLD_RST_W<'_, L1_CACHE_PRELOAD_RST_CTRL_SPEC> {
+        L1_CACHE_PLD_RST_W::new(self, 4)
+    }
+}
+#[doc = "Cache Preload Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_preload_rst_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_preload_rst_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_PRELOAD_RST_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_PRELOAD_RST_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_preload_rst_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_PRELOAD_RST_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_preload_rst_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_PRELOAD_RST_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_PRELOAD_RST_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_PRELOAD_RST_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_prelock_conf.rs
+++ b/esp32h2/src/cache/l1_cache_prelock_conf.rs
@@ -1,0 +1,70 @@
+#[doc = "Register `L1_CACHE_PRELOCK_CONF` reader"]
+pub type R = crate::R<L1_CACHE_PRELOCK_CONF_SPEC>;
+#[doc = "Register `L1_CACHE_PRELOCK_CONF` writer"]
+pub type W = crate::W<L1_CACHE_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L1-Cache."]
+pub type L1_CACHE_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_EN` writer - The bit is used to enable the first section of prelock function on L1-Cache."]
+pub type L1_CACHE_PRELOCK_SCT0_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L1-Cache."]
+pub type L1_CACHE_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_EN` writer - The bit is used to enable the second section of prelock function on L1-Cache."]
+pub type L1_CACHE_PRELOCK_SCT1_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PRELOCK_RGID` reader - The bit is used to set the gid of l1 cache prelock."]
+pub type L1_CACHE_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_en(&self) -> L1_CACHE_PRELOCK_SCT0_EN_R {
+        L1_CACHE_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_en(&self) -> L1_CACHE_PRELOCK_SCT1_EN_R {
+        L1_CACHE_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l1 cache prelock."]
+    #[inline(always)]
+    pub fn l1_cache_prelock_rgid(&self) -> L1_CACHE_PRELOCK_RGID_R {
+        L1_CACHE_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_PRELOCK_CONF")
+            .field("l1_cache_prelock_sct0_en", &self.l1_cache_prelock_sct0_en())
+            .field("l1_cache_prelock_sct1_en", &self.l1_cache_prelock_sct1_en())
+            .field("l1_cache_prelock_rgid", &self.l1_cache_prelock_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_en(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT0_EN_W<'_, L1_CACHE_PRELOCK_CONF_SPEC> {
+        L1_CACHE_PRELOCK_SCT0_EN_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_en(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT1_EN_W<'_, L1_CACHE_PRELOCK_CONF_SPEC> {
+        L1_CACHE_PRELOCK_SCT1_EN_W::new(self, 1)
+    }
+}
+#[doc = "L1 Cache prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_prelock_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_prelock_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_PRELOCK_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_prelock_conf::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_PRELOCK_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L1_CACHE_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_cache_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_cache_prelock_sct0_addr.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_CACHE_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_CACHE_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Register `L1_CACHE_PRELOCK_SCT0_ADDR` writer"]
+pub type W = crate::W<L1_CACHE_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_CACHE_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_ADDR` writer - Those bits are used to configure the start virtual address of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_CACHE_PRELOCK_SCT0_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_addr(&self) -> L1_CACHE_PRELOCK_SCT0_ADDR_R {
+        L1_CACHE_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_PRELOCK_SCT0_ADDR")
+            .field(
+                "l1_cache_prelock_sct0_addr",
+                &self.l1_cache_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_addr(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT0_ADDR_W<'_, L1_CACHE_PRELOCK_SCT0_ADDR_SPEC> {
+        L1_CACHE_PRELOCK_SCT0_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_prelock_sct0_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_prelock_sct0_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_prelock_sct0_addr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_PRELOCK_SCT0_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_CACHE_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_preload_exception.rs
+++ b/esp32h2/src/cache/l1_cache_sync_preload_exception.rs
@@ -1,0 +1,68 @@
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_EXCEPTION` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_CODE` reader - The value 2 is Only available which means preload size is error in L1-ICache0."]
+pub type L1_ICACHE0_PLD_ERR_CODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_CODE` reader - The value 2 is Only available which means preload size is error in L1-ICache1."]
+pub type L1_ICACHE1_PLD_ERR_CODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_CODE` reader - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_CODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_CODE` reader - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_CODE_R = crate::FieldReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_CODE` reader - The value 2 is Only available which means preload size is error in L1-Cache."]
+pub type L1_CACHE_PLD_ERR_CODE_R = crate::FieldReader;
+#[doc = "Field `CACHE_SYNC_ERR_CODE` reader - The values 0-2 are available which means sync map, command conflict and size are error in Cache System."]
+pub type CACHE_SYNC_ERR_CODE_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:1 - The value 2 is Only available which means preload size is error in L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_code(&self) -> L1_ICACHE0_PLD_ERR_CODE_R {
+        L1_ICACHE0_PLD_ERR_CODE_R::new((self.bits & 3) as u8)
+    }
+    #[doc = "Bits 2:3 - The value 2 is Only available which means preload size is error in L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_code(&self) -> L1_ICACHE1_PLD_ERR_CODE_R {
+        L1_ICACHE1_PLD_ERR_CODE_R::new(((self.bits >> 2) & 3) as u8)
+    }
+    #[doc = "Bits 4:5 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_code(&self) -> L1_ICACHE2_PLD_ERR_CODE_R {
+        L1_ICACHE2_PLD_ERR_CODE_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bits 6:7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_code(&self) -> L1_ICACHE3_PLD_ERR_CODE_R {
+        L1_ICACHE3_PLD_ERR_CODE_R::new(((self.bits >> 6) & 3) as u8)
+    }
+    #[doc = "Bits 8:9 - The value 2 is Only available which means preload size is error in L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_code(&self) -> L1_CACHE_PLD_ERR_CODE_R {
+        L1_CACHE_PLD_ERR_CODE_R::new(((self.bits >> 8) & 3) as u8)
+    }
+    #[doc = "Bits 12:13 - The values 0-2 are available which means sync map, command conflict and size are error in Cache System."]
+    #[inline(always)]
+    pub fn cache_sync_err_code(&self) -> CACHE_SYNC_ERR_CODE_R {
+        CACHE_SYNC_ERR_CODE_R::new(((self.bits >> 12) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_PRELOAD_EXCEPTION")
+            .field("l1_icache0_pld_err_code", &self.l1_icache0_pld_err_code())
+            .field("l1_icache1_pld_err_code", &self.l1_icache1_pld_err_code())
+            .field("l1_icache2_pld_err_code", &self.l1_icache2_pld_err_code())
+            .field("l1_icache3_pld_err_code", &self.l1_icache3_pld_err_code())
+            .field("l1_cache_pld_err_code", &self.l1_cache_pld_err_code())
+            .field("cache_sync_err_code", &self.cache_sync_err_code())
+            .finish()
+    }
+}
+#[doc = "Cache Sync/Preload Operation exception register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_exception::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_preload_exception::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_PRELOAD_EXCEPTION to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_preload_int_clr.rs
+++ b/esp32h2/src/cache/l1_cache_sync_preload_int_clr.rs
@@ -1,0 +1,152 @@
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_CLR` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC>;
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_CLR` writer"]
+pub type W = crate::W<L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_DONE_INT_CLR` reader - The bit is used to clear interrupt that occurs only when L1-ICache0 preload-operation is done."]
+pub type L1_ICACHE0_PLD_DONE_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_DONE_INT_CLR` reader - The bit is used to clear interrupt that occurs only when L1-ICache1 preload-operation is done."]
+pub type L1_ICACHE1_PLD_DONE_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_DONE_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE2_PLD_DONE_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_DONE_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE3_PLD_DONE_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_CLR` writer - The bit is used to clear interrupt that occurs only when L1-Cache preload-operation is done."]
+pub type L1_CACHE_PLD_DONE_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_DONE_INT_CLR` writer - The bit is used to clear interrupt that occurs only when Cache sync-operation is done."]
+pub type CACHE_SYNC_DONE_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_INT_CLR` reader - The bit is used to clear interrupt of L1-ICache0 preload-operation error."]
+pub type L1_ICACHE0_PLD_ERR_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_INT_CLR` reader - The bit is used to clear interrupt of L1-ICache1 preload-operation error."]
+pub type L1_ICACHE1_PLD_ERR_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_INT_CLR` reader - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_CLR` writer - The bit is used to clear interrupt of L1-Cache preload-operation error."]
+pub type L1_CACHE_PLD_ERR_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_ERR_INT_CLR` writer - The bit is used to clear interrupt of Cache sync-operation error."]
+pub type CACHE_SYNC_ERR_INT_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to clear interrupt that occurs only when L1-ICache0 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_done_int_clr(&self) -> L1_ICACHE0_PLD_DONE_INT_CLR_R {
+        L1_ICACHE0_PLD_DONE_INT_CLR_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to clear interrupt that occurs only when L1-ICache1 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_done_int_clr(&self) -> L1_ICACHE1_PLD_DONE_INT_CLR_R {
+        L1_ICACHE1_PLD_DONE_INT_CLR_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_done_int_clr(&self) -> L1_ICACHE2_PLD_DONE_INT_CLR_R {
+        L1_ICACHE2_PLD_DONE_INT_CLR_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_done_int_clr(&self) -> L1_ICACHE3_PLD_DONE_INT_CLR_R {
+        L1_ICACHE3_PLD_DONE_INT_CLR_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The bit is used to clear interrupt of L1-ICache0 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_int_clr(&self) -> L1_ICACHE0_PLD_ERR_INT_CLR_R {
+        L1_ICACHE0_PLD_ERR_INT_CLR_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The bit is used to clear interrupt of L1-ICache1 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_int_clr(&self) -> L1_ICACHE1_PLD_ERR_INT_CLR_R {
+        L1_ICACHE1_PLD_ERR_INT_CLR_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_int_clr(&self) -> L1_ICACHE2_PLD_ERR_INT_CLR_R {
+        L1_ICACHE2_PLD_ERR_INT_CLR_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_int_clr(&self) -> L1_ICACHE3_PLD_ERR_INT_CLR_R {
+        L1_ICACHE3_PLD_ERR_INT_CLR_R::new(((self.bits >> 10) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_PRELOAD_INT_CLR")
+            .field(
+                "l1_icache0_pld_done_int_clr",
+                &self.l1_icache0_pld_done_int_clr(),
+            )
+            .field(
+                "l1_icache1_pld_done_int_clr",
+                &self.l1_icache1_pld_done_int_clr(),
+            )
+            .field(
+                "l1_icache2_pld_done_int_clr",
+                &self.l1_icache2_pld_done_int_clr(),
+            )
+            .field(
+                "l1_icache3_pld_done_int_clr",
+                &self.l1_icache3_pld_done_int_clr(),
+            )
+            .field(
+                "l1_icache0_pld_err_int_clr",
+                &self.l1_icache0_pld_err_int_clr(),
+            )
+            .field(
+                "l1_icache1_pld_err_int_clr",
+                &self.l1_icache1_pld_err_int_clr(),
+            )
+            .field(
+                "l1_icache2_pld_err_int_clr",
+                &self.l1_icache2_pld_err_int_clr(),
+            )
+            .field(
+                "l1_icache3_pld_err_int_clr",
+                &self.l1_icache3_pld_err_int_clr(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to clear interrupt that occurs only when L1-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_clr(
+        &mut self,
+    ) -> L1_CACHE_PLD_DONE_INT_CLR_W<'_, L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC> {
+        L1_CACHE_PLD_DONE_INT_CLR_W::new(self, 4)
+    }
+    #[doc = "Bit 6 - The bit is used to clear interrupt that occurs only when Cache sync-operation is done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_clr(
+        &mut self,
+    ) -> CACHE_SYNC_DONE_INT_CLR_W<'_, L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC> {
+        CACHE_SYNC_DONE_INT_CLR_W::new(self, 6)
+    }
+    #[doc = "Bit 11 - The bit is used to clear interrupt of L1-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_clr(
+        &mut self,
+    ) -> L1_CACHE_PLD_ERR_INT_CLR_W<'_, L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC> {
+        L1_CACHE_PLD_ERR_INT_CLR_W::new(self, 11)
+    }
+    #[doc = "Bit 13 - The bit is used to clear interrupt of Cache sync-operation error."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_clr(
+        &mut self,
+    ) -> CACHE_SYNC_ERR_INT_CLR_W<'_, L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC> {
+        CACHE_SYNC_ERR_INT_CLR_W::new(self, 13)
+    }
+}
+#[doc = "Sync Preload operation Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_clr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_clr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_preload_int_clr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_sync_preload_int_clr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_PRELOAD_INT_CLR to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_preload_int_ena.rs
+++ b/esp32h2/src/cache/l1_cache_sync_preload_int_ena.rs
@@ -1,0 +1,187 @@
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_ENA` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC>;
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_ENA` writer"]
+pub type W = crate::W<L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_DONE_INT_ENA` reader - The bit is used to enable interrupt of L1-ICache0 preload-operation. If preload operation is done, interrupt occurs."]
+pub type L1_ICACHE0_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_DONE_INT_ENA` reader - The bit is used to enable interrupt of L1-ICache1 preload-operation. If preload operation is done, interrupt occurs."]
+pub type L1_ICACHE1_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_DONE_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE2_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_DONE_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE3_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_ENA` reader - The bit is used to enable interrupt of L1-Cache preload-operation. If preload operation is done, interrupt occurs."]
+pub type L1_CACHE_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_ENA` writer - The bit is used to enable interrupt of L1-Cache preload-operation. If preload operation is done, interrupt occurs."]
+pub type L1_CACHE_PLD_DONE_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_DONE_INT_ENA` reader - The bit is used to enable interrupt of Cache sync-operation done."]
+pub type CACHE_SYNC_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_DONE_INT_ENA` writer - The bit is used to enable interrupt of Cache sync-operation done."]
+pub type CACHE_SYNC_DONE_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_INT_ENA` reader - The bit is used to enable interrupt of L1-ICache0 preload-operation error."]
+pub type L1_ICACHE0_PLD_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_INT_ENA` reader - The bit is used to enable interrupt of L1-ICache1 preload-operation error."]
+pub type L1_ICACHE1_PLD_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_INT_ENA` reader - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_ENA` reader - The bit is used to enable interrupt of L1-Cache preload-operation error."]
+pub type L1_CACHE_PLD_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_ENA` writer - The bit is used to enable interrupt of L1-Cache preload-operation error."]
+pub type L1_CACHE_PLD_ERR_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_ERR_INT_ENA` reader - The bit is used to enable interrupt of Cache sync-operation error."]
+pub type CACHE_SYNC_ERR_INT_ENA_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_ERR_INT_ENA` writer - The bit is used to enable interrupt of Cache sync-operation error."]
+pub type CACHE_SYNC_ERR_INT_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable interrupt of L1-ICache0 preload-operation. If preload operation is done, interrupt occurs."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_done_int_ena(&self) -> L1_ICACHE0_PLD_DONE_INT_ENA_R {
+        L1_ICACHE0_PLD_DONE_INT_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable interrupt of L1-ICache1 preload-operation. If preload operation is done, interrupt occurs."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_done_int_ena(&self) -> L1_ICACHE1_PLD_DONE_INT_ENA_R {
+        L1_ICACHE1_PLD_DONE_INT_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_done_int_ena(&self) -> L1_ICACHE2_PLD_DONE_INT_ENA_R {
+        L1_ICACHE2_PLD_DONE_INT_ENA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_done_int_ena(&self) -> L1_ICACHE3_PLD_DONE_INT_ENA_R {
+        L1_ICACHE3_PLD_DONE_INT_ENA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable interrupt of L1-Cache preload-operation. If preload operation is done, interrupt occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_ena(&self) -> L1_CACHE_PLD_DONE_INT_ENA_R {
+        L1_CACHE_PLD_DONE_INT_ENA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The bit is used to enable interrupt of Cache sync-operation done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_ena(&self) -> CACHE_SYNC_DONE_INT_ENA_R {
+        CACHE_SYNC_DONE_INT_ENA_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The bit is used to enable interrupt of L1-ICache0 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_int_ena(&self) -> L1_ICACHE0_PLD_ERR_INT_ENA_R {
+        L1_ICACHE0_PLD_ERR_INT_ENA_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The bit is used to enable interrupt of L1-ICache1 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_int_ena(&self) -> L1_ICACHE1_PLD_ERR_INT_ENA_R {
+        L1_ICACHE1_PLD_ERR_INT_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_int_ena(&self) -> L1_ICACHE2_PLD_ERR_INT_ENA_R {
+        L1_ICACHE2_PLD_ERR_INT_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_int_ena(&self) -> L1_ICACHE3_PLD_ERR_INT_ENA_R {
+        L1_ICACHE3_PLD_ERR_INT_ENA_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The bit is used to enable interrupt of L1-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_ena(&self) -> L1_CACHE_PLD_ERR_INT_ENA_R {
+        L1_CACHE_PLD_ERR_INT_ENA_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit is used to enable interrupt of Cache sync-operation error."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_ena(&self) -> CACHE_SYNC_ERR_INT_ENA_R {
+        CACHE_SYNC_ERR_INT_ENA_R::new(((self.bits >> 13) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_PRELOAD_INT_ENA")
+            .field(
+                "l1_icache0_pld_done_int_ena",
+                &self.l1_icache0_pld_done_int_ena(),
+            )
+            .field(
+                "l1_icache1_pld_done_int_ena",
+                &self.l1_icache1_pld_done_int_ena(),
+            )
+            .field(
+                "l1_icache2_pld_done_int_ena",
+                &self.l1_icache2_pld_done_int_ena(),
+            )
+            .field(
+                "l1_icache3_pld_done_int_ena",
+                &self.l1_icache3_pld_done_int_ena(),
+            )
+            .field(
+                "l1_cache_pld_done_int_ena",
+                &self.l1_cache_pld_done_int_ena(),
+            )
+            .field("cache_sync_done_int_ena", &self.cache_sync_done_int_ena())
+            .field(
+                "l1_icache0_pld_err_int_ena",
+                &self.l1_icache0_pld_err_int_ena(),
+            )
+            .field(
+                "l1_icache1_pld_err_int_ena",
+                &self.l1_icache1_pld_err_int_ena(),
+            )
+            .field(
+                "l1_icache2_pld_err_int_ena",
+                &self.l1_icache2_pld_err_int_ena(),
+            )
+            .field(
+                "l1_icache3_pld_err_int_ena",
+                &self.l1_icache3_pld_err_int_ena(),
+            )
+            .field("l1_cache_pld_err_int_ena", &self.l1_cache_pld_err_int_ena())
+            .field("cache_sync_err_int_ena", &self.cache_sync_err_int_ena())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to enable interrupt of L1-Cache preload-operation. If preload operation is done, interrupt occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_ena(
+        &mut self,
+    ) -> L1_CACHE_PLD_DONE_INT_ENA_W<'_, L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC> {
+        L1_CACHE_PLD_DONE_INT_ENA_W::new(self, 4)
+    }
+    #[doc = "Bit 6 - The bit is used to enable interrupt of Cache sync-operation done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_ena(
+        &mut self,
+    ) -> CACHE_SYNC_DONE_INT_ENA_W<'_, L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC> {
+        CACHE_SYNC_DONE_INT_ENA_W::new(self, 6)
+    }
+    #[doc = "Bit 11 - The bit is used to enable interrupt of L1-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_ena(
+        &mut self,
+    ) -> L1_CACHE_PLD_ERR_INT_ENA_W<'_, L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC> {
+        L1_CACHE_PLD_ERR_INT_ENA_W::new(self, 11)
+    }
+    #[doc = "Bit 13 - The bit is used to enable interrupt of Cache sync-operation error."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_ena(
+        &mut self,
+    ) -> CACHE_SYNC_ERR_INT_ENA_W<'_, L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC> {
+        CACHE_SYNC_ERR_INT_ENA_W::new(self, 13)
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_ena::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_ena::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_preload_int_ena::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_sync_preload_int_ena::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_PRELOAD_INT_ENA to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_preload_int_raw.rs
+++ b/esp32h2/src/cache/l1_cache_sync_preload_int_raw.rs
@@ -1,0 +1,259 @@
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_RAW` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_RAW` writer"]
+pub type W = crate::W<L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_DONE_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+pub type L1_ICACHE0_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PLD_DONE_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+pub type L1_ICACHE0_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE1_PLD_DONE_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+pub type L1_ICACHE1_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_DONE_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+pub type L1_ICACHE1_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE2_PLD_DONE_INT_RAW` reader - Reserved"]
+pub type L1_ICACHE2_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_DONE_INT_RAW` writer - Reserved"]
+pub type L1_ICACHE2_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE3_PLD_DONE_INT_RAW` reader - Reserved"]
+pub type L1_ICACHE3_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_DONE_INT_RAW` writer - Reserved"]
+pub type L1_ICACHE3_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-Cache preload-operation is done."]
+pub type L1_CACHE_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-Cache preload-operation is done."]
+pub type L1_CACHE_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_DONE_INT_RAW` reader - The raw bit of the interrupt that occurs only when Cache sync-operation is done."]
+pub type CACHE_SYNC_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_DONE_INT_RAW` writer - The raw bit of the interrupt that occurs only when Cache sync-operation is done."]
+pub type CACHE_SYNC_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation error occurs."]
+pub type L1_ICACHE0_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation error occurs."]
+pub type L1_ICACHE0_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation error occurs."]
+pub type L1_ICACHE1_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation error occurs."]
+pub type L1_ICACHE1_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_INT_RAW` reader - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_INT_RAW` writer - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_INT_RAW` reader - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_INT_RAW` writer - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_RAW` reader - The raw bit of the interrupt that occurs only when L1-Cache preload-operation error occurs."]
+pub type L1_CACHE_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_RAW` writer - The raw bit of the interrupt that occurs only when L1-Cache preload-operation error occurs."]
+pub type L1_CACHE_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CACHE_SYNC_ERR_INT_RAW` reader - The raw bit of the interrupt that occurs only when Cache sync-operation error occurs."]
+pub type CACHE_SYNC_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_ERR_INT_RAW` writer - The raw bit of the interrupt that occurs only when Cache sync-operation error occurs."]
+pub type CACHE_SYNC_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_done_int_raw(&self) -> L1_ICACHE0_PLD_DONE_INT_RAW_R {
+        L1_ICACHE0_PLD_DONE_INT_RAW_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_done_int_raw(&self) -> L1_ICACHE1_PLD_DONE_INT_RAW_R {
+        L1_ICACHE1_PLD_DONE_INT_RAW_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_done_int_raw(&self) -> L1_ICACHE2_PLD_DONE_INT_RAW_R {
+        L1_ICACHE2_PLD_DONE_INT_RAW_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_done_int_raw(&self) -> L1_ICACHE3_PLD_DONE_INT_RAW_R {
+        L1_ICACHE3_PLD_DONE_INT_RAW_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt that occurs only when L1-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_raw(&self) -> L1_CACHE_PLD_DONE_INT_RAW_R {
+        L1_CACHE_PLD_DONE_INT_RAW_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The raw bit of the interrupt that occurs only when Cache sync-operation is done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_raw(&self) -> CACHE_SYNC_DONE_INT_RAW_R {
+        CACHE_SYNC_DONE_INT_RAW_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_int_raw(&self) -> L1_ICACHE0_PLD_ERR_INT_RAW_R {
+        L1_ICACHE0_PLD_ERR_INT_RAW_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_int_raw(&self) -> L1_ICACHE1_PLD_ERR_INT_RAW_R {
+        L1_ICACHE1_PLD_ERR_INT_RAW_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_int_raw(&self) -> L1_ICACHE2_PLD_ERR_INT_RAW_R {
+        L1_ICACHE2_PLD_ERR_INT_RAW_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_int_raw(&self) -> L1_ICACHE3_PLD_ERR_INT_RAW_R {
+        L1_ICACHE3_PLD_ERR_INT_RAW_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The raw bit of the interrupt that occurs only when L1-Cache preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_raw(&self) -> L1_CACHE_PLD_ERR_INT_RAW_R {
+        L1_CACHE_PLD_ERR_INT_RAW_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The raw bit of the interrupt that occurs only when Cache sync-operation error occurs."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_raw(&self) -> CACHE_SYNC_ERR_INT_RAW_R {
+        CACHE_SYNC_ERR_INT_RAW_R::new(((self.bits >> 13) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_PRELOAD_INT_RAW")
+            .field(
+                "l1_icache0_pld_done_int_raw",
+                &self.l1_icache0_pld_done_int_raw(),
+            )
+            .field(
+                "l1_icache1_pld_done_int_raw",
+                &self.l1_icache1_pld_done_int_raw(),
+            )
+            .field(
+                "l1_icache2_pld_done_int_raw",
+                &self.l1_icache2_pld_done_int_raw(),
+            )
+            .field(
+                "l1_icache3_pld_done_int_raw",
+                &self.l1_icache3_pld_done_int_raw(),
+            )
+            .field(
+                "l1_cache_pld_done_int_raw",
+                &self.l1_cache_pld_done_int_raw(),
+            )
+            .field("cache_sync_done_int_raw", &self.cache_sync_done_int_raw())
+            .field(
+                "l1_icache0_pld_err_int_raw",
+                &self.l1_icache0_pld_err_int_raw(),
+            )
+            .field(
+                "l1_icache1_pld_err_int_raw",
+                &self.l1_icache1_pld_err_int_raw(),
+            )
+            .field(
+                "l1_icache2_pld_err_int_raw",
+                &self.l1_icache2_pld_err_int_raw(),
+            )
+            .field(
+                "l1_icache3_pld_err_int_raw",
+                &self.l1_icache3_pld_err_int_raw(),
+            )
+            .field("l1_cache_pld_err_int_raw", &self.l1_cache_pld_err_int_raw())
+            .field("cache_sync_err_int_raw", &self.cache_sync_err_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_done_int_raw(
+        &mut self,
+    ) -> L1_ICACHE0_PLD_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE0_PLD_DONE_INT_RAW_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_done_int_raw(
+        &mut self,
+    ) -> L1_ICACHE1_PLD_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE1_PLD_DONE_INT_RAW_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_done_int_raw(
+        &mut self,
+    ) -> L1_ICACHE2_PLD_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE2_PLD_DONE_INT_RAW_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_done_int_raw(
+        &mut self,
+    ) -> L1_ICACHE3_PLD_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE3_PLD_DONE_INT_RAW_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - The raw bit of the interrupt that occurs only when L1-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_raw(
+        &mut self,
+    ) -> L1_CACHE_PLD_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_CACHE_PLD_DONE_INT_RAW_W::new(self, 4)
+    }
+    #[doc = "Bit 6 - The raw bit of the interrupt that occurs only when Cache sync-operation is done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_raw(
+        &mut self,
+    ) -> CACHE_SYNC_DONE_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        CACHE_SYNC_DONE_INT_RAW_W::new(self, 6)
+    }
+    #[doc = "Bit 7 - The raw bit of the interrupt that occurs only when L1-ICache0 preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_int_raw(
+        &mut self,
+    ) -> L1_ICACHE0_PLD_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE0_PLD_ERR_INT_RAW_W::new(self, 7)
+    }
+    #[doc = "Bit 8 - The raw bit of the interrupt that occurs only when L1-ICache1 preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_int_raw(
+        &mut self,
+    ) -> L1_ICACHE1_PLD_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE1_PLD_ERR_INT_RAW_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_int_raw(
+        &mut self,
+    ) -> L1_ICACHE2_PLD_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE2_PLD_ERR_INT_RAW_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_int_raw(
+        &mut self,
+    ) -> L1_ICACHE3_PLD_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_ICACHE3_PLD_ERR_INT_RAW_W::new(self, 10)
+    }
+    #[doc = "Bit 11 - The raw bit of the interrupt that occurs only when L1-Cache preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_raw(
+        &mut self,
+    ) -> L1_CACHE_PLD_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L1_CACHE_PLD_ERR_INT_RAW_W::new(self, 11)
+    }
+    #[doc = "Bit 13 - The raw bit of the interrupt that occurs only when Cache sync-operation error occurs."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_raw(
+        &mut self,
+    ) -> CACHE_SYNC_ERR_INT_RAW_W<'_, L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        CACHE_SYNC_ERR_INT_RAW_W::new(self, 13)
+    }
+}
+#[doc = "Sync Preload operation Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_preload_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_preload_int_raw::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_sync_preload_int_raw::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_PRELOAD_INT_RAW to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_preload_int_st.rs
+++ b/esp32h2/src/cache/l1_cache_sync_preload_int_st.rs
@@ -1,0 +1,140 @@
+#[doc = "Register `L1_CACHE_SYNC_PRELOAD_INT_ST` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC>;
+#[doc = "Field `L1_ICACHE0_PLD_DONE_INT_ST` reader - The bit indicates the status of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+pub type L1_ICACHE0_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_DONE_INT_ST` reader - The bit indicates the status of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+pub type L1_ICACHE1_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_DONE_INT_ST` reader - Reserved"]
+pub type L1_ICACHE2_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_DONE_INT_ST` reader - Reserved"]
+pub type L1_ICACHE3_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_DONE_INT_ST` reader - The bit indicates the status of the interrupt that occurs only when L1-Cache preload-operation is done."]
+pub type L1_CACHE_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_DONE_INT_ST` reader - The bit indicates the status of the interrupt that occurs only when Cache sync-operation is done."]
+pub type CACHE_SYNC_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PLD_ERR_INT_ST` reader - The bit indicates the status of the interrupt of L1-ICache0 preload-operation error."]
+pub type L1_ICACHE0_PLD_ERR_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PLD_ERR_INT_ST` reader - The bit indicates the status of the interrupt of L1-ICache1 preload-operation error."]
+pub type L1_ICACHE1_PLD_ERR_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PLD_ERR_INT_ST` reader - Reserved"]
+pub type L1_ICACHE2_PLD_ERR_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PLD_ERR_INT_ST` reader - Reserved"]
+pub type L1_ICACHE3_PLD_ERR_INT_ST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_PLD_ERR_INT_ST` reader - The bit indicates the status of the interrupt of L1-Cache preload-operation error."]
+pub type L1_CACHE_PLD_ERR_INT_ST_R = crate::BitReader;
+#[doc = "Field `CACHE_SYNC_ERR_INT_ST` reader - The bit indicates the status of the interrupt of Cache sync-operation error."]
+pub type CACHE_SYNC_ERR_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The bit indicates the status of the interrupt that occurs only when L1-ICache0 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_done_int_st(&self) -> L1_ICACHE0_PLD_DONE_INT_ST_R {
+        L1_ICACHE0_PLD_DONE_INT_ST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit indicates the status of the interrupt that occurs only when L1-ICache1 preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_done_int_st(&self) -> L1_ICACHE1_PLD_DONE_INT_ST_R {
+        L1_ICACHE1_PLD_DONE_INT_ST_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_done_int_st(&self) -> L1_ICACHE2_PLD_DONE_INT_ST_R {
+        L1_ICACHE2_PLD_DONE_INT_ST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_done_int_st(&self) -> L1_ICACHE3_PLD_DONE_INT_ST_R {
+        L1_ICACHE3_PLD_DONE_INT_ST_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit indicates the status of the interrupt that occurs only when L1-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l1_cache_pld_done_int_st(&self) -> L1_CACHE_PLD_DONE_INT_ST_R {
+        L1_CACHE_PLD_DONE_INT_ST_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The bit indicates the status of the interrupt that occurs only when Cache sync-operation is done."]
+    #[inline(always)]
+    pub fn cache_sync_done_int_st(&self) -> CACHE_SYNC_DONE_INT_ST_R {
+        CACHE_SYNC_DONE_INT_ST_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The bit indicates the status of the interrupt of L1-ICache0 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache0_pld_err_int_st(&self) -> L1_ICACHE0_PLD_ERR_INT_ST_R {
+        L1_ICACHE0_PLD_ERR_INT_ST_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The bit indicates the status of the interrupt of L1-ICache1 preload-operation error."]
+    #[inline(always)]
+    pub fn l1_icache1_pld_err_int_st(&self) -> L1_ICACHE1_PLD_ERR_INT_ST_R {
+        L1_ICACHE1_PLD_ERR_INT_ST_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_pld_err_int_st(&self) -> L1_ICACHE2_PLD_ERR_INT_ST_R {
+        L1_ICACHE2_PLD_ERR_INT_ST_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_pld_err_int_st(&self) -> L1_ICACHE3_PLD_ERR_INT_ST_R {
+        L1_ICACHE3_PLD_ERR_INT_ST_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The bit indicates the status of the interrupt of L1-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l1_cache_pld_err_int_st(&self) -> L1_CACHE_PLD_ERR_INT_ST_R {
+        L1_CACHE_PLD_ERR_INT_ST_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit indicates the status of the interrupt of Cache sync-operation error."]
+    #[inline(always)]
+    pub fn cache_sync_err_int_st(&self) -> CACHE_SYNC_ERR_INT_ST_R {
+        CACHE_SYNC_ERR_INT_ST_R::new(((self.bits >> 13) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_PRELOAD_INT_ST")
+            .field(
+                "l1_icache0_pld_done_int_st",
+                &self.l1_icache0_pld_done_int_st(),
+            )
+            .field(
+                "l1_icache1_pld_done_int_st",
+                &self.l1_icache1_pld_done_int_st(),
+            )
+            .field(
+                "l1_icache2_pld_done_int_st",
+                &self.l1_icache2_pld_done_int_st(),
+            )
+            .field(
+                "l1_icache3_pld_done_int_st",
+                &self.l1_icache3_pld_done_int_st(),
+            )
+            .field("l1_cache_pld_done_int_st", &self.l1_cache_pld_done_int_st())
+            .field("cache_sync_done_int_st", &self.cache_sync_done_int_st())
+            .field(
+                "l1_icache0_pld_err_int_st",
+                &self.l1_icache0_pld_err_int_st(),
+            )
+            .field(
+                "l1_icache1_pld_err_int_st",
+                &self.l1_icache1_pld_err_int_st(),
+            )
+            .field(
+                "l1_icache2_pld_err_int_st",
+                &self.l1_icache2_pld_err_int_st(),
+            )
+            .field(
+                "l1_icache3_pld_err_int_st",
+                &self.l1_icache3_pld_err_int_st(),
+            )
+            .field("l1_cache_pld_err_int_st", &self.l1_cache_pld_err_int_st())
+            .field("cache_sync_err_int_st", &self.cache_sync_err_int_st())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_preload_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_preload_int_st::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_PRELOAD_INT_ST to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_PRELOAD_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l1_cache_sync_rst_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_sync_rst_ctrl.rs
@@ -1,0 +1,75 @@
+#[doc = "Register `L1_CACHE_SYNC_RST_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_SYNC_RST_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_SYNC_RST_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_SYNC_RST_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_SYNC_RST` reader - set this bit to reset sync-logic inside L1-ICache0. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+pub type L1_ICACHE0_SYNC_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_SYNC_RST` reader - set this bit to reset sync-logic inside L1-ICache1. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+pub type L1_ICACHE1_SYNC_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_SYNC_RST` reader - Reserved"]
+pub type L1_ICACHE2_SYNC_RST_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_SYNC_RST` reader - Reserved"]
+pub type L1_ICACHE3_SYNC_RST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SYNC_RST` reader - set this bit to reset sync-logic inside L1-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+pub type L1_CACHE_SYNC_RST_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_SYNC_RST` writer - set this bit to reset sync-logic inside L1-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+pub type L1_CACHE_SYNC_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - set this bit to reset sync-logic inside L1-ICache0. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+    #[inline(always)]
+    pub fn l1_icache0_sync_rst(&self) -> L1_ICACHE0_SYNC_RST_R {
+        L1_ICACHE0_SYNC_RST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - set this bit to reset sync-logic inside L1-ICache1. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+    #[inline(always)]
+    pub fn l1_icache1_sync_rst(&self) -> L1_ICACHE1_SYNC_RST_R {
+        L1_ICACHE1_SYNC_RST_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_sync_rst(&self) -> L1_ICACHE2_SYNC_RST_R {
+        L1_ICACHE2_SYNC_RST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_sync_rst(&self) -> L1_ICACHE3_SYNC_RST_R {
+        L1_ICACHE3_SYNC_RST_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - set this bit to reset sync-logic inside L1-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+    #[inline(always)]
+    pub fn l1_cache_sync_rst(&self) -> L1_CACHE_SYNC_RST_R {
+        L1_CACHE_SYNC_RST_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_SYNC_RST_CTRL")
+            .field("l1_icache0_sync_rst", &self.l1_icache0_sync_rst())
+            .field("l1_icache1_sync_rst", &self.l1_icache1_sync_rst())
+            .field("l1_icache2_sync_rst", &self.l1_icache2_sync_rst())
+            .field("l1_icache3_sync_rst", &self.l1_icache3_sync_rst())
+            .field("l1_cache_sync_rst", &self.l1_cache_sync_rst())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - set this bit to reset sync-logic inside L1-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+    #[inline(always)]
+    pub fn l1_cache_sync_rst(&mut self) -> L1_CACHE_SYNC_RST_W<'_, L1_CACHE_SYNC_RST_CTRL_SPEC> {
+        L1_CACHE_SYNC_RST_W::new(self, 4)
+    }
+}
+#[doc = "Cache Sync Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_sync_rst_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_sync_rst_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_SYNC_RST_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_SYNC_RST_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_sync_rst_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_SYNC_RST_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_sync_rst_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_SYNC_RST_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_SYNC_RST_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_SYNC_RST_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_cache_tag_mem_acs_conf.rs
+++ b/esp32h2/src/cache/l1_cache_tag_mem_acs_conf.rs
@@ -1,0 +1,128 @@
+#[doc = "Register `L1_CACHE_TAG_MEM_ACS_CONF` reader"]
+pub type R = crate::R<L1_CACHE_TAG_MEM_ACS_CONF_SPEC>;
+#[doc = "Register `L1_CACHE_TAG_MEM_ACS_CONF` writer"]
+pub type W = crate::W<L1_CACHE_TAG_MEM_ACS_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE0_TAG_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-ICache0 tag memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE0_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_TAG_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-ICache0 tag memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE0_TAG_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-ICache1 tag memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE1_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-ICache1 tag memoryory. 0: disable, 1: enable."]
+pub type L1_ICACHE1_TAG_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_MEM_RD_EN` reader - Reserved"]
+pub type L1_ICACHE2_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_MEM_WR_EN` reader - Reserved"]
+pub type L1_ICACHE2_TAG_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_MEM_RD_EN` reader - Reserved"]
+pub type L1_ICACHE3_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_MEM_WR_EN` reader - Reserved"]
+pub type L1_ICACHE3_TAG_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_RD_EN` reader - The bit is used to enable config-bus read L1-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_RD_EN` writer - The bit is used to enable config-bus read L1-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_TAG_MEM_RD_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_TAG_MEM_WR_EN` reader - The bit is used to enable config-bus write L1-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_TAG_MEM_WR_EN_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_WR_EN` writer - The bit is used to enable config-bus write L1-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L1_CACHE_TAG_MEM_WR_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable config-bus read L1-ICache0 tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache0_tag_mem_rd_en(&self) -> L1_ICACHE0_TAG_MEM_RD_EN_R {
+        L1_ICACHE0_TAG_MEM_RD_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable config-bus write L1-ICache0 tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache0_tag_mem_wr_en(&self) -> L1_ICACHE0_TAG_MEM_WR_EN_R {
+        L1_ICACHE0_TAG_MEM_WR_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to enable config-bus read L1-ICache1 tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache1_tag_mem_rd_en(&self) -> L1_ICACHE1_TAG_MEM_RD_EN_R {
+        L1_ICACHE1_TAG_MEM_RD_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to enable config-bus write L1-ICache1 tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_icache1_tag_mem_wr_en(&self) -> L1_ICACHE1_TAG_MEM_WR_EN_R {
+        L1_ICACHE1_TAG_MEM_WR_EN_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_mem_rd_en(&self) -> L1_ICACHE2_TAG_MEM_RD_EN_R {
+        L1_ICACHE2_TAG_MEM_RD_EN_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_mem_wr_en(&self) -> L1_ICACHE2_TAG_MEM_WR_EN_R {
+        L1_ICACHE2_TAG_MEM_WR_EN_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_mem_rd_en(&self) -> L1_ICACHE3_TAG_MEM_RD_EN_R {
+        L1_ICACHE3_TAG_MEM_RD_EN_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_mem_wr_en(&self) -> L1_ICACHE3_TAG_MEM_WR_EN_R {
+        L1_ICACHE3_TAG_MEM_WR_EN_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to enable config-bus read L1-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_rd_en(&self) -> L1_CACHE_TAG_MEM_RD_EN_R {
+        L1_CACHE_TAG_MEM_RD_EN_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to enable config-bus write L1-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_wr_en(&self) -> L1_CACHE_TAG_MEM_WR_EN_R {
+        L1_CACHE_TAG_MEM_WR_EN_R::new(((self.bits >> 17) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_TAG_MEM_ACS_CONF")
+            .field("l1_icache0_tag_mem_rd_en", &self.l1_icache0_tag_mem_rd_en())
+            .field("l1_icache0_tag_mem_wr_en", &self.l1_icache0_tag_mem_wr_en())
+            .field("l1_icache1_tag_mem_rd_en", &self.l1_icache1_tag_mem_rd_en())
+            .field("l1_icache1_tag_mem_wr_en", &self.l1_icache1_tag_mem_wr_en())
+            .field("l1_icache2_tag_mem_rd_en", &self.l1_icache2_tag_mem_rd_en())
+            .field("l1_icache2_tag_mem_wr_en", &self.l1_icache2_tag_mem_wr_en())
+            .field("l1_icache3_tag_mem_rd_en", &self.l1_icache3_tag_mem_rd_en())
+            .field("l1_icache3_tag_mem_wr_en", &self.l1_icache3_tag_mem_wr_en())
+            .field("l1_cache_tag_mem_rd_en", &self.l1_cache_tag_mem_rd_en())
+            .field("l1_cache_tag_mem_wr_en", &self.l1_cache_tag_mem_wr_en())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 16 - The bit is used to enable config-bus read L1-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_rd_en(
+        &mut self,
+    ) -> L1_CACHE_TAG_MEM_RD_EN_W<'_, L1_CACHE_TAG_MEM_ACS_CONF_SPEC> {
+        L1_CACHE_TAG_MEM_RD_EN_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - The bit is used to enable config-bus write L1-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_wr_en(
+        &mut self,
+    ) -> L1_CACHE_TAG_MEM_WR_EN_W<'_, L1_CACHE_TAG_MEM_ACS_CONF_SPEC> {
+        L1_CACHE_TAG_MEM_WR_EN_W::new(self, 17)
+    }
+}
+#[doc = "Cache tag memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_tag_mem_acs_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_tag_mem_acs_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_TAG_MEM_ACS_CONF_SPEC;
+impl crate::RegisterSpec for L1_CACHE_TAG_MEM_ACS_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_tag_mem_acs_conf::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_TAG_MEM_ACS_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_tag_mem_acs_conf::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_TAG_MEM_ACS_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_TAG_MEM_ACS_CONF to value 0x0003_3333"]
+impl crate::Resettable for L1_CACHE_TAG_MEM_ACS_CONF_SPEC {
+    const RESET_VALUE: u32 = 0x0003_3333;
+}

--- a/esp32h2/src/cache/l1_cache_tag_mem_power_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_tag_mem_power_ctrl.rs
@@ -1,0 +1,222 @@
+#[doc = "Register `L1_CACHE_TAG_MEM_POWER_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_TAG_MEM_POWER_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_TAG_MEM_POWER_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_TAG_MEM_POWER_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_TAG_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-ICache0 tag memory. 1: close gating, 0: open clock gating."]
+pub type L1_ICACHE0_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_TAG_MEM_FORCE_PD` reader - The bit is used to power L1-ICache0 tag memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_ICACHE0_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_TAG_MEM_FORCE_PU` reader - The bit is used to power L1-ICache0 tag memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_ICACHE0_TAG_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-ICache1 tag memory. 1: close gating, 0: open clock gating."]
+pub type L1_ICACHE1_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_MEM_FORCE_PD` reader - The bit is used to power L1-ICache1 tag memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_ICACHE1_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_TAG_MEM_FORCE_PU` reader - The bit is used to power L1-ICache1 tag memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_ICACHE1_TAG_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_MEM_FORCE_ON` reader - Reserved"]
+pub type L1_ICACHE2_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_MEM_FORCE_PD` reader - Reserved"]
+pub type L1_ICACHE2_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_TAG_MEM_FORCE_PU` reader - Reserved"]
+pub type L1_ICACHE2_TAG_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_MEM_FORCE_ON` reader - Reserved"]
+pub type L1_ICACHE3_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_MEM_FORCE_PD` reader - Reserved"]
+pub type L1_ICACHE3_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_TAG_MEM_FORCE_PU` reader - Reserved"]
+pub type L1_ICACHE3_TAG_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_ON` reader - The bit is used to close clock gating of L1-Cache tag memory. 1: close gating, 0: open clock gating."]
+pub type L1_CACHE_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_ON` writer - The bit is used to close clock gating of L1-Cache tag memory. 1: close gating, 0: open clock gating."]
+pub type L1_CACHE_TAG_MEM_FORCE_ON_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_PD` reader - The bit is used to power L1-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_CACHE_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_PD` writer - The bit is used to power L1-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L1_CACHE_TAG_MEM_FORCE_PD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_PU` reader - The bit is used to power L1-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_CACHE_TAG_MEM_FORCE_PU_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_TAG_MEM_FORCE_PU` writer - The bit is used to power L1-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L1_CACHE_TAG_MEM_FORCE_PU_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to close clock gating of L1-ICache0 tag memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_icache0_tag_mem_force_on(&self) -> L1_ICACHE0_TAG_MEM_FORCE_ON_R {
+        L1_ICACHE0_TAG_MEM_FORCE_ON_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to power L1-ICache0 tag memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_icache0_tag_mem_force_pd(&self) -> L1_ICACHE0_TAG_MEM_FORCE_PD_R {
+        L1_ICACHE0_TAG_MEM_FORCE_PD_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to power L1-ICache0 tag memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_icache0_tag_mem_force_pu(&self) -> L1_ICACHE0_TAG_MEM_FORCE_PU_R {
+        L1_ICACHE0_TAG_MEM_FORCE_PU_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to close clock gating of L1-ICache1 tag memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_icache1_tag_mem_force_on(&self) -> L1_ICACHE1_TAG_MEM_FORCE_ON_R {
+        L1_ICACHE1_TAG_MEM_FORCE_ON_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The bit is used to power L1-ICache1 tag memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_icache1_tag_mem_force_pd(&self) -> L1_ICACHE1_TAG_MEM_FORCE_PD_R {
+        L1_ICACHE1_TAG_MEM_FORCE_PD_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The bit is used to power L1-ICache1 tag memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_icache1_tag_mem_force_pu(&self) -> L1_ICACHE1_TAG_MEM_FORCE_PU_R {
+        L1_ICACHE1_TAG_MEM_FORCE_PU_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_mem_force_on(&self) -> L1_ICACHE2_TAG_MEM_FORCE_ON_R {
+        L1_ICACHE2_TAG_MEM_FORCE_ON_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_mem_force_pd(&self) -> L1_ICACHE2_TAG_MEM_FORCE_PD_R {
+        L1_ICACHE2_TAG_MEM_FORCE_PD_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_tag_mem_force_pu(&self) -> L1_ICACHE2_TAG_MEM_FORCE_PU_R {
+        L1_ICACHE2_TAG_MEM_FORCE_PU_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_mem_force_on(&self) -> L1_ICACHE3_TAG_MEM_FORCE_ON_R {
+        L1_ICACHE3_TAG_MEM_FORCE_ON_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_mem_force_pd(&self) -> L1_ICACHE3_TAG_MEM_FORCE_PD_R {
+        L1_ICACHE3_TAG_MEM_FORCE_PD_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_tag_mem_force_pu(&self) -> L1_ICACHE3_TAG_MEM_FORCE_PU_R {
+        L1_ICACHE3_TAG_MEM_FORCE_PU_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 16 - The bit is used to close clock gating of L1-Cache tag memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_on(&self) -> L1_CACHE_TAG_MEM_FORCE_ON_R {
+        L1_CACHE_TAG_MEM_FORCE_ON_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - The bit is used to power L1-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_pd(&self) -> L1_CACHE_TAG_MEM_FORCE_PD_R {
+        L1_CACHE_TAG_MEM_FORCE_PD_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - The bit is used to power L1-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_pu(&self) -> L1_CACHE_TAG_MEM_FORCE_PU_R {
+        L1_CACHE_TAG_MEM_FORCE_PU_R::new(((self.bits >> 18) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_TAG_MEM_POWER_CTRL")
+            .field(
+                "l1_icache0_tag_mem_force_on",
+                &self.l1_icache0_tag_mem_force_on(),
+            )
+            .field(
+                "l1_icache0_tag_mem_force_pd",
+                &self.l1_icache0_tag_mem_force_pd(),
+            )
+            .field(
+                "l1_icache0_tag_mem_force_pu",
+                &self.l1_icache0_tag_mem_force_pu(),
+            )
+            .field(
+                "l1_icache1_tag_mem_force_on",
+                &self.l1_icache1_tag_mem_force_on(),
+            )
+            .field(
+                "l1_icache1_tag_mem_force_pd",
+                &self.l1_icache1_tag_mem_force_pd(),
+            )
+            .field(
+                "l1_icache1_tag_mem_force_pu",
+                &self.l1_icache1_tag_mem_force_pu(),
+            )
+            .field(
+                "l1_icache2_tag_mem_force_on",
+                &self.l1_icache2_tag_mem_force_on(),
+            )
+            .field(
+                "l1_icache2_tag_mem_force_pd",
+                &self.l1_icache2_tag_mem_force_pd(),
+            )
+            .field(
+                "l1_icache2_tag_mem_force_pu",
+                &self.l1_icache2_tag_mem_force_pu(),
+            )
+            .field(
+                "l1_icache3_tag_mem_force_on",
+                &self.l1_icache3_tag_mem_force_on(),
+            )
+            .field(
+                "l1_icache3_tag_mem_force_pd",
+                &self.l1_icache3_tag_mem_force_pd(),
+            )
+            .field(
+                "l1_icache3_tag_mem_force_pu",
+                &self.l1_icache3_tag_mem_force_pu(),
+            )
+            .field(
+                "l1_cache_tag_mem_force_on",
+                &self.l1_cache_tag_mem_force_on(),
+            )
+            .field(
+                "l1_cache_tag_mem_force_pd",
+                &self.l1_cache_tag_mem_force_pd(),
+            )
+            .field(
+                "l1_cache_tag_mem_force_pu",
+                &self.l1_cache_tag_mem_force_pu(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 16 - The bit is used to close clock gating of L1-Cache tag memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_on(
+        &mut self,
+    ) -> L1_CACHE_TAG_MEM_FORCE_ON_W<'_, L1_CACHE_TAG_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_TAG_MEM_FORCE_ON_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - The bit is used to power L1-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_pd(
+        &mut self,
+    ) -> L1_CACHE_TAG_MEM_FORCE_PD_W<'_, L1_CACHE_TAG_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_TAG_MEM_FORCE_PD_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - The bit is used to power L1-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l1_cache_tag_mem_force_pu(
+        &mut self,
+    ) -> L1_CACHE_TAG_MEM_FORCE_PU_W<'_, L1_CACHE_TAG_MEM_POWER_CTRL_SPEC> {
+        L1_CACHE_TAG_MEM_FORCE_PU_W::new(self, 18)
+    }
+}
+#[doc = "Cache tag memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_tag_mem_power_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_tag_mem_power_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_TAG_MEM_POWER_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_TAG_MEM_POWER_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_tag_mem_power_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_TAG_MEM_POWER_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_tag_mem_power_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_TAG_MEM_POWER_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_TAG_MEM_POWER_CTRL to value 0x0005_5555"]
+impl crate::Resettable for L1_CACHE_TAG_MEM_POWER_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x0005_5555;
+}

--- a/esp32h2/src/cache/l1_cache_vaddr.rs
+++ b/esp32h2/src/cache/l1_cache_vaddr.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `L1_CACHE_VADDR` reader"]
+pub type R = crate::R<L1_CACHE_VADDR_SPEC>;
+#[doc = "Register `L1_CACHE_VADDR` writer"]
+pub type W = crate::W<L1_CACHE_VADDR_SPEC>;
+#[doc = "Field `L1_CACHE_VADDR` reader - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+pub type L1_CACHE_VADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_VADDR` writer - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+pub type L1_CACHE_VADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+    #[inline(always)]
+    pub fn l1_cache_vaddr(&self) -> L1_CACHE_VADDR_R {
+        L1_CACHE_VADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_VADDR")
+            .field("l1_cache_vaddr", &self.l1_cache_vaddr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+    #[inline(always)]
+    pub fn l1_cache_vaddr(&mut self) -> L1_CACHE_VADDR_W<'_, L1_CACHE_VADDR_SPEC> {
+        L1_CACHE_VADDR_W::new(self, 0)
+    }
+}
+#[doc = "Cache Vaddr register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_vaddr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_vaddr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_VADDR_SPEC;
+impl crate::RegisterSpec for L1_CACHE_VADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_vaddr::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_VADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_vaddr::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_VADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_VADDR to value 0x4000_0000"]
+impl crate::Resettable for L1_CACHE_VADDR_SPEC {
+    const RESET_VALUE: u32 = 0x4000_0000;
+}

--- a/esp32h2/src/cache/l1_cache_way_object.rs
+++ b/esp32h2/src/cache/l1_cache_way_object.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `L1_CACHE_WAY_OBJECT` reader"]
+pub type R = crate::R<L1_CACHE_WAY_OBJECT_SPEC>;
+#[doc = "Register `L1_CACHE_WAY_OBJECT` writer"]
+pub type W = crate::W<L1_CACHE_WAY_OBJECT_SPEC>;
+#[doc = "Field `L1_CACHE_WAY_OBJECT` reader - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+pub type L1_CACHE_WAY_OBJECT_R = crate::FieldReader;
+#[doc = "Field `L1_CACHE_WAY_OBJECT` writer - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+pub type L1_CACHE_WAY_OBJECT_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+impl R {
+    #[doc = "Bits 0:2 - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+    #[inline(always)]
+    pub fn l1_cache_way_object(&self) -> L1_CACHE_WAY_OBJECT_R {
+        L1_CACHE_WAY_OBJECT_R::new((self.bits & 7) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_WAY_OBJECT")
+            .field("l1_cache_way_object", &self.l1_cache_way_object())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+    #[inline(always)]
+    pub fn l1_cache_way_object(&mut self) -> L1_CACHE_WAY_OBJECT_W<'_, L1_CACHE_WAY_OBJECT_SPEC> {
+        L1_CACHE_WAY_OBJECT_W::new(self, 0)
+    }
+}
+#[doc = "Cache Tag and Data memory way register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_way_object::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_way_object::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_WAY_OBJECT_SPEC;
+impl crate::RegisterSpec for L1_CACHE_WAY_OBJECT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_way_object::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_WAY_OBJECT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_way_object::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_WAY_OBJECT_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_WAY_OBJECT to value 0"]
+impl crate::Resettable for L1_CACHE_WAY_OBJECT_SPEC {}

--- a/esp32h2/src/cache/l1_cache_wrap_around_ctrl.rs
+++ b/esp32h2/src/cache/l1_cache_wrap_around_ctrl.rs
@@ -1,0 +1,75 @@
+#[doc = "Register `L1_CACHE_WRAP_AROUND_CTRL` reader"]
+pub type R = crate::R<L1_CACHE_WRAP_AROUND_CTRL_SPEC>;
+#[doc = "Register `L1_CACHE_WRAP_AROUND_CTRL` writer"]
+pub type W = crate::W<L1_CACHE_WRAP_AROUND_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_WRAP` reader - Set this bit as 1 to enable L1-ICache0 wrap around mode."]
+pub type L1_ICACHE0_WRAP_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_WRAP` reader - Set this bit as 1 to enable L1-ICache1 wrap around mode."]
+pub type L1_ICACHE1_WRAP_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_WRAP` reader - Reserved"]
+pub type L1_ICACHE2_WRAP_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_WRAP` reader - Reserved"]
+pub type L1_ICACHE3_WRAP_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_WRAP` reader - Set this bit as 1 to enable L1-DCache wrap around mode."]
+pub type L1_CACHE_WRAP_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_WRAP` writer - Set this bit as 1 to enable L1-DCache wrap around mode."]
+pub type L1_CACHE_WRAP_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Set this bit as 1 to enable L1-ICache0 wrap around mode."]
+    #[inline(always)]
+    pub fn l1_icache0_wrap(&self) -> L1_ICACHE0_WRAP_R {
+        L1_ICACHE0_WRAP_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Set this bit as 1 to enable L1-ICache1 wrap around mode."]
+    #[inline(always)]
+    pub fn l1_icache1_wrap(&self) -> L1_ICACHE1_WRAP_R {
+        L1_ICACHE1_WRAP_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_wrap(&self) -> L1_ICACHE2_WRAP_R {
+        L1_ICACHE2_WRAP_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_wrap(&self) -> L1_ICACHE3_WRAP_R {
+        L1_ICACHE3_WRAP_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Set this bit as 1 to enable L1-DCache wrap around mode."]
+    #[inline(always)]
+    pub fn l1_cache_wrap(&self) -> L1_CACHE_WRAP_R {
+        L1_CACHE_WRAP_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_CACHE_WRAP_AROUND_CTRL")
+            .field("l1_icache0_wrap", &self.l1_icache0_wrap())
+            .field("l1_icache1_wrap", &self.l1_icache1_wrap())
+            .field("l1_icache2_wrap", &self.l1_icache2_wrap())
+            .field("l1_icache3_wrap", &self.l1_icache3_wrap())
+            .field("l1_cache_wrap", &self.l1_cache_wrap())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - Set this bit as 1 to enable L1-DCache wrap around mode."]
+    #[inline(always)]
+    pub fn l1_cache_wrap(&mut self) -> L1_CACHE_WRAP_W<'_, L1_CACHE_WRAP_AROUND_CTRL_SPEC> {
+        L1_CACHE_WRAP_W::new(self, 4)
+    }
+}
+#[doc = "Cache wrap around control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_cache_wrap_around_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_cache_wrap_around_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_CACHE_WRAP_AROUND_CTRL_SPEC;
+impl crate::RegisterSpec for L1_CACHE_WRAP_AROUND_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_cache_wrap_around_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_CACHE_WRAP_AROUND_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_cache_wrap_around_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_CACHE_WRAP_AROUND_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_CACHE_WRAP_AROUND_CTRL to value 0"]
+impl crate::Resettable for L1_CACHE_WRAP_AROUND_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_dbus2_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus2_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS2_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_DBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_DBUS2_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus2 accesses L1-DCache."]
+pub type L1_DBUS2_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus2 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_conflict_cnt(&self) -> L1_DBUS2_CONFLICT_CNT_R {
+        L1_DBUS2_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS2_ACS_CONFLICT_CNT")
+            .field("l1_dbus2_conflict_cnt", &self.l1_dbus2_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS2_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS2_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus2_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS2_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS2_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_DBUS2_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus2_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus2_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS2_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_DBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_DBUS2_HIT_CNT` reader - The register records the number of hits when bus2 accesses L1-DCache."]
+pub type L1_DBUS2_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus2 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_hit_cnt(&self) -> L1_DBUS2_HIT_CNT_R {
+        L1_DBUS2_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS2_ACS_HIT_CNT")
+            .field("l1_dbus2_hit_cnt", &self.l1_dbus2_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS2_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS2_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus2_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS2_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS2_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_DBUS2_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus2_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus2_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS2_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_DBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_DBUS2_MISS_CNT` reader - The register records the number of missing when bus2 accesses L1-DCache."]
+pub type L1_DBUS2_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus2 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_miss_cnt(&self) -> L1_DBUS2_MISS_CNT_R {
+        L1_DBUS2_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS2_ACS_MISS_CNT")
+            .field("l1_dbus2_miss_cnt", &self.l1_dbus2_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS2_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS2_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus2_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS2_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS2_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_DBUS2_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus2_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus2_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS2_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_DBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_DBUS2_NXTLVL_CNT` reader - The register records the number of times that L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+pub type L1_DBUS2_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus2_nxtlvl_cnt(&self) -> L1_DBUS2_NXTLVL_CNT_R {
+        L1_DBUS2_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS2_ACS_NXTLVL_CNT")
+            .field("l1_dbus2_nxtlvl_cnt", &self.l1_dbus2_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus2_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS2_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS2_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus2_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS2_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS2_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_DBUS2_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus3_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus3_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS3_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_DBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_DBUS3_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus3 accesses L1-DCache."]
+pub type L1_DBUS3_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus3 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_conflict_cnt(&self) -> L1_DBUS3_CONFLICT_CNT_R {
+        L1_DBUS3_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS3_ACS_CONFLICT_CNT")
+            .field("l1_dbus3_conflict_cnt", &self.l1_dbus3_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS3_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS3_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus3_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS3_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS3_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_DBUS3_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus3_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus3_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS3_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_DBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_DBUS3_HIT_CNT` reader - The register records the number of hits when bus3 accesses L1-DCache."]
+pub type L1_DBUS3_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus3 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_hit_cnt(&self) -> L1_DBUS3_HIT_CNT_R {
+        L1_DBUS3_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS3_ACS_HIT_CNT")
+            .field("l1_dbus3_hit_cnt", &self.l1_dbus3_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS3_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS3_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus3_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS3_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS3_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_DBUS3_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus3_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus3_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS3_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_DBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_DBUS3_MISS_CNT` reader - The register records the number of missing when bus3 accesses L1-DCache."]
+pub type L1_DBUS3_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus3 accesses L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_miss_cnt(&self) -> L1_DBUS3_MISS_CNT_R {
+        L1_DBUS3_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS3_ACS_MISS_CNT")
+            .field("l1_dbus3_miss_cnt", &self.l1_dbus3_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS3_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS3_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus3_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS3_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS3_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_DBUS3_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dbus3_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_dbus3_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DBUS3_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_DBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_DBUS3_NXTLVL_CNT` reader - The register records the number of times that L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+pub type L1_DBUS3_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l1_dbus3_nxtlvl_cnt(&self) -> L1_DBUS3_NXTLVL_CNT_R {
+        L1_DBUS3_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DBUS3_ACS_NXTLVL_CNT")
+            .field("l1_dbus3_nxtlvl_cnt", &self.l1_dbus3_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-DCache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dbus3_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DBUS3_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_DBUS3_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dbus3_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_DBUS3_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_DBUS3_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_DBUS3_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_dcache_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l1_dcache_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_DCACHE_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L1_DCACHE_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_FAIL_ADDR` reader - The register records the address of fail-access when cache accesses L1-Cache."]
+pub type L1_CACHE_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when cache accesses L1-Cache."]
+    #[inline(always)]
+    pub fn l1_cache_fail_addr(&self) -> L1_CACHE_FAIL_ADDR_R {
+        L1_CACHE_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DCACHE_ACS_FAIL_ADDR")
+            .field("l1_cache_fail_addr", &self.l1_cache_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DCACHE_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L1_DCACHE_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dcache_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L1_DCACHE_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_DCACHE_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L1_DCACHE_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_dcache_preload_addr.rs
+++ b/esp32h2/src/cache/l1_dcache_preload_addr.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `L1_DCACHE_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L1_DCACHE_PRELOAD_ADDR_SPEC>;
+#[doc = "Register `L1_DCACHE_PRELOAD_ADDR` writer"]
+pub type W = crate::W<L1_DCACHE_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L1-Cache, which should be used together with L1_CACHE_PRELOAD_SIZE_REG"]
+pub type L1_CACHE_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_PRELOAD_ADDR` writer - Those bits are used to configure the start virtual address of preload on L1-Cache, which should be used together with L1_CACHE_PRELOAD_SIZE_REG"]
+pub type L1_CACHE_PRELOAD_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-Cache, which should be used together with L1_CACHE_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_preload_addr(&self) -> L1_CACHE_PRELOAD_ADDR_R {
+        L1_CACHE_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DCACHE_PRELOAD_ADDR")
+            .field("l1_cache_preload_addr", &self.l1_cache_preload_addr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-Cache, which should be used together with L1_CACHE_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_preload_addr(
+        &mut self,
+    ) -> L1_CACHE_PRELOAD_ADDR_W<'_, L1_DCACHE_PRELOAD_ADDR_SPEC> {
+        L1_CACHE_PRELOAD_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_preload_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_preload_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DCACHE_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L1_DCACHE_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dcache_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L1_DCACHE_PRELOAD_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_dcache_preload_addr::W`](W) writer structure"]
+impl crate::Writable for L1_DCACHE_PRELOAD_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_DCACHE_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L1_DCACHE_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_dcache_preload_size.rs
+++ b/esp32h2/src/cache/l1_dcache_preload_size.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `L1_DCACHE_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L1_DCACHE_PRELOAD_SIZE_SPEC>;
+#[doc = "Register `L1_DCACHE_PRELOAD_SIZE` writer"]
+pub type W = crate::W<L1_DCACHE_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOAD_ADDR_REG"]
+pub type L1_CACHE_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_CACHE_PRELOAD_SIZE` writer - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOAD_ADDR_REG"]
+pub type L1_CACHE_PRELOAD_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 14, u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_preload_size(&self) -> L1_CACHE_PRELOAD_SIZE_R {
+        L1_CACHE_PRELOAD_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DCACHE_PRELOAD_SIZE")
+            .field("l1_cache_preload_size", &self.l1_cache_preload_size())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_preload_size(
+        &mut self,
+    ) -> L1_CACHE_PRELOAD_SIZE_W<'_, L1_DCACHE_PRELOAD_SIZE_SPEC> {
+        L1_CACHE_PRELOAD_SIZE_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_preload_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_preload_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DCACHE_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L1_DCACHE_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dcache_preload_size::R`](R) reader structure"]
+impl crate::Readable for L1_DCACHE_PRELOAD_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_dcache_preload_size::W`](W) writer structure"]
+impl crate::Writable for L1_DCACHE_PRELOAD_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_DCACHE_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L1_DCACHE_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_dcache_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_dcache_prelock_sct1_addr.rs
@@ -1,0 +1,48 @@
+#[doc = "Register `L1_DCACHE_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Register `L1_DCACHE_PRELOCK_SCT1_ADDR` writer"]
+pub type W = crate::W<L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_CACHE_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_ADDR` writer - Those bits are used to configure the start virtual address of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_CACHE_PRELOCK_SCT1_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_addr(&self) -> L1_CACHE_PRELOCK_SCT1_ADDR_R {
+        L1_CACHE_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DCACHE_PRELOCK_SCT1_ADDR")
+            .field(
+                "l1_cache_prelock_sct1_addr",
+                &self.l1_cache_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_addr(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT1_ADDR_W<'_, L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC> {
+        L1_CACHE_PRELOCK_SCT1_ADDR_W::new(self, 0)
+    }
+}
+#[doc = "L1 Cache prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_prelock_sct1_addr::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_prelock_sct1_addr::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dcache_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_dcache_prelock_sct1_addr::W`](W) writer structure"]
+impl crate::Writable for L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_DCACHE_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_DCACHE_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_dcache_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l1_dcache_prelock_sct_size.rs
@@ -1,0 +1,70 @@
+#[doc = "Register `L1_DCACHE_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L1_DCACHE_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Register `L1_DCACHE_PRELOCK_SCT_SIZE` writer"]
+pub type W = crate::W<L1_DCACHE_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_CACHE_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT0_SIZE` writer - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_CACHE_PRELOCK_SCT0_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 14, u16>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_CACHE_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_CACHE_PRELOCK_SCT1_SIZE` writer - Those bits are used to configure the size of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_CACHE_PRELOCK_SCT1_SIZE_W<'a, REG> = crate::FieldWriter<'a, REG, 14, u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_size(&self) -> L1_CACHE_PRELOCK_SCT0_SIZE_R {
+        L1_CACHE_PRELOCK_SCT0_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_size(&self) -> L1_CACHE_PRELOCK_SCT1_SIZE_R {
+        L1_CACHE_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_DCACHE_PRELOCK_SCT_SIZE")
+            .field(
+                "l1_cache_prelock_sct0_size",
+                &self.l1_cache_prelock_sct0_size(),
+            )
+            .field(
+                "l1_cache_prelock_sct1_size",
+                &self.l1_cache_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct0_size(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT0_SIZE_W<'_, L1_DCACHE_PRELOCK_SCT_SIZE_SPEC> {
+        L1_CACHE_PRELOCK_SCT0_SIZE_W::new(self, 0)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-Cache, which should be used together with L1_CACHE_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_cache_prelock_sct1_size(
+        &mut self,
+    ) -> L1_CACHE_PRELOCK_SCT1_SIZE_W<'_, L1_DCACHE_PRELOCK_SCT_SIZE_SPEC> {
+        L1_CACHE_PRELOCK_SCT1_SIZE_W::new(self, 16)
+    }
+}
+#[doc = "L1 Cache prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_dcache_prelock_sct_size::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_dcache_prelock_sct_size::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_DCACHE_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L1_DCACHE_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_dcache_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L1_DCACHE_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_dcache_prelock_sct_size::W`](W) writer structure"]
+impl crate::Writable for L1_DCACHE_PRELOCK_SCT_SIZE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_DCACHE_PRELOCK_SCT_SIZE to value 0x3fff_3fff"]
+impl crate::Resettable for L1_DCACHE_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0x3fff_3fff;
+}

--- a/esp32h2/src/cache/l1_ibus0_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus0_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS0_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_IBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS0_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_conflict_cnt(&self) -> L1_IBUS0_CONFLICT_CNT_R {
+        L1_IBUS0_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS0_ACS_CONFLICT_CNT")
+            .field("l1_ibus0_conflict_cnt", &self.l1_ibus0_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS0_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS0_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus0_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS0_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS0_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS0_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus0_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus0_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS0_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_IBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS0_HIT_CNT` reader - The register records the number of hits when bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_hit_cnt(&self) -> L1_IBUS0_HIT_CNT_R {
+        L1_IBUS0_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS0_ACS_HIT_CNT")
+            .field("l1_ibus0_hit_cnt", &self.l1_ibus0_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS0_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS0_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus0_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS0_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS0_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS0_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus0_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus0_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS0_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_IBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_IBUS0_MISS_CNT` reader - The register records the number of missing when bus0 accesses L1-ICache0."]
+pub type L1_IBUS0_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus0 accesses L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_miss_cnt(&self) -> L1_IBUS0_MISS_CNT_R {
+        L1_IBUS0_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS0_ACS_MISS_CNT")
+            .field("l1_ibus0_miss_cnt", &self.l1_ibus0_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS0_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS0_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus0_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS0_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS0_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_IBUS0_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus0_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus0_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS0_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_IBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_IBUS0_NXTLVL_CNT` reader - The register records the number of times that L1-ICache accesses L2-Cache due to bus0 accessing L1-ICache0."]
+pub type L1_IBUS0_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-ICache accesses L2-Cache due to bus0 accessing L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_ibus0_nxtlvl_cnt(&self) -> L1_IBUS0_NXTLVL_CNT_R {
+        L1_IBUS0_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS0_ACS_NXTLVL_CNT")
+            .field("l1_ibus0_nxtlvl_cnt", &self.l1_ibus0_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus0_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS0_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS0_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus0_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS0_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS0_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_IBUS0_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus1_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus1_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS1_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_IBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS1_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_conflict_cnt(&self) -> L1_IBUS1_CONFLICT_CNT_R {
+        L1_IBUS1_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS1_ACS_CONFLICT_CNT")
+            .field("l1_ibus1_conflict_cnt", &self.l1_ibus1_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS1_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS1_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus1_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS1_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS1_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS1_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus1_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus1_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS1_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_IBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS1_HIT_CNT` reader - The register records the number of hits when bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_hit_cnt(&self) -> L1_IBUS1_HIT_CNT_R {
+        L1_IBUS1_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS1_ACS_HIT_CNT")
+            .field("l1_ibus1_hit_cnt", &self.l1_ibus1_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS1_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS1_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus1_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS1_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS1_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS1_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus1_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus1_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS1_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_IBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_IBUS1_MISS_CNT` reader - The register records the number of missing when bus1 accesses L1-ICache1."]
+pub type L1_IBUS1_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus1 accesses L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_miss_cnt(&self) -> L1_IBUS1_MISS_CNT_R {
+        L1_IBUS1_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS1_ACS_MISS_CNT")
+            .field("l1_ibus1_miss_cnt", &self.l1_ibus1_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS1_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS1_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus1_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS1_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS1_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_IBUS1_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus1_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus1_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS1_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_IBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_IBUS1_NXTLVL_CNT` reader - The register records the number of times that L1-ICache accesses L2-Cache due to bus1 accessing L1-ICache1."]
+pub type L1_IBUS1_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-ICache accesses L2-Cache due to bus1 accessing L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_ibus1_nxtlvl_cnt(&self) -> L1_IBUS1_NXTLVL_CNT_R {
+        L1_IBUS1_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS1_ACS_NXTLVL_CNT")
+            .field("l1_ibus1_nxtlvl_cnt", &self.l1_ibus1_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus1_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS1_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS1_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus1_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS1_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS1_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_IBUS1_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus2_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus2_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS2_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_IBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS2_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus2 accesses L1-ICache2."]
+pub type L1_IBUS2_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus2 accesses L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_conflict_cnt(&self) -> L1_IBUS2_CONFLICT_CNT_R {
+        L1_IBUS2_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS2_ACS_CONFLICT_CNT")
+            .field("l1_ibus2_conflict_cnt", &self.l1_ibus2_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS2_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS2_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus2_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS2_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS2_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS2_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus2_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus2_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS2_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_IBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS2_HIT_CNT` reader - The register records the number of hits when bus2 accesses L1-ICache2."]
+pub type L1_IBUS2_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus2 accesses L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_hit_cnt(&self) -> L1_IBUS2_HIT_CNT_R {
+        L1_IBUS2_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS2_ACS_HIT_CNT")
+            .field("l1_ibus2_hit_cnt", &self.l1_ibus2_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS2_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS2_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus2_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS2_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS2_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS2_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus2_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus2_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS2_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_IBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_IBUS2_MISS_CNT` reader - The register records the number of missing when bus2 accesses L1-ICache2."]
+pub type L1_IBUS2_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus2 accesses L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_miss_cnt(&self) -> L1_IBUS2_MISS_CNT_R {
+        L1_IBUS2_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS2_ACS_MISS_CNT")
+            .field("l1_ibus2_miss_cnt", &self.l1_ibus2_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS2_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS2_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus2_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS2_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS2_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_IBUS2_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus2_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus2_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS2_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_IBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_IBUS2_NXTLVL_CNT` reader - The register records the number of times that L1-ICache accesses L2-Cache due to bus2 accessing L1-ICache2."]
+pub type L1_IBUS2_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-ICache accesses L2-Cache due to bus2 accessing L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_ibus2_nxtlvl_cnt(&self) -> L1_IBUS2_NXTLVL_CNT_R {
+        L1_IBUS2_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS2_ACS_NXTLVL_CNT")
+            .field("l1_ibus2_nxtlvl_cnt", &self.l1_ibus2_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus2_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS2_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS2_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus2_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS2_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS2_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_IBUS2_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus3_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus3_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS3_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L1_IBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS3_CONFLICT_CNT` reader - The register records the number of access-conflicts when bus3 accesses L1-ICache3."]
+pub type L1_IBUS3_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when bus3 accesses L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_conflict_cnt(&self) -> L1_IBUS3_CONFLICT_CNT_R {
+        L1_IBUS3_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS3_ACS_CONFLICT_CNT")
+            .field("l1_ibus3_conflict_cnt", &self.l1_ibus3_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS3_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS3_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus3_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS3_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS3_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS3_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus3_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus3_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS3_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L1_IBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L1_IBUS3_HIT_CNT` reader - The register records the number of hits when bus3 accesses L1-ICache3."]
+pub type L1_IBUS3_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when bus3 accesses L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_hit_cnt(&self) -> L1_IBUS3_HIT_CNT_R {
+        L1_IBUS3_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS3_ACS_HIT_CNT")
+            .field("l1_ibus3_hit_cnt", &self.l1_ibus3_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS3_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS3_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus3_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS3_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS3_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L1_IBUS3_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus3_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus3_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS3_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L1_IBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L1_IBUS3_MISS_CNT` reader - The register records the number of missing when bus3 accesses L1-ICache3."]
+pub type L1_IBUS3_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when bus3 accesses L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_miss_cnt(&self) -> L1_IBUS3_MISS_CNT_R {
+        L1_IBUS3_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS3_ACS_MISS_CNT")
+            .field("l1_ibus3_miss_cnt", &self.l1_ibus3_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS3_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS3_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus3_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS3_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS3_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L1_IBUS3_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_ibus3_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l1_ibus3_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_IBUS3_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L1_IBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L1_IBUS3_NXTLVL_CNT` reader - The register records the number of times that L1-ICache accesses L2-Cache due to bus3 accessing L1-ICache3."]
+pub type L1_IBUS3_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L1-ICache accesses L2-Cache due to bus3 accessing L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_ibus3_nxtlvl_cnt(&self) -> L1_IBUS3_NXTLVL_CNT_R {
+        L1_IBUS3_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_IBUS3_ACS_NXTLVL_CNT")
+            .field("l1_ibus3_nxtlvl_cnt", &self.l1_ibus3_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L1-ICache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_ibus3_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_IBUS3_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L1_IBUS3_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_ibus3_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L1_IBUS3_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L1_IBUS3_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L1_IBUS3_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE0_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_ADDR` reader - The register records the address of fail-access when cache0 accesses L1-ICache."]
+pub type L1_ICACHE0_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when cache0 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_addr(&self) -> L1_ICACHE0_FAIL_ADDR_R {
+        L1_ICACHE0_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_ACS_FAIL_ADDR")
+            .field("l1_icache0_fail_addr", &self.l1_icache0_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l1_icache0_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L1_ICACHE0_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L1_ICACHE0_FAIL_ID` reader - The register records the ID of fail-access when cache0 accesses L1-ICache."]
+pub type L1_ICACHE0_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE0_FAIL_ATTR` reader - The register records the attribution of fail-access when cache0 accesses L1-ICache."]
+pub type L1_ICACHE0_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when cache0 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_id(&self) -> L1_ICACHE0_FAIL_ID_R {
+        L1_ICACHE0_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when cache0 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache0_fail_attr(&self) -> L1_ICACHE0_FAIL_ATTR_R {
+        L1_ICACHE0_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_ACS_FAIL_ID_ATTR")
+            .field("l1_icache0_fail_id", &self.l1_icache0_fail_id())
+            .field("l1_icache0_fail_attr", &self.l1_icache0_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L1_ICACHE0_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache0_autoload_ctrl.rs
@@ -1,0 +1,90 @@
+#[doc = "Register `L1_ICACHE0_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE0_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L1-ICache0. 1: enable, 0: disable."]
+pub type L1_ICACHE0_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L1-ICache0 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE0_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L1-ICache0. 0: ascending. 1: descending."]
+pub type L1_ICACHE0_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L1-ICache0. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_ICACHE0_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L1-ICache0."]
+pub type L1_ICACHE0_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L1-ICache0."]
+pub type L1_ICACHE0_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_RGID` reader - The bit is used to set the gid of l1 icache0 autoload."]
+pub type L1_ICACHE0_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-ICache0. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_ena(&self) -> L1_ICACHE0_AUTOLOAD_ENA_R {
+        L1_ICACHE0_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L1-ICache0 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_done(&self) -> L1_ICACHE0_AUTOLOAD_DONE_R {
+        L1_ICACHE0_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-ICache0. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_order(&self) -> L1_ICACHE0_AUTOLOAD_ORDER_R {
+        L1_ICACHE0_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-ICache0. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_trigger_mode(&self) -> L1_ICACHE0_AUTOLOAD_TRIGGER_MODE_R {
+        L1_ICACHE0_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct0_ena(&self) -> L1_ICACHE0_AUTOLOAD_SCT0_ENA_R {
+        L1_ICACHE0_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct1_ena(&self) -> L1_ICACHE0_AUTOLOAD_SCT1_ENA_R {
+        L1_ICACHE0_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bits 10:13 - The bit is used to set the gid of l1 icache0 autoload."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_rgid(&self) -> L1_ICACHE0_AUTOLOAD_RGID_R {
+        L1_ICACHE0_AUTOLOAD_RGID_R::new(((self.bits >> 10) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_AUTOLOAD_CTRL")
+            .field("l1_icache0_autoload_ena", &self.l1_icache0_autoload_ena())
+            .field("l1_icache0_autoload_done", &self.l1_icache0_autoload_done())
+            .field(
+                "l1_icache0_autoload_order",
+                &self.l1_icache0_autoload_order(),
+            )
+            .field(
+                "l1_icache0_autoload_trigger_mode",
+                &self.l1_icache0_autoload_trigger_mode(),
+            )
+            .field(
+                "l1_icache0_autoload_sct0_ena",
+                &self.l1_icache0_autoload_sct0_ena(),
+            )
+            .field(
+                "l1_icache0_autoload_sct1_ena",
+                &self.l1_icache0_autoload_sct1_ena(),
+            )
+            .field("l1_icache0_autoload_rgid", &self.l1_icache0_autoload_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE0_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache0_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_autoload_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE0_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct0_addr(&self) -> L1_ICACHE0_AUTOLOAD_SCT0_ADDR_R {
+        L1_ICACHE0_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l1_icache0_autoload_sct0_addr",
+                &self.l1_icache0_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l1_icache0_autoload_sct0_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE0_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct0_size(&self) -> L1_ICACHE0_AUTOLOAD_SCT0_SIZE_R {
+        L1_ICACHE0_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l1_icache0_autoload_sct0_size",
+                &self.l1_icache0_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct0_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE0_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_autoload_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE0_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct1_addr(&self) -> L1_ICACHE0_AUTOLOAD_SCT1_ADDR_R {
+        L1_ICACHE0_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l1_icache0_autoload_sct1_addr",
+                &self.l1_icache0_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l1_icache0_autoload_sct1_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE0_AUTOLOAD_SCT1_SIZE` reader - Those bits are used to configure the size of the second section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE0_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L1-ICache0. Note that it should be used together with L1_ICACHE0_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache0_autoload_sct1_size(&self) -> L1_ICACHE0_AUTOLOAD_SCT1_SIZE_R {
+        L1_ICACHE0_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l1_icache0_autoload_sct1_size",
+                &self.l1_icache0_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_autoload_sct1_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE0_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_preload_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_preload_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE0_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L1-ICache0, which should be used together with L1_ICACHE0_PRELOAD_SIZE_REG"]
+pub type L1_ICACHE0_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-ICache0, which should be used together with L1_ICACHE0_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_preload_addr(&self) -> L1_ICACHE0_PRELOAD_ADDR_R {
+        L1_ICACHE0_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOAD_ADDR")
+            .field("l1_icache0_preload_addr", &self.l1_icache0_preload_addr())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOAD_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_preload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache0_preload_ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `L1_ICACHE0_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L1_ICACHE0_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L1_ICACHE0_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOAD_ENA` reader - The bit is used to enable preload operation on L1-ICache0. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE0_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PRELOAD_ENA` writer - The bit is used to enable preload operation on L1-ICache0. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE0_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE0_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE0_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_ICACHE0_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PRELOAD_RGID` reader - The bit is used to set the gid of l1 icache0 preload."]
+pub type L1_ICACHE0_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache0. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_preload_ena(&self) -> L1_ICACHE0_PRELOAD_ENA_R {
+        L1_ICACHE0_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache0_preload_done(&self) -> L1_ICACHE0_PRELOAD_DONE_R {
+        L1_ICACHE0_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache0_preload_order(&self) -> L1_ICACHE0_PRELOAD_ORDER_R {
+        L1_ICACHE0_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l1 icache0 preload."]
+    #[inline(always)]
+    pub fn l1_icache0_preload_rgid(&self) -> L1_ICACHE0_PRELOAD_RGID_R {
+        L1_ICACHE0_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOAD_CTRL")
+            .field("l1_icache0_preload_ena", &self.l1_icache0_preload_ena())
+            .field("l1_icache0_preload_done", &self.l1_icache0_preload_done())
+            .field("l1_icache0_preload_order", &self.l1_icache0_preload_order())
+            .field("l1_icache0_preload_rgid", &self.l1_icache0_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache0. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache0_preload_ena(
+        &mut self,
+    ) -> L1_ICACHE0_PRELOAD_ENA_W<'_, L1_ICACHE0_PRELOAD_CTRL_SPEC> {
+        L1_ICACHE0_PRELOAD_ENA_W::new(self, 0)
+    }
+}
+#[doc = "L1 instruction Cache 0 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache0_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_icache0_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_ICACHE0_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE0_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache0_preload_size.rs
+++ b/esp32h2/src/cache/l1_icache0_preload_size.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE0_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOAD_ADDR_REG"]
+pub type L1_ICACHE0_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_preload_size(&self) -> L1_ICACHE0_PRELOAD_SIZE_R {
+        L1_ICACHE0_PRELOAD_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOAD_SIZE")
+            .field("l1_icache0_preload_size", &self.l1_icache0_preload_size())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_preload_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_preload_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOAD_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE0_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_prelock_conf.rs
+++ b/esp32h2/src/cache/l1_icache0_prelock_conf.rs
@@ -1,0 +1,50 @@
+#[doc = "Register `L1_ICACHE0_PRELOCK_CONF` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L1-ICache0."]
+pub type L1_ICACHE0_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L1-ICache0."]
+pub type L1_ICACHE0_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE0_PRELOCK_RGID` reader - The bit is used to set the gid of l1 icache0 prelock."]
+pub type L1_ICACHE0_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct0_en(&self) -> L1_ICACHE0_PRELOCK_SCT0_EN_R {
+        L1_ICACHE0_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-ICache0."]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct1_en(&self) -> L1_ICACHE0_PRELOCK_SCT1_EN_R {
+        L1_ICACHE0_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l1 icache0 prelock."]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_rgid(&self) -> L1_ICACHE0_PRELOCK_RGID_R {
+        L1_ICACHE0_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOCK_CONF")
+            .field(
+                "l1_icache0_prelock_sct0_en",
+                &self.l1_icache0_prelock_sct0_en(),
+            )
+            .field(
+                "l1_icache0_prelock_sct1_en",
+                &self.l1_icache0_prelock_sct1_en(),
+            )
+            .field("l1_icache0_prelock_rgid", &self.l1_icache0_prelock_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOCK_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE0_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_prelock_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_ICACHE0_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct0_addr(&self) -> L1_ICACHE0_PRELOCK_SCT0_ADDR_R {
+        L1_ICACHE0_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOCK_SCT0_ADDR")
+            .field(
+                "l1_icache0_prelock_sct0_addr",
+                &self.l1_icache0_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache0_prelock_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE0_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_ICACHE0_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct1_addr(&self) -> L1_ICACHE0_PRELOCK_SCT1_ADDR_R {
+        L1_ICACHE0_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOCK_SCT1_ADDR")
+            .field(
+                "l1_icache0_prelock_sct1_addr",
+                &self.l1_icache0_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE0_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache0_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l1_icache0_prelock_sct_size.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L1_ICACHE0_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_ICACHE0_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE0_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_ICACHE0_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct0_size(&self) -> L1_ICACHE0_PRELOCK_SCT0_SIZE_R {
+        L1_ICACHE0_PRELOCK_SCT0_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-ICache0, which should be used together with L1_ICACHE0_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache0_prelock_sct1_size(&self) -> L1_ICACHE0_PRELOCK_SCT1_SIZE_R {
+        L1_ICACHE0_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE0_PRELOCK_SCT_SIZE")
+            .field(
+                "l1_icache0_prelock_sct0_size",
+                &self.l1_icache0_prelock_sct0_size(),
+            )
+            .field(
+                "l1_icache0_prelock_sct1_size",
+                &self.l1_icache0_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 0 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache0_prelock_sct_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache0_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE0_PRELOCK_SCT_SIZE to value 0x3fff_3fff"]
+impl crate::Resettable for L1_ICACHE0_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0x3fff_3fff;
+}

--- a/esp32h2/src/cache/l1_icache1_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE1_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_FAIL_ADDR` reader - The register records the address of fail-access when cache1 accesses L1-ICache."]
+pub type L1_ICACHE1_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when cache1 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_addr(&self) -> L1_ICACHE1_FAIL_ADDR_R {
+        L1_ICACHE1_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_ACS_FAIL_ADDR")
+            .field("l1_icache1_fail_addr", &self.l1_icache1_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l1_icache1_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L1_ICACHE1_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L1_ICACHE1_FAIL_ID` reader - The register records the ID of fail-access when cache1 accesses L1-ICache."]
+pub type L1_ICACHE1_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE1_FAIL_ATTR` reader - The register records the attribution of fail-access when cache1 accesses L1-ICache."]
+pub type L1_ICACHE1_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when cache1 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_id(&self) -> L1_ICACHE1_FAIL_ID_R {
+        L1_ICACHE1_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when cache1 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache1_fail_attr(&self) -> L1_ICACHE1_FAIL_ATTR_R {
+        L1_ICACHE1_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_ACS_FAIL_ID_ATTR")
+            .field("l1_icache1_fail_id", &self.l1_icache1_fail_id())
+            .field("l1_icache1_fail_attr", &self.l1_icache1_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L1_ICACHE1_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache1_autoload_ctrl.rs
@@ -1,0 +1,90 @@
+#[doc = "Register `L1_ICACHE1_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE1_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L1-ICache1. 1: enable, 0: disable."]
+pub type L1_ICACHE1_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L1-ICache1 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE1_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L1-ICache1. 0: ascending. 1: descending."]
+pub type L1_ICACHE1_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L1-ICache1. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_ICACHE1_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L1-ICache1."]
+pub type L1_ICACHE1_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L1-ICache1."]
+pub type L1_ICACHE1_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_RGID` reader - The bit is used to set the gid of l1 icache1 autoload."]
+pub type L1_ICACHE1_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-ICache1. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_ena(&self) -> L1_ICACHE1_AUTOLOAD_ENA_R {
+        L1_ICACHE1_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L1-ICache1 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_done(&self) -> L1_ICACHE1_AUTOLOAD_DONE_R {
+        L1_ICACHE1_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-ICache1. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_order(&self) -> L1_ICACHE1_AUTOLOAD_ORDER_R {
+        L1_ICACHE1_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-ICache1. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_trigger_mode(&self) -> L1_ICACHE1_AUTOLOAD_TRIGGER_MODE_R {
+        L1_ICACHE1_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct0_ena(&self) -> L1_ICACHE1_AUTOLOAD_SCT0_ENA_R {
+        L1_ICACHE1_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct1_ena(&self) -> L1_ICACHE1_AUTOLOAD_SCT1_ENA_R {
+        L1_ICACHE1_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bits 10:13 - The bit is used to set the gid of l1 icache1 autoload."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_rgid(&self) -> L1_ICACHE1_AUTOLOAD_RGID_R {
+        L1_ICACHE1_AUTOLOAD_RGID_R::new(((self.bits >> 10) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_AUTOLOAD_CTRL")
+            .field("l1_icache1_autoload_ena", &self.l1_icache1_autoload_ena())
+            .field("l1_icache1_autoload_done", &self.l1_icache1_autoload_done())
+            .field(
+                "l1_icache1_autoload_order",
+                &self.l1_icache1_autoload_order(),
+            )
+            .field(
+                "l1_icache1_autoload_trigger_mode",
+                &self.l1_icache1_autoload_trigger_mode(),
+            )
+            .field(
+                "l1_icache1_autoload_sct0_ena",
+                &self.l1_icache1_autoload_sct0_ena(),
+            )
+            .field(
+                "l1_icache1_autoload_sct1_ena",
+                &self.l1_icache1_autoload_sct1_ena(),
+            )
+            .field("l1_icache1_autoload_rgid", &self.l1_icache1_autoload_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE1_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache1_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_autoload_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE1_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct0_addr(&self) -> L1_ICACHE1_AUTOLOAD_SCT0_ADDR_R {
+        L1_ICACHE1_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l1_icache1_autoload_sct0_addr",
+                &self.l1_icache1_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l1_icache1_autoload_sct0_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE1_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct0_size(&self) -> L1_ICACHE1_AUTOLOAD_SCT0_SIZE_R {
+        L1_ICACHE1_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l1_icache1_autoload_sct0_size",
+                &self.l1_icache1_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct0_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE1_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_autoload_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE1_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct1_addr(&self) -> L1_ICACHE1_AUTOLOAD_SCT1_ADDR_R {
+        L1_ICACHE1_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l1_icache1_autoload_sct1_addr",
+                &self.l1_icache1_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l1_icache1_autoload_sct1_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE1_AUTOLOAD_SCT1_SIZE` reader - Those bits are used to configure the size of the second section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE1_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L1-ICache1. Note that it should be used together with L1_ICACHE1_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache1_autoload_sct1_size(&self) -> L1_ICACHE1_AUTOLOAD_SCT1_SIZE_R {
+        L1_ICACHE1_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l1_icache1_autoload_sct1_size",
+                &self.l1_icache1_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_autoload_sct1_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE1_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_preload_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_preload_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE1_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L1-ICache1, which should be used together with L1_ICACHE1_PRELOAD_SIZE_REG"]
+pub type L1_ICACHE1_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-ICache1, which should be used together with L1_ICACHE1_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_preload_addr(&self) -> L1_ICACHE1_PRELOAD_ADDR_R {
+        L1_ICACHE1_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOAD_ADDR")
+            .field("l1_icache1_preload_addr", &self.l1_icache1_preload_addr())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOAD_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_preload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache1_preload_ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `L1_ICACHE1_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L1_ICACHE1_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L1_ICACHE1_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOAD_ENA` reader - The bit is used to enable preload operation on L1-ICache1. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE1_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PRELOAD_ENA` writer - The bit is used to enable preload operation on L1-ICache1. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE1_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE1_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE1_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_ICACHE1_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PRELOAD_RGID` reader - The bit is used to set the gid of l1 icache1 preload."]
+pub type L1_ICACHE1_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache1. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_preload_ena(&self) -> L1_ICACHE1_PRELOAD_ENA_R {
+        L1_ICACHE1_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache1_preload_done(&self) -> L1_ICACHE1_PRELOAD_DONE_R {
+        L1_ICACHE1_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache1_preload_order(&self) -> L1_ICACHE1_PRELOAD_ORDER_R {
+        L1_ICACHE1_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l1 icache1 preload."]
+    #[inline(always)]
+    pub fn l1_icache1_preload_rgid(&self) -> L1_ICACHE1_PRELOAD_RGID_R {
+        L1_ICACHE1_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOAD_CTRL")
+            .field("l1_icache1_preload_ena", &self.l1_icache1_preload_ena())
+            .field("l1_icache1_preload_done", &self.l1_icache1_preload_done())
+            .field("l1_icache1_preload_order", &self.l1_icache1_preload_order())
+            .field("l1_icache1_preload_rgid", &self.l1_icache1_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache1. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache1_preload_ena(
+        &mut self,
+    ) -> L1_ICACHE1_PRELOAD_ENA_W<'_, L1_ICACHE1_PRELOAD_CTRL_SPEC> {
+        L1_ICACHE1_PRELOAD_ENA_W::new(self, 0)
+    }
+}
+#[doc = "L1 instruction Cache 1 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache1_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_icache1_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_ICACHE1_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE1_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache1_preload_size.rs
+++ b/esp32h2/src/cache/l1_icache1_preload_size.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE1_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOAD_ADDR_REG"]
+pub type L1_ICACHE1_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_preload_size(&self) -> L1_ICACHE1_PRELOAD_SIZE_R {
+        L1_ICACHE1_PRELOAD_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOAD_SIZE")
+            .field("l1_icache1_preload_size", &self.l1_icache1_preload_size())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_preload_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_preload_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOAD_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE1_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_prelock_conf.rs
+++ b/esp32h2/src/cache/l1_icache1_prelock_conf.rs
@@ -1,0 +1,50 @@
+#[doc = "Register `L1_ICACHE1_PRELOCK_CONF` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L1-ICache1."]
+pub type L1_ICACHE1_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L1-ICache1."]
+pub type L1_ICACHE1_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_PRELOCK_RGID` reader - The bit is used to set the gid of l1 icache1 prelock."]
+pub type L1_ICACHE1_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct0_en(&self) -> L1_ICACHE1_PRELOCK_SCT0_EN_R {
+        L1_ICACHE1_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-ICache1."]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct1_en(&self) -> L1_ICACHE1_PRELOCK_SCT1_EN_R {
+        L1_ICACHE1_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l1 icache1 prelock."]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_rgid(&self) -> L1_ICACHE1_PRELOCK_RGID_R {
+        L1_ICACHE1_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOCK_CONF")
+            .field(
+                "l1_icache1_prelock_sct0_en",
+                &self.l1_icache1_prelock_sct0_en(),
+            )
+            .field(
+                "l1_icache1_prelock_sct1_en",
+                &self.l1_icache1_prelock_sct1_en(),
+            )
+            .field("l1_icache1_prelock_rgid", &self.l1_icache1_prelock_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOCK_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE1_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_prelock_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_ICACHE1_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct0_addr(&self) -> L1_ICACHE1_PRELOCK_SCT0_ADDR_R {
+        L1_ICACHE1_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOCK_SCT0_ADDR")
+            .field(
+                "l1_icache1_prelock_sct0_addr",
+                &self.l1_icache1_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache1_prelock_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE1_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_ICACHE1_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct1_addr(&self) -> L1_ICACHE1_PRELOCK_SCT1_ADDR_R {
+        L1_ICACHE1_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOCK_SCT1_ADDR")
+            .field(
+                "l1_icache1_prelock_sct1_addr",
+                &self.l1_icache1_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE1_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache1_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l1_icache1_prelock_sct_size.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L1_ICACHE1_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_ICACHE1_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE1_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_ICACHE1_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct0_size(&self) -> L1_ICACHE1_PRELOCK_SCT0_SIZE_R {
+        L1_ICACHE1_PRELOCK_SCT0_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-ICache1, which should be used together with L1_ICACHE1_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache1_prelock_sct1_size(&self) -> L1_ICACHE1_PRELOCK_SCT1_SIZE_R {
+        L1_ICACHE1_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE1_PRELOCK_SCT_SIZE")
+            .field(
+                "l1_icache1_prelock_sct0_size",
+                &self.l1_icache1_prelock_sct0_size(),
+            )
+            .field(
+                "l1_icache1_prelock_sct1_size",
+                &self.l1_icache1_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 1 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache1_prelock_sct_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache1_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE1_PRELOCK_SCT_SIZE to value 0x3fff_3fff"]
+impl crate::Resettable for L1_ICACHE1_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0x3fff_3fff;
+}

--- a/esp32h2/src/cache/l1_icache2_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE2_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_FAIL_ADDR` reader - The register records the address of fail-access when cache2 accesses L1-ICache."]
+pub type L1_ICACHE2_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when cache2 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache2_fail_addr(&self) -> L1_ICACHE2_FAIL_ADDR_R {
+        L1_ICACHE2_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_ACS_FAIL_ADDR")
+            .field("l1_icache2_fail_addr", &self.l1_icache2_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l1_icache2_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L1_ICACHE2_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L1_ICACHE2_FAIL_ID` reader - The register records the ID of fail-access when cache2 accesses L1-ICache."]
+pub type L1_ICACHE2_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE2_FAIL_ATTR` reader - The register records the attribution of fail-access when cache2 accesses L1-ICache."]
+pub type L1_ICACHE2_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when cache2 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache2_fail_id(&self) -> L1_ICACHE2_FAIL_ID_R {
+        L1_ICACHE2_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when cache2 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache2_fail_attr(&self) -> L1_ICACHE2_FAIL_ATTR_R {
+        L1_ICACHE2_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_ACS_FAIL_ID_ATTR")
+            .field("l1_icache2_fail_id", &self.l1_icache2_fail_id())
+            .field("l1_icache2_fail_attr", &self.l1_icache2_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L1_ICACHE2_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache2_autoload_ctrl.rs
@@ -1,0 +1,90 @@
+#[doc = "Register `L1_ICACHE2_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE2_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L1-ICache2. 1: enable, 0: disable."]
+pub type L1_ICACHE2_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L1-ICache2 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE2_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L1-ICache2. 0: ascending. 1: descending."]
+pub type L1_ICACHE2_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L1-ICache2. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_ICACHE2_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L1-ICache2."]
+pub type L1_ICACHE2_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L1-ICache2."]
+pub type L1_ICACHE2_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_RGID` reader - The bit is used to set the gid of l1 icache2 autoload."]
+pub type L1_ICACHE2_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-ICache2. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_ena(&self) -> L1_ICACHE2_AUTOLOAD_ENA_R {
+        L1_ICACHE2_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L1-ICache2 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_done(&self) -> L1_ICACHE2_AUTOLOAD_DONE_R {
+        L1_ICACHE2_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-ICache2. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_order(&self) -> L1_ICACHE2_AUTOLOAD_ORDER_R {
+        L1_ICACHE2_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-ICache2. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_trigger_mode(&self) -> L1_ICACHE2_AUTOLOAD_TRIGGER_MODE_R {
+        L1_ICACHE2_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct0_ena(&self) -> L1_ICACHE2_AUTOLOAD_SCT0_ENA_R {
+        L1_ICACHE2_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct1_ena(&self) -> L1_ICACHE2_AUTOLOAD_SCT1_ENA_R {
+        L1_ICACHE2_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bits 10:13 - The bit is used to set the gid of l1 icache2 autoload."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_rgid(&self) -> L1_ICACHE2_AUTOLOAD_RGID_R {
+        L1_ICACHE2_AUTOLOAD_RGID_R::new(((self.bits >> 10) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_AUTOLOAD_CTRL")
+            .field("l1_icache2_autoload_ena", &self.l1_icache2_autoload_ena())
+            .field("l1_icache2_autoload_done", &self.l1_icache2_autoload_done())
+            .field(
+                "l1_icache2_autoload_order",
+                &self.l1_icache2_autoload_order(),
+            )
+            .field(
+                "l1_icache2_autoload_trigger_mode",
+                &self.l1_icache2_autoload_trigger_mode(),
+            )
+            .field(
+                "l1_icache2_autoload_sct0_ena",
+                &self.l1_icache2_autoload_sct0_ena(),
+            )
+            .field(
+                "l1_icache2_autoload_sct1_ena",
+                &self.l1_icache2_autoload_sct1_ena(),
+            )
+            .field("l1_icache2_autoload_rgid", &self.l1_icache2_autoload_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE2_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache2_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_autoload_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE2_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct0_addr(&self) -> L1_ICACHE2_AUTOLOAD_SCT0_ADDR_R {
+        L1_ICACHE2_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l1_icache2_autoload_sct0_addr",
+                &self.l1_icache2_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l1_icache2_autoload_sct0_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE2_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct0_size(&self) -> L1_ICACHE2_AUTOLOAD_SCT0_SIZE_R {
+        L1_ICACHE2_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l1_icache2_autoload_sct0_size",
+                &self.l1_icache2_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct0_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE2_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_autoload_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE2_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct1_addr(&self) -> L1_ICACHE2_AUTOLOAD_SCT1_ADDR_R {
+        L1_ICACHE2_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l1_icache2_autoload_sct1_addr",
+                &self.l1_icache2_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l1_icache2_autoload_sct1_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE2_AUTOLOAD_SCT1_SIZE` reader - Those bits are used to configure the size of the second section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE2_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L1-ICache2. Note that it should be used together with L1_ICACHE2_AUTOLOAD_SCT1_ADDR and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache2_autoload_sct1_size(&self) -> L1_ICACHE2_AUTOLOAD_SCT1_SIZE_R {
+        L1_ICACHE2_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l1_icache2_autoload_sct1_size",
+                &self.l1_icache2_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_autoload_sct1_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE2_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_preload_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_preload_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE2_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L1-ICache2, which should be used together with L1_ICACHE2_PRELOAD_SIZE_REG"]
+pub type L1_ICACHE2_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-ICache2, which should be used together with L1_ICACHE2_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_preload_addr(&self) -> L1_ICACHE2_PRELOAD_ADDR_R {
+        L1_ICACHE2_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOAD_ADDR")
+            .field("l1_icache2_preload_addr", &self.l1_icache2_preload_addr())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOAD_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_preload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache2_preload_ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `L1_ICACHE2_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L1_ICACHE2_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L1_ICACHE2_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOAD_ENA` reader - The bit is used to enable preload operation on L1-ICache2. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE2_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PRELOAD_ENA` writer - The bit is used to enable preload operation on L1-ICache2. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE2_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE2_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE2_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_ICACHE2_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PRELOAD_RGID` reader - The bit is used to set the gid of l1 icache2 preload."]
+pub type L1_ICACHE2_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache2. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache2_preload_ena(&self) -> L1_ICACHE2_PRELOAD_ENA_R {
+        L1_ICACHE2_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache2_preload_done(&self) -> L1_ICACHE2_PRELOAD_DONE_R {
+        L1_ICACHE2_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache2_preload_order(&self) -> L1_ICACHE2_PRELOAD_ORDER_R {
+        L1_ICACHE2_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l1 icache2 preload."]
+    #[inline(always)]
+    pub fn l1_icache2_preload_rgid(&self) -> L1_ICACHE2_PRELOAD_RGID_R {
+        L1_ICACHE2_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOAD_CTRL")
+            .field("l1_icache2_preload_ena", &self.l1_icache2_preload_ena())
+            .field("l1_icache2_preload_done", &self.l1_icache2_preload_done())
+            .field("l1_icache2_preload_order", &self.l1_icache2_preload_order())
+            .field("l1_icache2_preload_rgid", &self.l1_icache2_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache2. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache2_preload_ena(
+        &mut self,
+    ) -> L1_ICACHE2_PRELOAD_ENA_W<'_, L1_ICACHE2_PRELOAD_CTRL_SPEC> {
+        L1_ICACHE2_PRELOAD_ENA_W::new(self, 0)
+    }
+}
+#[doc = "L1 instruction Cache 2 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache2_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_icache2_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_ICACHE2_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE2_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache2_preload_size.rs
+++ b/esp32h2/src/cache/l1_icache2_preload_size.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE2_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOAD_ADDR_REG"]
+pub type L1_ICACHE2_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_preload_size(&self) -> L1_ICACHE2_PRELOAD_SIZE_R {
+        L1_ICACHE2_PRELOAD_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOAD_SIZE")
+            .field("l1_icache2_preload_size", &self.l1_icache2_preload_size())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_preload_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_preload_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOAD_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE2_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_prelock_conf.rs
+++ b/esp32h2/src/cache/l1_icache2_prelock_conf.rs
@@ -1,0 +1,50 @@
+#[doc = "Register `L1_ICACHE2_PRELOCK_CONF` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L1-ICache2."]
+pub type L1_ICACHE2_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L1-ICache2."]
+pub type L1_ICACHE2_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_PRELOCK_RGID` reader - The bit is used to set the gid of l1 icache2 prelock."]
+pub type L1_ICACHE2_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct0_en(&self) -> L1_ICACHE2_PRELOCK_SCT0_EN_R {
+        L1_ICACHE2_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-ICache2."]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct1_en(&self) -> L1_ICACHE2_PRELOCK_SCT1_EN_R {
+        L1_ICACHE2_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l1 icache2 prelock."]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_rgid(&self) -> L1_ICACHE2_PRELOCK_RGID_R {
+        L1_ICACHE2_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOCK_CONF")
+            .field(
+                "l1_icache2_prelock_sct0_en",
+                &self.l1_icache2_prelock_sct0_en(),
+            )
+            .field(
+                "l1_icache2_prelock_sct1_en",
+                &self.l1_icache2_prelock_sct1_en(),
+            )
+            .field("l1_icache2_prelock_rgid", &self.l1_icache2_prelock_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOCK_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE2_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_prelock_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_ICACHE2_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct0_addr(&self) -> L1_ICACHE2_PRELOCK_SCT0_ADDR_R {
+        L1_ICACHE2_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOCK_SCT0_ADDR")
+            .field(
+                "l1_icache2_prelock_sct0_addr",
+                &self.l1_icache2_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache2_prelock_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE2_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_ICACHE2_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct1_addr(&self) -> L1_ICACHE2_PRELOCK_SCT1_ADDR_R {
+        L1_ICACHE2_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOCK_SCT1_ADDR")
+            .field(
+                "l1_icache2_prelock_sct1_addr",
+                &self.l1_icache2_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE2_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache2_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l1_icache2_prelock_sct_size.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L1_ICACHE2_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_ICACHE2_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE2_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_ICACHE2_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct0_size(&self) -> L1_ICACHE2_PRELOCK_SCT0_SIZE_R {
+        L1_ICACHE2_PRELOCK_SCT0_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-ICache2, which should be used together with L1_ICACHE2_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache2_prelock_sct1_size(&self) -> L1_ICACHE2_PRELOCK_SCT1_SIZE_R {
+        L1_ICACHE2_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE2_PRELOCK_SCT_SIZE")
+            .field(
+                "l1_icache2_prelock_sct0_size",
+                &self.l1_icache2_prelock_sct0_size(),
+            )
+            .field(
+                "l1_icache2_prelock_sct1_size",
+                &self.l1_icache2_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 2 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache2_prelock_sct_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache2_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE2_PRELOCK_SCT_SIZE to value 0x3fff_3fff"]
+impl crate::Resettable for L1_ICACHE2_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0x3fff_3fff;
+}

--- a/esp32h2/src/cache/l1_icache3_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE3_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_FAIL_ADDR` reader - The register records the address of fail-access when cache3 accesses L1-ICache."]
+pub type L1_ICACHE3_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when cache3 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache3_fail_addr(&self) -> L1_ICACHE3_FAIL_ADDR_R {
+        L1_ICACHE3_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_ACS_FAIL_ADDR")
+            .field("l1_icache3_fail_addr", &self.l1_icache3_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l1_icache3_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L1_ICACHE3_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L1_ICACHE3_FAIL_ID` reader - The register records the ID of fail-access when cache3 accesses L1-ICache."]
+pub type L1_ICACHE3_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE3_FAIL_ATTR` reader - The register records the attribution of fail-access when cache3 accesses L1-ICache."]
+pub type L1_ICACHE3_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when cache3 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache3_fail_id(&self) -> L1_ICACHE3_FAIL_ID_R {
+        L1_ICACHE3_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when cache3 accesses L1-ICache."]
+    #[inline(always)]
+    pub fn l1_icache3_fail_attr(&self) -> L1_ICACHE3_FAIL_ATTR_R {
+        L1_ICACHE3_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_ACS_FAIL_ID_ATTR")
+            .field("l1_icache3_fail_id", &self.l1_icache3_fail_id())
+            .field("l1_icache3_fail_attr", &self.l1_icache3_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L1-ICache0 Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L1_ICACHE3_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache3_autoload_ctrl.rs
@@ -1,0 +1,90 @@
+#[doc = "Register `L1_ICACHE3_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE3_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L1-ICache3. 1: enable, 0: disable."]
+pub type L1_ICACHE3_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L1-ICache3 is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE3_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L1-ICache3. 0: ascending. 1: descending."]
+pub type L1_ICACHE3_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L1-ICache3. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L1_ICACHE3_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L1-ICache3."]
+pub type L1_ICACHE3_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L1-ICache3."]
+pub type L1_ICACHE3_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_RGID` reader - The bit is used to set the gid of l1 icache3 autoload."]
+pub type L1_ICACHE3_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L1-ICache3. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_ena(&self) -> L1_ICACHE3_AUTOLOAD_ENA_R {
+        L1_ICACHE3_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L1-ICache3 is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_done(&self) -> L1_ICACHE3_AUTOLOAD_DONE_R {
+        L1_ICACHE3_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L1-ICache3. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_order(&self) -> L1_ICACHE3_AUTOLOAD_ORDER_R {
+        L1_ICACHE3_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L1-ICache3. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_trigger_mode(&self) -> L1_ICACHE3_AUTOLOAD_TRIGGER_MODE_R {
+        L1_ICACHE3_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct0_ena(&self) -> L1_ICACHE3_AUTOLOAD_SCT0_ENA_R {
+        L1_ICACHE3_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct1_ena(&self) -> L1_ICACHE3_AUTOLOAD_SCT1_ENA_R {
+        L1_ICACHE3_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bits 10:13 - The bit is used to set the gid of l1 icache3 autoload."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_rgid(&self) -> L1_ICACHE3_AUTOLOAD_RGID_R {
+        L1_ICACHE3_AUTOLOAD_RGID_R::new(((self.bits >> 10) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_AUTOLOAD_CTRL")
+            .field("l1_icache3_autoload_ena", &self.l1_icache3_autoload_ena())
+            .field("l1_icache3_autoload_done", &self.l1_icache3_autoload_done())
+            .field(
+                "l1_icache3_autoload_order",
+                &self.l1_icache3_autoload_order(),
+            )
+            .field(
+                "l1_icache3_autoload_trigger_mode",
+                &self.l1_icache3_autoload_trigger_mode(),
+            )
+            .field(
+                "l1_icache3_autoload_sct0_ena",
+                &self.l1_icache3_autoload_sct0_ena(),
+            )
+            .field(
+                "l1_icache3_autoload_sct1_ena",
+                &self.l1_icache3_autoload_sct1_ena(),
+            )
+            .field("l1_icache3_autoload_rgid", &self.l1_icache3_autoload_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE3_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache3_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_autoload_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE3_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT0_SIZE and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct0_addr(&self) -> L1_ICACHE3_AUTOLOAD_SCT0_ADDR_R {
+        L1_ICACHE3_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l1_icache3_autoload_sct0_addr",
+                &self.l1_icache3_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l1_icache3_autoload_sct0_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+pub type L1_ICACHE3_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT0_ADDR and L1_ICACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct0_size(&self) -> L1_ICACHE3_AUTOLOAD_SCT0_SIZE_R {
+        L1_ICACHE3_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l1_icache3_autoload_sct0_size",
+                &self.l1_icache3_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct0_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE3_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_autoload_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+pub type L1_ICACHE3_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L1-ICache3. Note that it should be used together with L1_ICACHE3_AUTOLOAD_SCT1_SIZE and L1_ICACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct1_addr(&self) -> L1_ICACHE3_AUTOLOAD_SCT1_ADDR_R {
+        L1_ICACHE3_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l1_icache3_autoload_sct1_addr",
+                &self.l1_icache3_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l1_icache3_autoload_sct1_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE3_AUTOLOAD_SCT1_SIZE` reader - Reserved"]
+pub type L1_ICACHE3_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_autoload_sct1_size(&self) -> L1_ICACHE3_AUTOLOAD_SCT1_SIZE_R {
+        L1_ICACHE3_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l1_icache3_autoload_sct1_size",
+                &self.l1_icache3_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_autoload_sct1_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE3_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_preload_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_preload_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE3_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L1-ICache3, which should be used together with L1_ICACHE3_PRELOAD_SIZE_REG"]
+pub type L1_ICACHE3_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L1-ICache3, which should be used together with L1_ICACHE3_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_preload_addr(&self) -> L1_ICACHE3_PRELOAD_ADDR_R {
+        L1_ICACHE3_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOAD_ADDR")
+            .field("l1_icache3_preload_addr", &self.l1_icache3_preload_addr())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOAD_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_preload_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache3_preload_ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `L1_ICACHE3_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L1_ICACHE3_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L1_ICACHE3_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOAD_ENA` reader - The bit is used to enable preload operation on L1-ICache3. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE3_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PRELOAD_ENA` writer - The bit is used to enable preload operation on L1-ICache3. It will be cleared by hardware automatically after preload operation is done."]
+pub type L1_ICACHE3_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L1_ICACHE3_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L1_ICACHE3_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L1_ICACHE3_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PRELOAD_RGID` reader - The bit is used to set the gid of l1 icache3 preload."]
+pub type L1_ICACHE3_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache3. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache3_preload_ena(&self) -> L1_ICACHE3_PRELOAD_ENA_R {
+        L1_ICACHE3_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l1_icache3_preload_done(&self) -> L1_ICACHE3_PRELOAD_DONE_R {
+        L1_ICACHE3_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l1_icache3_preload_order(&self) -> L1_ICACHE3_PRELOAD_ORDER_R {
+        L1_ICACHE3_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l1 icache3 preload."]
+    #[inline(always)]
+    pub fn l1_icache3_preload_rgid(&self) -> L1_ICACHE3_PRELOAD_RGID_R {
+        L1_ICACHE3_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOAD_CTRL")
+            .field("l1_icache3_preload_ena", &self.l1_icache3_preload_ena())
+            .field("l1_icache3_preload_done", &self.l1_icache3_preload_done())
+            .field("l1_icache3_preload_order", &self.l1_icache3_preload_order())
+            .field("l1_icache3_preload_rgid", &self.l1_icache3_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L1-ICache3. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l1_icache3_preload_ena(
+        &mut self,
+    ) -> L1_ICACHE3_PRELOAD_ENA_W<'_, L1_ICACHE3_PRELOAD_CTRL_SPEC> {
+        L1_ICACHE3_PRELOAD_ENA_W::new(self, 0)
+    }
+}
+#[doc = "L1 instruction Cache 3 preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_icache3_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_icache3_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L1_ICACHE3_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L1_ICACHE3_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l1_icache3_preload_size.rs
+++ b/esp32h2/src/cache/l1_icache3_preload_size.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L1_ICACHE3_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOAD_ADDR_REG"]
+pub type L1_ICACHE3_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_preload_size(&self) -> L1_ICACHE3_PRELOAD_SIZE_R {
+        L1_ICACHE3_PRELOAD_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOAD_SIZE")
+            .field("l1_icache3_preload_size", &self.l1_icache3_preload_size())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_preload_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_preload_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOAD_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L1_ICACHE3_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_prelock_conf.rs
+++ b/esp32h2/src/cache/l1_icache3_prelock_conf.rs
@@ -1,0 +1,50 @@
+#[doc = "Register `L1_ICACHE3_PRELOCK_CONF` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L1-ICache3."]
+pub type L1_ICACHE3_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L1-ICache3."]
+pub type L1_ICACHE3_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_PRELOCK_RGID` reader - The bit is used to set the gid of l1 icache3 prelock."]
+pub type L1_ICACHE3_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct0_en(&self) -> L1_ICACHE3_PRELOCK_SCT0_EN_R {
+        L1_ICACHE3_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L1-ICache3."]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct1_en(&self) -> L1_ICACHE3_PRELOCK_SCT1_EN_R {
+        L1_ICACHE3_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l1 icache3 prelock."]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_rgid(&self) -> L1_ICACHE3_PRELOCK_RGID_R {
+        L1_ICACHE3_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOCK_CONF")
+            .field(
+                "l1_icache3_prelock_sct0_en",
+                &self.l1_icache3_prelock_sct0_en(),
+            )
+            .field(
+                "l1_icache3_prelock_sct1_en",
+                &self.l1_icache3_prelock_sct1_en(),
+            )
+            .field("l1_icache3_prelock_rgid", &self.l1_icache3_prelock_rgid())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOCK_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE3_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_prelock_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT0_SIZE_REG"]
+pub type L1_ICACHE3_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct0_addr(&self) -> L1_ICACHE3_PRELOCK_SCT0_ADDR_R {
+        L1_ICACHE3_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOCK_SCT0_ADDR")
+            .field(
+                "l1_icache3_prelock_sct0_addr",
+                &self.l1_icache3_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l1_icache3_prelock_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L1_ICACHE3_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT1_SIZE_REG"]
+pub type L1_ICACHE3_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct1_addr(&self) -> L1_ICACHE3_PRELOCK_SCT1_ADDR_R {
+        L1_ICACHE3_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOCK_SCT1_ADDR")
+            .field(
+                "l1_icache3_prelock_sct1_addr",
+                &self.l1_icache3_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L1_ICACHE3_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l1_icache3_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l1_icache3_prelock_sct_size.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L1_ICACHE3_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT0_ADDR_REG"]
+pub type L1_ICACHE3_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L1_ICACHE3_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT1_ADDR_REG"]
+pub type L1_ICACHE3_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:13 - Those bits are used to configure the size of the first section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct0_size(&self) -> L1_ICACHE3_PRELOCK_SCT0_SIZE_R {
+        L1_ICACHE3_PRELOCK_SCT0_SIZE_R::new((self.bits & 0x3fff) as u16)
+    }
+    #[doc = "Bits 16:29 - Those bits are used to configure the size of the second section of prelock on L1-ICache3, which should be used together with L1_ICACHE3_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l1_icache3_prelock_sct1_size(&self) -> L1_ICACHE3_PRELOCK_SCT1_SIZE_R {
+        L1_ICACHE3_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0x3fff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE3_PRELOCK_SCT_SIZE")
+            .field(
+                "l1_icache3_prelock_sct0_size",
+                &self.l1_icache3_prelock_sct0_size(),
+            )
+            .field(
+                "l1_icache3_prelock_sct1_size",
+                &self.l1_icache3_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache 3 prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache3_prelock_sct_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache3_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE3_PRELOCK_SCT_SIZE to value 0x3fff_3fff"]
+impl crate::Resettable for L1_ICACHE3_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0x3fff_3fff;
+}

--- a/esp32h2/src/cache/l1_icache_blocksize_conf.rs
+++ b/esp32h2/src/cache/l1_icache_blocksize_conf.rs
@@ -1,0 +1,68 @@
+#[doc = "Register `L1_ICACHE_BLOCKSIZE_CONF` reader"]
+pub type R = crate::R<L1_ICACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_8` reader - The field is used to configureblocksize of L1-ICache as 8 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_8_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_16` reader - The field is used to configureblocksize of L1-ICache as 16 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_16_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_32` reader - The field is used to configureblocksize of L1-ICache as 32 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_32_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_64` reader - The field is used to configureblocksize of L1-ICache as 64 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_64_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_128` reader - The field is used to configureblocksize of L1-ICache as 128 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_128_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_BLOCKSIZE_256` reader - The field is used to configureblocksize of L1-ICache as 256 bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_BLOCKSIZE_256_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configureblocksize of L1-ICache as 8 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_8(&self) -> L1_ICACHE_BLOCKSIZE_8_R {
+        L1_ICACHE_BLOCKSIZE_8_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configureblocksize of L1-ICache as 16 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_16(&self) -> L1_ICACHE_BLOCKSIZE_16_R {
+        L1_ICACHE_BLOCKSIZE_16_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configureblocksize of L1-ICache as 32 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_32(&self) -> L1_ICACHE_BLOCKSIZE_32_R {
+        L1_ICACHE_BLOCKSIZE_32_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configureblocksize of L1-ICache as 64 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_64(&self) -> L1_ICACHE_BLOCKSIZE_64_R {
+        L1_ICACHE_BLOCKSIZE_64_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configureblocksize of L1-ICache as 128 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_128(&self) -> L1_ICACHE_BLOCKSIZE_128_R {
+        L1_ICACHE_BLOCKSIZE_128_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configureblocksize of L1-ICache as 256 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_blocksize_256(&self) -> L1_ICACHE_BLOCKSIZE_256_R {
+        L1_ICACHE_BLOCKSIZE_256_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE_BLOCKSIZE_CONF")
+            .field("l1_icache_blocksize_8", &self.l1_icache_blocksize_8())
+            .field("l1_icache_blocksize_16", &self.l1_icache_blocksize_16())
+            .field("l1_icache_blocksize_32", &self.l1_icache_blocksize_32())
+            .field("l1_icache_blocksize_64", &self.l1_icache_blocksize_64())
+            .field("l1_icache_blocksize_128", &self.l1_icache_blocksize_128())
+            .field("l1_icache_blocksize_256", &self.l1_icache_blocksize_256())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_blocksize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE_BLOCKSIZE_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE_BLOCKSIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache_blocksize_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE_BLOCKSIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE_BLOCKSIZE_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE_BLOCKSIZE_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache_cachesize_conf.rs
+++ b/esp32h2/src/cache/l1_icache_cachesize_conf.rs
@@ -1,0 +1,133 @@
+#[doc = "Register `L1_ICACHE_CACHESIZE_CONF` reader"]
+pub type R = crate::R<L1_ICACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "Field `L1_ICACHE_CACHESIZE_1K` reader - The field is used to configure cachesize of L1-ICache as 1k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_1K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_2K` reader - The field is used to configure cachesize of L1-ICache as 2k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_2K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_4K` reader - The field is used to configure cachesize of L1-ICache as 4k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_4K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_8K` reader - The field is used to configure cachesize of L1-ICache as 8k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_8K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_16K` reader - The field is used to configure cachesize of L1-ICache as 16k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_16K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_32K` reader - The field is used to configure cachesize of L1-ICache as 32k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_32K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_64K` reader - The field is used to configure cachesize of L1-ICache as 64k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_64K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_128K` reader - The field is used to configure cachesize of L1-ICache as 128k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_128K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_256K` reader - The field is used to configure cachesize of L1-ICache as 256k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_256K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_512K` reader - The field is used to configure cachesize of L1-ICache as 512k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_512K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_1024K` reader - The field is used to configure cachesize of L1-ICache as 1024k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_1024K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_2048K` reader - The field is used to configure cachesize of L1-ICache as 2048k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_2048K_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_CACHESIZE_4096K` reader - The field is used to configure cachesize of L1-ICache as 4096k bytes. This field and all other fields within this register is onehot."]
+pub type L1_ICACHE_CACHESIZE_4096K_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configure cachesize of L1-ICache as 1k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_1k(&self) -> L1_ICACHE_CACHESIZE_1K_R {
+        L1_ICACHE_CACHESIZE_1K_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configure cachesize of L1-ICache as 2k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_2k(&self) -> L1_ICACHE_CACHESIZE_2K_R {
+        L1_ICACHE_CACHESIZE_2K_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configure cachesize of L1-ICache as 4k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_4k(&self) -> L1_ICACHE_CACHESIZE_4K_R {
+        L1_ICACHE_CACHESIZE_4K_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configure cachesize of L1-ICache as 8k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_8k(&self) -> L1_ICACHE_CACHESIZE_8K_R {
+        L1_ICACHE_CACHESIZE_8K_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configure cachesize of L1-ICache as 16k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_16k(&self) -> L1_ICACHE_CACHESIZE_16K_R {
+        L1_ICACHE_CACHESIZE_16K_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configure cachesize of L1-ICache as 32k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_32k(&self) -> L1_ICACHE_CACHESIZE_32K_R {
+        L1_ICACHE_CACHESIZE_32K_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The field is used to configure cachesize of L1-ICache as 64k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_64k(&self) -> L1_ICACHE_CACHESIZE_64K_R {
+        L1_ICACHE_CACHESIZE_64K_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The field is used to configure cachesize of L1-ICache as 128k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_128k(&self) -> L1_ICACHE_CACHESIZE_128K_R {
+        L1_ICACHE_CACHESIZE_128K_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The field is used to configure cachesize of L1-ICache as 256k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_256k(&self) -> L1_ICACHE_CACHESIZE_256K_R {
+        L1_ICACHE_CACHESIZE_256K_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The field is used to configure cachesize of L1-ICache as 512k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_512k(&self) -> L1_ICACHE_CACHESIZE_512K_R {
+        L1_ICACHE_CACHESIZE_512K_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The field is used to configure cachesize of L1-ICache as 1024k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_1024k(&self) -> L1_ICACHE_CACHESIZE_1024K_R {
+        L1_ICACHE_CACHESIZE_1024K_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The field is used to configure cachesize of L1-ICache as 2048k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_2048k(&self) -> L1_ICACHE_CACHESIZE_2048K_R {
+        L1_ICACHE_CACHESIZE_2048K_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The field is used to configure cachesize of L1-ICache as 4096k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l1_icache_cachesize_4096k(&self) -> L1_ICACHE_CACHESIZE_4096K_R {
+        L1_ICACHE_CACHESIZE_4096K_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE_CACHESIZE_CONF")
+            .field("l1_icache_cachesize_1k", &self.l1_icache_cachesize_1k())
+            .field("l1_icache_cachesize_2k", &self.l1_icache_cachesize_2k())
+            .field("l1_icache_cachesize_4k", &self.l1_icache_cachesize_4k())
+            .field("l1_icache_cachesize_8k", &self.l1_icache_cachesize_8k())
+            .field("l1_icache_cachesize_16k", &self.l1_icache_cachesize_16k())
+            .field("l1_icache_cachesize_32k", &self.l1_icache_cachesize_32k())
+            .field("l1_icache_cachesize_64k", &self.l1_icache_cachesize_64k())
+            .field("l1_icache_cachesize_128k", &self.l1_icache_cachesize_128k())
+            .field("l1_icache_cachesize_256k", &self.l1_icache_cachesize_256k())
+            .field("l1_icache_cachesize_512k", &self.l1_icache_cachesize_512k())
+            .field(
+                "l1_icache_cachesize_1024k",
+                &self.l1_icache_cachesize_1024k(),
+            )
+            .field(
+                "l1_icache_cachesize_2048k",
+                &self.l1_icache_cachesize_2048k(),
+            )
+            .field(
+                "l1_icache_cachesize_4096k",
+                &self.l1_icache_cachesize_4096k(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_cachesize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE_CACHESIZE_CONF_SPEC;
+impl crate::RegisterSpec for L1_ICACHE_CACHESIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache_cachesize_conf::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE_CACHESIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE_CACHESIZE_CONF to value 0"]
+impl crate::Resettable for L1_ICACHE_CACHESIZE_CONF_SPEC {}

--- a/esp32h2/src/cache/l1_icache_ctrl.rs
+++ b/esp32h2/src/cache/l1_icache_ctrl.rs
@@ -1,0 +1,60 @@
+#[doc = "Register `L1_ICACHE_CTRL` reader"]
+pub type R = crate::R<L1_ICACHE_CTRL_SPEC>;
+#[doc = "Field `L1_ICACHE_SHUT_IBUS0` reader - The bit is used to disable core0 ibus access L1-ICache, 0: enable, 1: disable"]
+pub type L1_ICACHE_SHUT_IBUS0_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_SHUT_IBUS1` reader - The bit is used to disable core1 ibus access L1-ICache, 0: enable, 1: disable"]
+pub type L1_ICACHE_SHUT_IBUS1_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_SHUT_IBUS2` reader - Reserved"]
+pub type L1_ICACHE_SHUT_IBUS2_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_SHUT_IBUS3` reader - Reserved"]
+pub type L1_ICACHE_SHUT_IBUS3_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE_UNDEF_OP` reader - Reserved"]
+pub type L1_ICACHE_UNDEF_OP_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to disable core0 ibus access L1-ICache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_icache_shut_ibus0(&self) -> L1_ICACHE_SHUT_IBUS0_R {
+        L1_ICACHE_SHUT_IBUS0_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to disable core1 ibus access L1-ICache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l1_icache_shut_ibus1(&self) -> L1_ICACHE_SHUT_IBUS1_R {
+        L1_ICACHE_SHUT_IBUS1_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache_shut_ibus2(&self) -> L1_ICACHE_SHUT_IBUS2_R {
+        L1_ICACHE_SHUT_IBUS2_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache_shut_ibus3(&self) -> L1_ICACHE_SHUT_IBUS3_R {
+        L1_ICACHE_SHUT_IBUS3_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bits 4:7 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache_undef_op(&self) -> L1_ICACHE_UNDEF_OP_R {
+        L1_ICACHE_UNDEF_OP_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_ICACHE_CTRL")
+            .field("l1_icache_shut_ibus0", &self.l1_icache_shut_ibus0())
+            .field("l1_icache_shut_ibus1", &self.l1_icache_shut_ibus1())
+            .field("l1_icache_shut_ibus2", &self.l1_icache_shut_ibus2())
+            .field("l1_icache_shut_ibus3", &self.l1_icache_shut_ibus3())
+            .field("l1_icache_undef_op", &self.l1_icache_undef_op())
+            .finish()
+    }
+}
+#[doc = "L1 instruction Cache(L1-ICache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_icache_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_ICACHE_CTRL_SPEC;
+impl crate::RegisterSpec for L1_ICACHE_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_icache_ctrl::R`](R) reader structure"]
+impl crate::Readable for L1_ICACHE_CTRL_SPEC {}
+#[doc = "`reset()` method sets L1_ICACHE_CTRL to value 0"]
+impl crate::Resettable for L1_ICACHE_CTRL_SPEC {}

--- a/esp32h2/src/cache/l1_unallocate_buffer_clear.rs
+++ b/esp32h2/src/cache/l1_unallocate_buffer_clear.rs
@@ -1,0 +1,77 @@
+#[doc = "Register `L1_UNALLOCATE_BUFFER_CLEAR` reader"]
+pub type R = crate::R<L1_UNALLOCATE_BUFFER_CLEAR_SPEC>;
+#[doc = "Register `L1_UNALLOCATE_BUFFER_CLEAR` writer"]
+pub type W = crate::W<L1_UNALLOCATE_BUFFER_CLEAR_SPEC>;
+#[doc = "Field `L1_ICACHE0_UNALLOC_CLR` reader - The bit is used to clear the unallocate request buffer of l1 icache0 where the unallocate request is responsed but not completed."]
+pub type L1_ICACHE0_UNALLOC_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE1_UNALLOC_CLR` reader - The bit is used to clear the unallocate request buffer of l1 icache1 where the unallocate request is responsed but not completed."]
+pub type L1_ICACHE1_UNALLOC_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE2_UNALLOC_CLR` reader - Reserved"]
+pub type L1_ICACHE2_UNALLOC_CLR_R = crate::BitReader;
+#[doc = "Field `L1_ICACHE3_UNALLOC_CLR` reader - Reserved"]
+pub type L1_ICACHE3_UNALLOC_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_UNALLOC_CLR` reader - The bit is used to clear the unallocate request buffer of l1 cache where the unallocate request is responsed but not completed."]
+pub type L1_CACHE_UNALLOC_CLR_R = crate::BitReader;
+#[doc = "Field `L1_CACHE_UNALLOC_CLR` writer - The bit is used to clear the unallocate request buffer of l1 cache where the unallocate request is responsed but not completed."]
+pub type L1_CACHE_UNALLOC_CLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - The bit is used to clear the unallocate request buffer of l1 icache0 where the unallocate request is responsed but not completed."]
+    #[inline(always)]
+    pub fn l1_icache0_unalloc_clr(&self) -> L1_ICACHE0_UNALLOC_CLR_R {
+        L1_ICACHE0_UNALLOC_CLR_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to clear the unallocate request buffer of l1 icache1 where the unallocate request is responsed but not completed."]
+    #[inline(always)]
+    pub fn l1_icache1_unalloc_clr(&self) -> L1_ICACHE1_UNALLOC_CLR_R {
+        L1_ICACHE1_UNALLOC_CLR_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache2_unalloc_clr(&self) -> L1_ICACHE2_UNALLOC_CLR_R {
+        L1_ICACHE2_UNALLOC_CLR_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Reserved"]
+    #[inline(always)]
+    pub fn l1_icache3_unalloc_clr(&self) -> L1_ICACHE3_UNALLOC_CLR_R {
+        L1_ICACHE3_UNALLOC_CLR_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The bit is used to clear the unallocate request buffer of l1 cache where the unallocate request is responsed but not completed."]
+    #[inline(always)]
+    pub fn l1_cache_unalloc_clr(&self) -> L1_CACHE_UNALLOC_CLR_R {
+        L1_CACHE_UNALLOC_CLR_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L1_UNALLOCATE_BUFFER_CLEAR")
+            .field("l1_icache0_unalloc_clr", &self.l1_icache0_unalloc_clr())
+            .field("l1_icache1_unalloc_clr", &self.l1_icache1_unalloc_clr())
+            .field("l1_icache2_unalloc_clr", &self.l1_icache2_unalloc_clr())
+            .field("l1_icache3_unalloc_clr", &self.l1_icache3_unalloc_clr())
+            .field("l1_cache_unalloc_clr", &self.l1_cache_unalloc_clr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 4 - The bit is used to clear the unallocate request buffer of l1 cache where the unallocate request is responsed but not completed."]
+    #[inline(always)]
+    pub fn l1_cache_unalloc_clr(
+        &mut self,
+    ) -> L1_CACHE_UNALLOC_CLR_W<'_, L1_UNALLOCATE_BUFFER_CLEAR_SPEC> {
+        L1_CACHE_UNALLOC_CLR_W::new(self, 4)
+    }
+}
+#[doc = "Unallocate request buffer clear registers\n\nYou can [`read`](crate::Reg::read) this register and get [`l1_unallocate_buffer_clear::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l1_unallocate_buffer_clear::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L1_UNALLOCATE_BUFFER_CLEAR_SPEC;
+impl crate::RegisterSpec for L1_UNALLOCATE_BUFFER_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l1_unallocate_buffer_clear::R`](R) reader structure"]
+impl crate::Readable for L1_UNALLOCATE_BUFFER_CLEAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l1_unallocate_buffer_clear::W`](W) writer structure"]
+impl crate::Writable for L1_UNALLOCATE_BUFFER_CLEAR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L1_UNALLOCATE_BUFFER_CLEAR to value 0"]
+impl crate::Resettable for L1_UNALLOCATE_BUFFER_CLEAR_SPEC {}

--- a/esp32h2/src/cache/l2_bypass_cache_conf.rs
+++ b/esp32h2/src/cache/l2_bypass_cache_conf.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_BYPASS_CACHE_CONF` reader"]
+pub type R = crate::R<L2_BYPASS_CACHE_CONF_SPEC>;
+#[doc = "Field `BYPASS_L2_CACHE_EN` reader - The bit is used to enable bypass L2-Cache. 0: disable bypass, 1: enable bypass."]
+pub type BYPASS_L2_CACHE_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to enable bypass L2-Cache. 0: disable bypass, 1: enable bypass."]
+    #[inline(always)]
+    pub fn bypass_l2_cache_en(&self) -> BYPASS_L2_CACHE_EN_R {
+        BYPASS_L2_CACHE_EN_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_BYPASS_CACHE_CONF")
+            .field("bypass_l2_cache_en", &self.bypass_l2_cache_en())
+            .finish()
+    }
+}
+#[doc = "Bypass Cache configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_bypass_cache_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_BYPASS_CACHE_CONF_SPEC;
+impl crate::RegisterSpec for L2_BYPASS_CACHE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_bypass_cache_conf::R`](R) reader structure"]
+impl crate::Readable for L2_BYPASS_CACHE_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_BYPASS_CACHE_CONF to value 0"]
+impl crate::Resettable for L2_BYPASS_CACHE_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_access_attr_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_access_attr_ctrl.rs
@@ -1,0 +1,60 @@
+#[doc = "Register `L2_CACHE_ACCESS_ATTR_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_ACCESS_ATTR_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_ACCESS_FORCE_CC` reader - Set this bit to force the request to l2 cache with cacheable attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of cacheable and non-cacheable."]
+pub type L2_CACHE_ACCESS_FORCE_CC_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_ACCESS_FORCE_WB` reader - Set this bit to force the request to l2 cache with write-back attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of write-back and write-through."]
+pub type L2_CACHE_ACCESS_FORCE_WB_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_ACCESS_FORCE_WMA` reader - Set this bit to force the request to l2 cache with write-miss-allocate attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of write-miss-allocate and write-miss-no-allocate."]
+pub type L2_CACHE_ACCESS_FORCE_WMA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_ACCESS_FORCE_RMA` reader - Set this bit to force the request to l2 cache with read-miss-allocate attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of read-miss-allocate and read-miss-no-allocate."]
+pub type L2_CACHE_ACCESS_FORCE_RMA_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Set this bit to force the request to l2 cache with cacheable attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of cacheable and non-cacheable."]
+    #[inline(always)]
+    pub fn l2_cache_access_force_cc(&self) -> L2_CACHE_ACCESS_FORCE_CC_R {
+        L2_CACHE_ACCESS_FORCE_CC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Set this bit to force the request to l2 cache with write-back attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of write-back and write-through."]
+    #[inline(always)]
+    pub fn l2_cache_access_force_wb(&self) -> L2_CACHE_ACCESS_FORCE_WB_R {
+        L2_CACHE_ACCESS_FORCE_WB_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Set this bit to force the request to l2 cache with write-miss-allocate attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of write-miss-allocate and write-miss-no-allocate."]
+    #[inline(always)]
+    pub fn l2_cache_access_force_wma(&self) -> L2_CACHE_ACCESS_FORCE_WMA_R {
+        L2_CACHE_ACCESS_FORCE_WMA_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Set this bit to force the request to l2 cache with read-miss-allocate attribute, otherwise, the attribute is propagated from L1 cache or CPU, it could be one of read-miss-allocate and read-miss-no-allocate."]
+    #[inline(always)]
+    pub fn l2_cache_access_force_rma(&self) -> L2_CACHE_ACCESS_FORCE_RMA_R {
+        L2_CACHE_ACCESS_FORCE_RMA_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACCESS_ATTR_CTRL")
+            .field("l2_cache_access_force_cc", &self.l2_cache_access_force_cc())
+            .field("l2_cache_access_force_wb", &self.l2_cache_access_force_wb())
+            .field(
+                "l2_cache_access_force_wma",
+                &self.l2_cache_access_force_wma(),
+            )
+            .field(
+                "l2_cache_access_force_rma",
+                &self.l2_cache_access_force_rma(),
+            )
+            .finish()
+    }
+}
+#[doc = "L1 Cache access Attribute propagation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_access_attr_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACCESS_ATTR_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACCESS_ATTR_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_access_attr_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACCESS_ATTR_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACCESS_ATTR_CTRL to value 0x0f"]
+impl crate::Resettable for L2_CACHE_ACCESS_ATTR_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x0f;
+}

--- a/esp32h2/src/cache/l2_cache_acs_cnt_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_acs_cnt_ctrl.rs
@@ -1,0 +1,148 @@
+#[doc = "Register `L2_CACHE_ACS_CNT_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_ACS_CNT_CTRL_SPEC>;
+#[doc = "Field `L2_IBUS0_CNT_ENA` reader - The bit is used to enable ibus0 counter in L2-Cache."]
+pub type L2_IBUS0_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_CNT_ENA` reader - The bit is used to enable ibus1 counter in L2-Cache."]
+pub type L2_IBUS1_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_CNT_ENA` reader - Reserved"]
+pub type L2_IBUS2_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_CNT_ENA` reader - Reserved"]
+pub type L2_IBUS3_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_CNT_ENA` reader - The bit is used to enable dbus0 counter in L2-Cache."]
+pub type L2_DBUS0_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_CNT_ENA` reader - The bit is used to enable dbus1 counter in L2-Cache."]
+pub type L2_DBUS1_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_CNT_ENA` reader - Reserved"]
+pub type L2_DBUS2_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_CNT_ENA` reader - Reserved"]
+pub type L2_DBUS3_CNT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS0_CNT_CLR` reader - The bit is used to clear ibus0 counter in L2-Cache."]
+pub type L2_IBUS0_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_CNT_CLR` reader - The bit is used to clear ibus1 counter in L2-Cache."]
+pub type L2_IBUS1_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_CNT_CLR` reader - Reserved"]
+pub type L2_IBUS2_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_CNT_CLR` reader - Reserved"]
+pub type L2_IBUS3_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_CNT_CLR` reader - The bit is used to clear dbus0 counter in L2-Cache."]
+pub type L2_DBUS0_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_CNT_CLR` reader - The bit is used to clear dbus1 counter in L2-Cache."]
+pub type L2_DBUS1_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_CNT_CLR` reader - Reserved"]
+pub type L2_DBUS2_CNT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_CNT_CLR` reader - Reserved"]
+pub type L2_DBUS3_CNT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 8 - The bit is used to enable ibus0 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus0_cnt_ena(&self) -> L2_IBUS0_CNT_ENA_R {
+        L2_IBUS0_CNT_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable ibus1 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus1_cnt_ena(&self) -> L2_IBUS1_CNT_ENA_R {
+        L2_IBUS1_CNT_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus2_cnt_ena(&self) -> L2_IBUS2_CNT_ENA_R {
+        L2_IBUS2_CNT_ENA_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus3_cnt_ena(&self) -> L2_IBUS3_CNT_ENA_R {
+        L2_IBUS3_CNT_ENA_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit is used to enable dbus0 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus0_cnt_ena(&self) -> L2_DBUS0_CNT_ENA_R {
+        L2_DBUS0_CNT_ENA_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit is used to enable dbus1 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus1_cnt_ena(&self) -> L2_DBUS1_CNT_ENA_R {
+        L2_DBUS1_CNT_ENA_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus2_cnt_ena(&self) -> L2_DBUS2_CNT_ENA_R {
+        L2_DBUS2_CNT_ENA_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus3_cnt_ena(&self) -> L2_DBUS3_CNT_ENA_R {
+        L2_DBUS3_CNT_ENA_R::new(((self.bits >> 15) & 1) != 0)
+    }
+    #[doc = "Bit 24 - The bit is used to clear ibus0 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus0_cnt_clr(&self) -> L2_IBUS0_CNT_CLR_R {
+        L2_IBUS0_CNT_CLR_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - The bit is used to clear ibus1 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus1_cnt_clr(&self) -> L2_IBUS1_CNT_CLR_R {
+        L2_IBUS1_CNT_CLR_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus2_cnt_clr(&self) -> L2_IBUS2_CNT_CLR_R {
+        L2_IBUS2_CNT_CLR_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus3_cnt_clr(&self) -> L2_IBUS3_CNT_CLR_R {
+        L2_IBUS3_CNT_CLR_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - The bit is used to clear dbus0 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus0_cnt_clr(&self) -> L2_DBUS0_CNT_CLR_R {
+        L2_DBUS0_CNT_CLR_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - The bit is used to clear dbus1 counter in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus1_cnt_clr(&self) -> L2_DBUS1_CNT_CLR_R {
+        L2_DBUS1_CNT_CLR_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus2_cnt_clr(&self) -> L2_DBUS2_CNT_CLR_R {
+        L2_DBUS2_CNT_CLR_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus3_cnt_clr(&self) -> L2_DBUS3_CNT_CLR_R {
+        L2_DBUS3_CNT_CLR_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_CNT_CTRL")
+            .field("l2_ibus0_cnt_ena", &self.l2_ibus0_cnt_ena())
+            .field("l2_ibus1_cnt_ena", &self.l2_ibus1_cnt_ena())
+            .field("l2_ibus2_cnt_ena", &self.l2_ibus2_cnt_ena())
+            .field("l2_ibus3_cnt_ena", &self.l2_ibus3_cnt_ena())
+            .field("l2_dbus0_cnt_ena", &self.l2_dbus0_cnt_ena())
+            .field("l2_dbus1_cnt_ena", &self.l2_dbus1_cnt_ena())
+            .field("l2_dbus2_cnt_ena", &self.l2_dbus2_cnt_ena())
+            .field("l2_dbus3_cnt_ena", &self.l2_dbus3_cnt_ena())
+            .field("l2_ibus0_cnt_clr", &self.l2_ibus0_cnt_clr())
+            .field("l2_ibus1_cnt_clr", &self.l2_ibus1_cnt_clr())
+            .field("l2_ibus2_cnt_clr", &self.l2_ibus2_cnt_clr())
+            .field("l2_ibus3_cnt_clr", &self.l2_ibus3_cnt_clr())
+            .field("l2_dbus0_cnt_clr", &self.l2_dbus0_cnt_clr())
+            .field("l2_dbus1_cnt_clr", &self.l2_dbus1_cnt_clr())
+            .field("l2_dbus2_cnt_clr", &self.l2_dbus2_cnt_clr())
+            .field("l2_dbus3_cnt_clr", &self.l2_dbus3_cnt_clr())
+            .finish()
+    }
+}
+#[doc = "Cache Access Counter enable and clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_CNT_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_CNT_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_cnt_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_CNT_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_CNT_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_CNT_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_cnt_int_clr.rs
+++ b/esp32h2/src/cache/l2_cache_acs_cnt_int_clr.rs
@@ -1,0 +1,84 @@
+#[doc = "Register `L2_CACHE_ACS_CNT_INT_CLR` reader"]
+pub type R = crate::R<L2_CACHE_ACS_CNT_INT_CLR_SPEC>;
+#[doc = "Field `L2_IBUS0_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_IBUS0_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_IBUS1_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_OVF_INT_CLR` reader - Reserved"]
+pub type L2_IBUS2_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_OVF_INT_CLR` reader - Reserved"]
+pub type L2_IBUS3_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_DBUS0_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_OVF_INT_CLR` reader - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_DBUS1_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_OVF_INT_CLR` reader - Reserved"]
+pub type L2_DBUS2_OVF_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_OVF_INT_CLR` reader - Reserved"]
+pub type L2_DBUS3_OVF_INT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 8 - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus0_ovf_int_clr(&self) -> L2_IBUS0_OVF_INT_CLR_R {
+        L2_IBUS0_OVF_INT_CLR_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus1_ovf_int_clr(&self) -> L2_IBUS1_OVF_INT_CLR_R {
+        L2_IBUS1_OVF_INT_CLR_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus2_ovf_int_clr(&self) -> L2_IBUS2_OVF_INT_CLR_R {
+        L2_IBUS2_OVF_INT_CLR_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus3_ovf_int_clr(&self) -> L2_IBUS3_OVF_INT_CLR_R {
+        L2_IBUS3_OVF_INT_CLR_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus0_ovf_int_clr(&self) -> L2_DBUS0_OVF_INT_CLR_R {
+        L2_DBUS0_OVF_INT_CLR_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit is used to clear counters overflow interrupt and counters in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus1_ovf_int_clr(&self) -> L2_DBUS1_OVF_INT_CLR_R {
+        L2_DBUS1_OVF_INT_CLR_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus2_ovf_int_clr(&self) -> L2_DBUS2_OVF_INT_CLR_R {
+        L2_DBUS2_OVF_INT_CLR_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus3_ovf_int_clr(&self) -> L2_DBUS3_OVF_INT_CLR_R {
+        L2_DBUS3_OVF_INT_CLR_R::new(((self.bits >> 15) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_CNT_INT_CLR")
+            .field("l2_ibus0_ovf_int_clr", &self.l2_ibus0_ovf_int_clr())
+            .field("l2_ibus1_ovf_int_clr", &self.l2_ibus1_ovf_int_clr())
+            .field("l2_ibus2_ovf_int_clr", &self.l2_ibus2_ovf_int_clr())
+            .field("l2_ibus3_ovf_int_clr", &self.l2_ibus3_ovf_int_clr())
+            .field("l2_dbus0_ovf_int_clr", &self.l2_dbus0_ovf_int_clr())
+            .field("l2_dbus1_ovf_int_clr", &self.l2_dbus1_ovf_int_clr())
+            .field("l2_dbus2_ovf_int_clr", &self.l2_dbus2_ovf_int_clr())
+            .field("l2_dbus3_ovf_int_clr", &self.l2_dbus3_ovf_int_clr())
+            .finish()
+    }
+}
+#[doc = "Cache Access Counter Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_clr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_CNT_INT_CLR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_CNT_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_cnt_int_clr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_CNT_INT_CLR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_CNT_INT_CLR to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_CNT_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_cnt_int_ena.rs
+++ b/esp32h2/src/cache/l2_cache_acs_cnt_int_ena.rs
@@ -1,0 +1,84 @@
+#[doc = "Register `L2_CACHE_ACS_CNT_INT_ENA` reader"]
+pub type R = crate::R<L2_CACHE_ACS_CNT_INT_ENA_SPEC>;
+#[doc = "Field `L2_IBUS0_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_IBUS0_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_IBUS1_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_OVF_INT_ENA` reader - Reserved"]
+pub type L2_IBUS2_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_OVF_INT_ENA` reader - Reserved"]
+pub type L2_IBUS3_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_DBUS0_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_OVF_INT_ENA` reader - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_DBUS1_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_OVF_INT_ENA` reader - Reserved"]
+pub type L2_DBUS2_OVF_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_OVF_INT_ENA` reader - Reserved"]
+pub type L2_DBUS3_OVF_INT_ENA_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 8 - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus0_ovf_int_ena(&self) -> L2_IBUS0_OVF_INT_ENA_R {
+        L2_IBUS0_OVF_INT_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus1_ovf_int_ena(&self) -> L2_IBUS1_OVF_INT_ENA_R {
+        L2_IBUS1_OVF_INT_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus2_ovf_int_ena(&self) -> L2_IBUS2_OVF_INT_ENA_R {
+        L2_IBUS2_OVF_INT_ENA_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus3_ovf_int_ena(&self) -> L2_IBUS3_OVF_INT_ENA_R {
+        L2_IBUS3_OVF_INT_ENA_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus0_ovf_int_ena(&self) -> L2_DBUS0_OVF_INT_ENA_R {
+        L2_DBUS0_OVF_INT_ENA_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit is used to enable interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus1_ovf_int_ena(&self) -> L2_DBUS1_OVF_INT_ENA_R {
+        L2_DBUS1_OVF_INT_ENA_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus2_ovf_int_ena(&self) -> L2_DBUS2_OVF_INT_ENA_R {
+        L2_DBUS2_OVF_INT_ENA_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus3_ovf_int_ena(&self) -> L2_DBUS3_OVF_INT_ENA_R {
+        L2_DBUS3_OVF_INT_ENA_R::new(((self.bits >> 15) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_CNT_INT_ENA")
+            .field("l2_ibus0_ovf_int_ena", &self.l2_ibus0_ovf_int_ena())
+            .field("l2_ibus1_ovf_int_ena", &self.l2_ibus1_ovf_int_ena())
+            .field("l2_ibus2_ovf_int_ena", &self.l2_ibus2_ovf_int_ena())
+            .field("l2_ibus3_ovf_int_ena", &self.l2_ibus3_ovf_int_ena())
+            .field("l2_dbus0_ovf_int_ena", &self.l2_dbus0_ovf_int_ena())
+            .field("l2_dbus1_ovf_int_ena", &self.l2_dbus1_ovf_int_ena())
+            .field("l2_dbus2_ovf_int_ena", &self.l2_dbus2_ovf_int_ena())
+            .field("l2_dbus3_ovf_int_ena", &self.l2_dbus3_ovf_int_ena())
+            .finish()
+    }
+}
+#[doc = "Cache Access Counter Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_ena::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_CNT_INT_ENA_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_CNT_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_cnt_int_ena::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_CNT_INT_ENA_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_CNT_INT_ENA to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_CNT_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_cnt_int_raw.rs
+++ b/esp32h2/src/cache/l2_cache_acs_cnt_int_raw.rs
@@ -1,0 +1,164 @@
+#[doc = "Register `L2_CACHE_ACS_CNT_INT_RAW` reader"]
+pub type R = crate::R<L2_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Register `L2_CACHE_ACS_CNT_INT_RAW` writer"]
+pub type W = crate::W<L2_CACHE_ACS_CNT_INT_RAW_SPEC>;
+#[doc = "Field `L2_IBUS0_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-ICache0."]
+pub type L2_IBUS0_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_IBUS0_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-ICache0."]
+pub type L2_IBUS0_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_IBUS1_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-ICache1."]
+pub type L2_IBUS1_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-ICache1."]
+pub type L2_IBUS1_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_IBUS2_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-ICache2."]
+pub type L2_IBUS2_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-ICache2."]
+pub type L2_IBUS2_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_IBUS3_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-ICache3."]
+pub type L2_IBUS3_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-ICache3."]
+pub type L2_IBUS3_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_DBUS0_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-DCache."]
+pub type L2_DBUS0_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-DCache."]
+pub type L2_DBUS0_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_DBUS1_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-DCache."]
+pub type L2_DBUS1_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-DCache."]
+pub type L2_DBUS1_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_DBUS2_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-DCache."]
+pub type L2_DBUS2_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-DCache."]
+pub type L2_DBUS2_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_DBUS3_OVF_INT_RAW` reader - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-DCache."]
+pub type L2_DBUS3_OVF_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_OVF_INT_RAW` writer - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-DCache."]
+pub type L2_DBUS3_OVF_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 8 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_ovf_int_raw(&self) -> L2_IBUS0_OVF_INT_RAW_R {
+        L2_IBUS0_OVF_INT_RAW_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_ovf_int_raw(&self) -> L2_IBUS1_OVF_INT_RAW_R {
+        L2_IBUS1_OVF_INT_RAW_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_ovf_int_raw(&self) -> L2_IBUS2_OVF_INT_RAW_R {
+        L2_IBUS2_OVF_INT_RAW_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_ovf_int_raw(&self) -> L2_IBUS3_OVF_INT_RAW_R {
+        L2_IBUS3_OVF_INT_RAW_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_ovf_int_raw(&self) -> L2_DBUS0_OVF_INT_RAW_R {
+        L2_DBUS0_OVF_INT_RAW_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_ovf_int_raw(&self) -> L2_DBUS1_OVF_INT_RAW_R {
+        L2_DBUS1_OVF_INT_RAW_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_ovf_int_raw(&self) -> L2_DBUS2_OVF_INT_RAW_R {
+        L2_DBUS2_OVF_INT_RAW_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_ovf_int_raw(&self) -> L2_DBUS3_OVF_INT_RAW_R {
+        L2_DBUS3_OVF_INT_RAW_R::new(((self.bits >> 15) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_CNT_INT_RAW")
+            .field("l2_ibus0_ovf_int_raw", &self.l2_ibus0_ovf_int_raw())
+            .field("l2_ibus1_ovf_int_raw", &self.l2_ibus1_ovf_int_raw())
+            .field("l2_ibus2_ovf_int_raw", &self.l2_ibus2_ovf_int_raw())
+            .field("l2_ibus3_ovf_int_raw", &self.l2_ibus3_ovf_int_raw())
+            .field("l2_dbus0_ovf_int_raw", &self.l2_dbus0_ovf_int_raw())
+            .field("l2_dbus1_ovf_int_raw", &self.l2_dbus1_ovf_int_raw())
+            .field("l2_dbus2_ovf_int_raw", &self.l2_dbus2_ovf_int_raw())
+            .field("l2_dbus3_ovf_int_raw", &self.l2_dbus3_ovf_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 8 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_ovf_int_raw(
+        &mut self,
+    ) -> L2_IBUS0_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_IBUS0_OVF_INT_RAW_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_ovf_int_raw(
+        &mut self,
+    ) -> L2_IBUS1_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_IBUS1_OVF_INT_RAW_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_ovf_int_raw(
+        &mut self,
+    ) -> L2_IBUS2_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_IBUS2_OVF_INT_RAW_W::new(self, 10)
+    }
+    #[doc = "Bit 11 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_ovf_int_raw(
+        &mut self,
+    ) -> L2_IBUS3_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_IBUS3_OVF_INT_RAW_W::new(self, 11)
+    }
+    #[doc = "Bit 12 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_ovf_int_raw(
+        &mut self,
+    ) -> L2_DBUS0_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_DBUS0_OVF_INT_RAW_W::new(self, 12)
+    }
+    #[doc = "Bit 13 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_ovf_int_raw(
+        &mut self,
+    ) -> L2_DBUS1_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_DBUS1_OVF_INT_RAW_W::new(self, 13)
+    }
+    #[doc = "Bit 14 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus2 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_ovf_int_raw(
+        &mut self,
+    ) -> L2_DBUS2_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_DBUS2_OVF_INT_RAW_W::new(self, 14)
+    }
+    #[doc = "Bit 15 - The raw bit of the interrupt of one of counters overflow that occurs in L2-Cache due to bus3 accesses L2-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_ovf_int_raw(
+        &mut self,
+    ) -> L2_DBUS3_OVF_INT_RAW_W<'_, L2_CACHE_ACS_CNT_INT_RAW_SPEC> {
+        L2_DBUS3_OVF_INT_RAW_W::new(self, 15)
+    }
+}
+#[doc = "Cache Access Counter Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_acs_cnt_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_CNT_INT_RAW_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_CNT_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_cnt_int_raw::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_CNT_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l2_cache_acs_cnt_int_raw::W`](W) writer structure"]
+impl crate::Writable for L2_CACHE_ACS_CNT_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L2_CACHE_ACS_CNT_INT_RAW to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_CNT_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_cnt_int_st.rs
+++ b/esp32h2/src/cache/l2_cache_acs_cnt_int_st.rs
@@ -1,0 +1,84 @@
+#[doc = "Register `L2_CACHE_ACS_CNT_INT_ST` reader"]
+pub type R = crate::R<L2_CACHE_ACS_CNT_INT_ST_SPEC>;
+#[doc = "Field `L2_IBUS0_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_IBUS0_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_IBUS1_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_IBUS1_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_IBUS2_OVF_INT_ST` reader - Reserved"]
+pub type L2_IBUS2_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_IBUS3_OVF_INT_ST` reader - Reserved"]
+pub type L2_IBUS3_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_DBUS0_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+pub type L2_DBUS0_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_DBUS1_OVF_INT_ST` reader - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+pub type L2_DBUS1_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_DBUS2_OVF_INT_ST` reader - Reserved"]
+pub type L2_DBUS2_OVF_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_DBUS3_OVF_INT_ST` reader - Reserved"]
+pub type L2_DBUS3_OVF_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 8 - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus0_ovf_int_st(&self) -> L2_IBUS0_OVF_INT_ST_R {
+        L2_IBUS0_OVF_INT_ST_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_ibus1_ovf_int_st(&self) -> L2_IBUS1_OVF_INT_ST_R {
+        L2_IBUS1_OVF_INT_ST_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus2_ovf_int_st(&self) -> L2_IBUS2_OVF_INT_ST_R {
+        L2_IBUS2_OVF_INT_ST_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Reserved"]
+    #[inline(always)]
+    pub fn l2_ibus3_ovf_int_st(&self) -> L2_IBUS3_OVF_INT_ST_R {
+        L2_IBUS3_OVF_INT_ST_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus0 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus0_ovf_int_st(&self) -> L2_DBUS0_OVF_INT_ST_R {
+        L2_DBUS0_OVF_INT_ST_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - The bit indicates the interrupt status of one of counters overflow that occurs in L2-Cache due to bus1 accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_dbus1_ovf_int_st(&self) -> L2_DBUS1_OVF_INT_ST_R {
+        L2_DBUS1_OVF_INT_ST_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus2_ovf_int_st(&self) -> L2_DBUS2_OVF_INT_ST_R {
+        L2_DBUS2_OVF_INT_ST_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - Reserved"]
+    #[inline(always)]
+    pub fn l2_dbus3_ovf_int_st(&self) -> L2_DBUS3_OVF_INT_ST_R {
+        L2_DBUS3_OVF_INT_ST_R::new(((self.bits >> 15) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_CNT_INT_ST")
+            .field("l2_ibus0_ovf_int_st", &self.l2_ibus0_ovf_int_st())
+            .field("l2_ibus1_ovf_int_st", &self.l2_ibus1_ovf_int_st())
+            .field("l2_ibus2_ovf_int_st", &self.l2_ibus2_ovf_int_st())
+            .field("l2_ibus3_ovf_int_st", &self.l2_ibus3_ovf_int_st())
+            .field("l2_dbus0_ovf_int_st", &self.l2_dbus0_ovf_int_st())
+            .field("l2_dbus1_ovf_int_st", &self.l2_dbus1_ovf_int_st())
+            .field("l2_dbus2_ovf_int_st", &self.l2_dbus2_ovf_int_st())
+            .field("l2_dbus3_ovf_int_st", &self.l2_dbus3_ovf_int_st())
+            .finish()
+    }
+}
+#[doc = "Cache Access Counter Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_cnt_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_CNT_INT_ST_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_CNT_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_cnt_int_st::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_CNT_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_CNT_INT_ST to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_CNT_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_addr.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_ADDR` reader - The register records the address of fail-access when L1-Cache accesses L2-Cache."]
+pub type L2_CACHE_FAIL_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the address of fail-access when L1-Cache accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_addr(&self) -> L2_CACHE_FAIL_ADDR_R {
+        L2_CACHE_FAIL_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_ADDR")
+            .field("l2_cache_fail_addr", &self.l2_cache_fail_addr())
+            .finish()
+    }
+}
+#[doc = "L2-Cache Access Fail Address information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_id_attr.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_id_attr.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_ID_ATTR` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_ID_ATTR_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_ID` reader - The register records the ID of fail-access when L1-Cache accesses L2-Cache."]
+pub type L2_CACHE_FAIL_ID_R = crate::FieldReader<u16>;
+#[doc = "Field `L2_CACHE_FAIL_ATTR` reader - The register records the attribution of fail-access when L1-Cache accesses L2-Cache due to cache accessing L1-Cache."]
+pub type L2_CACHE_FAIL_ATTR_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - The register records the ID of fail-access when L1-Cache accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_id(&self) -> L2_CACHE_FAIL_ID_R {
+        L2_CACHE_FAIL_ID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - The register records the attribution of fail-access when L1-Cache accesses L2-Cache due to cache accessing L1-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_attr(&self) -> L2_CACHE_FAIL_ATTR_R {
+        L2_CACHE_FAIL_ATTR_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_ID_ATTR")
+            .field("l2_cache_fail_id", &self.l2_cache_fail_id())
+            .field("l2_cache_fail_attr", &self.l2_cache_fail_attr())
+            .finish()
+    }
+}
+#[doc = "L2-Cache Access Fail ID/attribution information register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_id_attr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_ID_ATTR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_ID_ATTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_id_attr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_ID_ATTR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_ID_ATTR to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_ID_ATTR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_int_clr.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_int_clr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_INT_CLR` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_INT_CLR_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_INT_CLR` reader - The bit is used to clear interrupt of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+pub type L2_CACHE_FAIL_INT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to clear interrupt of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_int_clr(&self) -> L2_CACHE_FAIL_INT_CLR_R {
+        L2_CACHE_FAIL_INT_CLR_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_INT_CLR")
+            .field("l2_cache_fail_int_clr", &self.l2_cache_fail_int_clr())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_clr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_INT_CLR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_int_clr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_INT_CLR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_INT_CLR to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_int_ena.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_int_ena.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_INT_ENA` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_INT_ENA_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_INT_ENA` reader - The bit is used to enable interrupt of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+pub type L2_CACHE_FAIL_INT_ENA_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to enable interrupt of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_int_ena(&self) -> L2_CACHE_FAIL_INT_ENA_R {
+        L2_CACHE_FAIL_INT_ENA_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_INT_ENA")
+            .field("l2_cache_fail_int_ena", &self.l2_cache_fail_int_ena())
+            .finish()
+    }
+}
+#[doc = "Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_ena::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_INT_ENA_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_int_ena::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_INT_ENA_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_INT_ENA to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_int_raw.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_int_raw.rs
@@ -1,0 +1,45 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_INT_RAW` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Register `L2_CACHE_ACS_FAIL_INT_RAW` writer"]
+pub type W = crate::W<L2_CACHE_ACS_FAIL_INT_RAW_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_INT_RAW` reader - The raw bit of the interrupt of access fail that occurs in L2-Cache."]
+pub type L2_CACHE_FAIL_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_FAIL_INT_RAW` writer - The raw bit of the interrupt of access fail that occurs in L2-Cache."]
+pub type L2_CACHE_FAIL_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 5 - The raw bit of the interrupt of access fail that occurs in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_int_raw(&self) -> L2_CACHE_FAIL_INT_RAW_R {
+        L2_CACHE_FAIL_INT_RAW_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_INT_RAW")
+            .field("l2_cache_fail_int_raw", &self.l2_cache_fail_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 5 - The raw bit of the interrupt of access fail that occurs in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_int_raw(
+        &mut self,
+    ) -> L2_CACHE_FAIL_INT_RAW_W<'_, L2_CACHE_ACS_FAIL_INT_RAW_SPEC> {
+        L2_CACHE_FAIL_INT_RAW_W::new(self, 5)
+    }
+}
+#[doc = "Cache Access Fail Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_acs_fail_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_INT_RAW_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_int_raw::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l2_cache_acs_fail_int_raw::W`](W) writer structure"]
+impl crate::Writable for L2_CACHE_ACS_FAIL_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_INT_RAW to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l2_cache_acs_fail_int_st.rs
+++ b/esp32h2/src/cache/l2_cache_acs_fail_int_st.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_ACS_FAIL_INT_ST` reader"]
+pub type R = crate::R<L2_CACHE_ACS_FAIL_INT_ST_SPEC>;
+#[doc = "Field `L2_CACHE_FAIL_INT_ST` reader - The bit indicates the interrupt status of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+pub type L2_CACHE_FAIL_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit indicates the interrupt status of access fail that occurs in L2-Cache due to l1 cache accesses L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_fail_int_st(&self) -> L2_CACHE_FAIL_INT_ST_R {
+        L2_CACHE_FAIL_INT_ST_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_ACS_FAIL_INT_ST")
+            .field("l2_cache_fail_int_st", &self.l2_cache_fail_int_st())
+            .finish()
+    }
+}
+#[doc = "Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_acs_fail_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_ACS_FAIL_INT_ST_SPEC;
+impl crate::RegisterSpec for L2_CACHE_ACS_FAIL_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_acs_fail_int_st::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_ACS_FAIL_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_ACS_FAIL_INT_ST to value 0"]
+impl crate::Resettable for L2_CACHE_ACS_FAIL_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_buf_clr_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_buf_clr_ctrl.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_BUF_CLR_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_ALD_BUF_CLR` reader - set this bit to clear autoload-buffer inside L2-Cache. If this bit is active, autoload will not work in L2-Cache. This bit should not be active when autoload works in L2-Cache."]
+pub type L2_CACHE_ALD_BUF_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - set this bit to clear autoload-buffer inside L2-Cache. If this bit is active, autoload will not work in L2-Cache. This bit should not be active when autoload works in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_ald_buf_clr(&self) -> L2_CACHE_ALD_BUF_CLR_R {
+        L2_CACHE_ALD_BUF_CLR_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_BUF_CLR_CTRL")
+            .field("l2_cache_ald_buf_clr", &self.l2_cache_ald_buf_clr())
+            .finish()
+    }
+}
+#[doc = "Cache Autoload buffer clear control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_buf_clr_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_buf_clr_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_BUF_CLR_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_BUF_CLR_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_ctrl.rs
@@ -1,0 +1,109 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_ENA` reader - The bit is used to enable and disable autoload operation on L2-Cache. 1: enable, 0: disable."]
+pub type L2_CACHE_AUTOLOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_DONE` reader - The bit is used to indicate whether autoload operation on L2-Cache is finished or not. 0: not finished. 1: finished."]
+pub type L2_CACHE_AUTOLOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_ORDER` reader - The bit is used to configure the direction of autoload operation on L2-Cache. 0: ascending. 1: descending."]
+pub type L2_CACHE_AUTOLOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_TRIGGER_MODE` reader - The field is used to configure trigger mode of autoload operation on L2-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+pub type L2_CACHE_AUTOLOAD_TRIGGER_MODE_R = crate::FieldReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT0_ENA` reader - The bit is used to enable the first section for autoload operation on L2-Cache."]
+pub type L2_CACHE_AUTOLOAD_SCT0_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT1_ENA` reader - The bit is used to enable the second section for autoload operation on L2-Cache."]
+pub type L2_CACHE_AUTOLOAD_SCT1_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT2_ENA` reader - The bit is used to enable the third section for autoload operation on L2-Cache."]
+pub type L2_CACHE_AUTOLOAD_SCT2_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT3_ENA` reader - The bit is used to enable the fourth section for autoload operation on L2-Cache."]
+pub type L2_CACHE_AUTOLOAD_SCT3_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_AUTOLOAD_RGID` reader - The bit is used to set the gid of l2 cache autoload."]
+pub type L2_CACHE_AUTOLOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable and disable autoload operation on L2-Cache. 1: enable, 0: disable."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_ena(&self) -> L2_CACHE_AUTOLOAD_ENA_R {
+        L2_CACHE_AUTOLOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether autoload operation on L2-Cache is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_done(&self) -> L2_CACHE_AUTOLOAD_DONE_R {
+        L2_CACHE_AUTOLOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of autoload operation on L2-Cache. 0: ascending. 1: descending."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_order(&self) -> L2_CACHE_AUTOLOAD_ORDER_R {
+        L2_CACHE_AUTOLOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:4 - The field is used to configure trigger mode of autoload operation on L2-Cache. 0/3: miss-trigger, 1: hit-trigger, 2: miss-hit-trigger."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_trigger_mode(&self) -> L2_CACHE_AUTOLOAD_TRIGGER_MODE_R {
+        L2_CACHE_AUTOLOAD_TRIGGER_MODE_R::new(((self.bits >> 3) & 3) as u8)
+    }
+    #[doc = "Bit 8 - The bit is used to enable the first section for autoload operation on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct0_ena(&self) -> L2_CACHE_AUTOLOAD_SCT0_ENA_R {
+        L2_CACHE_AUTOLOAD_SCT0_ENA_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The bit is used to enable the second section for autoload operation on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct1_ena(&self) -> L2_CACHE_AUTOLOAD_SCT1_ENA_R {
+        L2_CACHE_AUTOLOAD_SCT1_ENA_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The bit is used to enable the third section for autoload operation on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct2_ena(&self) -> L2_CACHE_AUTOLOAD_SCT2_ENA_R {
+        L2_CACHE_AUTOLOAD_SCT2_ENA_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The bit is used to enable the fourth section for autoload operation on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct3_ena(&self) -> L2_CACHE_AUTOLOAD_SCT3_ENA_R {
+        L2_CACHE_AUTOLOAD_SCT3_ENA_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bits 12:15 - The bit is used to set the gid of l2 cache autoload."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_rgid(&self) -> L2_CACHE_AUTOLOAD_RGID_R {
+        L2_CACHE_AUTOLOAD_RGID_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_CTRL")
+            .field("l2_cache_autoload_ena", &self.l2_cache_autoload_ena())
+            .field("l2_cache_autoload_done", &self.l2_cache_autoload_done())
+            .field("l2_cache_autoload_order", &self.l2_cache_autoload_order())
+            .field(
+                "l2_cache_autoload_trigger_mode",
+                &self.l2_cache_autoload_trigger_mode(),
+            )
+            .field(
+                "l2_cache_autoload_sct0_ena",
+                &self.l2_cache_autoload_sct0_ena(),
+            )
+            .field(
+                "l2_cache_autoload_sct1_ena",
+                &self.l2_cache_autoload_sct1_ena(),
+            )
+            .field(
+                "l2_cache_autoload_sct2_ena",
+                &self.l2_cache_autoload_sct2_ena(),
+            )
+            .field(
+                "l2_cache_autoload_sct3_ena",
+                &self.l2_cache_autoload_sct3_ena(),
+            )
+            .field("l2_cache_autoload_rgid", &self.l2_cache_autoload_rgid())
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_CTRL to value 0x02"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l2_cache_autoload_sct0_addr.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT0_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT0_SIZE and L2_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT0_SIZE and L2_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct0_addr(&self) -> L2_CACHE_AUTOLOAD_SCT0_ADDR_R {
+        L2_CACHE_AUTOLOAD_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT0_ADDR")
+            .field(
+                "l2_cache_autoload_sct0_addr",
+                &self.l2_cache_autoload_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT0_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct0_size.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct0_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT0_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT0_SIZE` reader - Those bits are used to configure the size of the first section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT0_ADDR and L2_CACHE_AUTOLOAD_SCT0_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT0_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the first section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT0_ADDR and L2_CACHE_AUTOLOAD_SCT0_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct0_size(&self) -> L2_CACHE_AUTOLOAD_SCT0_SIZE_R {
+        L2_CACHE_AUTOLOAD_SCT0_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT0_SIZE")
+            .field(
+                "l2_cache_autoload_sct0_size",
+                &self.l2_cache_autoload_sct0_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 0 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct0_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct0_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT0_SIZE to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT0_SIZE_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct1_addr.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT1_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT1_SIZE and L2_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT1_SIZE and L2_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct1_addr(&self) -> L2_CACHE_AUTOLOAD_SCT1_ADDR_R {
+        L2_CACHE_AUTOLOAD_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT1_ADDR")
+            .field(
+                "l2_cache_autoload_sct1_addr",
+                &self.l2_cache_autoload_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT1_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct1_size.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct1_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT1_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT1_SIZE` reader - Those bits are used to configure the size of the second section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT1_ADDR and L2_CACHE_AUTOLOAD_SCT1_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT1_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the second section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT1_ADDR and L2_CACHE_AUTOLOAD_SCT1_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct1_size(&self) -> L2_CACHE_AUTOLOAD_SCT1_SIZE_R {
+        L2_CACHE_AUTOLOAD_SCT1_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT1_SIZE")
+            .field(
+                "l2_cache_autoload_sct1_size",
+                &self.l2_cache_autoload_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 1 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct1_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct1_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT1_SIZE to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT1_SIZE_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct2_addr.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct2_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT2_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT2_ADDR` reader - Those bits are used to configure the start virtual address of the third section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT2_SIZE and L2_CACHE_AUTOLOAD_SCT2_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT2_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the third section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT2_SIZE and L2_CACHE_AUTOLOAD_SCT2_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct2_addr(&self) -> L2_CACHE_AUTOLOAD_SCT2_ADDR_R {
+        L2_CACHE_AUTOLOAD_SCT2_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT2_ADDR")
+            .field(
+                "l2_cache_autoload_sct2_addr",
+                &self.l2_cache_autoload_sct2_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 2 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct2_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct2_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT2_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT2_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct2_size.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct2_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT2_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT2_SIZE` reader - Those bits are used to configure the size of the third section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT2_ADDR and L2_CACHE_AUTOLOAD_SCT2_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT2_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the third section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT2_ADDR and L2_CACHE_AUTOLOAD_SCT2_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct2_size(&self) -> L2_CACHE_AUTOLOAD_SCT2_SIZE_R {
+        L2_CACHE_AUTOLOAD_SCT2_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT2_SIZE")
+            .field(
+                "l2_cache_autoload_sct2_size",
+                &self.l2_cache_autoload_sct2_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 2 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct2_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct2_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT2_SIZE to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT2_SIZE_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct3_addr.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct3_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT3_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT3_ADDR` reader - Those bits are used to configure the start virtual address of the fourth section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT3_SIZE and L2_CACHE_AUTOLOAD_SCT3_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT3_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the fourth section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT3_SIZE and L2_CACHE_AUTOLOAD_SCT3_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct3_addr(&self) -> L2_CACHE_AUTOLOAD_SCT3_ADDR_R {
+        L2_CACHE_AUTOLOAD_SCT3_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT3_ADDR")
+            .field(
+                "l2_cache_autoload_sct3_addr",
+                &self.l2_cache_autoload_sct3_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 3 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct3_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct3_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT3_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT3_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_autoload_sct3_size.rs
+++ b/esp32h2/src/cache/l2_cache_autoload_sct3_size.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_AUTOLOAD_SCT3_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_AUTOLOAD_SCT3_SIZE` reader - Those bits are used to configure the size of the fourth section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT3_ADDR and L2_CACHE_AUTOLOAD_SCT3_ENA."]
+pub type L2_CACHE_AUTOLOAD_SCT3_SIZE_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:27 - Those bits are used to configure the size of the fourth section for autoload operation on L2-Cache. Note that it should be used together with L2_CACHE_AUTOLOAD_SCT3_ADDR and L2_CACHE_AUTOLOAD_SCT3_ENA."]
+    #[inline(always)]
+    pub fn l2_cache_autoload_sct3_size(&self) -> L2_CACHE_AUTOLOAD_SCT3_SIZE_R {
+        L2_CACHE_AUTOLOAD_SCT3_SIZE_R::new(self.bits & 0x0fff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_AUTOLOAD_SCT3_SIZE")
+            .field(
+                "l2_cache_autoload_sct3_size",
+                &self.l2_cache_autoload_sct3_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache autoload section 3 size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_autoload_sct3_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_autoload_sct3_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_AUTOLOAD_SCT3_SIZE to value 0"]
+impl crate::Resettable for L2_CACHE_AUTOLOAD_SCT3_SIZE_SPEC {}

--- a/esp32h2/src/cache/l2_cache_blocksize_conf.rs
+++ b/esp32h2/src/cache/l2_cache_blocksize_conf.rs
@@ -1,0 +1,68 @@
+#[doc = "Register `L2_CACHE_BLOCKSIZE_CONF` reader"]
+pub type R = crate::R<L2_CACHE_BLOCKSIZE_CONF_SPEC>;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_8` reader - The field is used to configureblocksize of L2-Cache as 8 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_8_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_16` reader - The field is used to configureblocksize of L2-Cache as 16 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_16_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_32` reader - The field is used to configureblocksize of L2-Cache as 32 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_32_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_64` reader - The field is used to configureblocksize of L2-Cache as 64 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_64_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_128` reader - The field is used to configureblocksize of L2-Cache as 128 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_128_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_BLOCKSIZE_256` reader - The field is used to configureblocksize of L2-Cache as 256 bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_BLOCKSIZE_256_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configureblocksize of L2-Cache as 8 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_8(&self) -> L2_CACHE_BLOCKSIZE_8_R {
+        L2_CACHE_BLOCKSIZE_8_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configureblocksize of L2-Cache as 16 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_16(&self) -> L2_CACHE_BLOCKSIZE_16_R {
+        L2_CACHE_BLOCKSIZE_16_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configureblocksize of L2-Cache as 32 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_32(&self) -> L2_CACHE_BLOCKSIZE_32_R {
+        L2_CACHE_BLOCKSIZE_32_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configureblocksize of L2-Cache as 64 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_64(&self) -> L2_CACHE_BLOCKSIZE_64_R {
+        L2_CACHE_BLOCKSIZE_64_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configureblocksize of L2-Cache as 128 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_128(&self) -> L2_CACHE_BLOCKSIZE_128_R {
+        L2_CACHE_BLOCKSIZE_128_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configureblocksize of L2-Cache as 256 bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_blocksize_256(&self) -> L2_CACHE_BLOCKSIZE_256_R {
+        L2_CACHE_BLOCKSIZE_256_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_BLOCKSIZE_CONF")
+            .field("l2_cache_blocksize_8", &self.l2_cache_blocksize_8())
+            .field("l2_cache_blocksize_16", &self.l2_cache_blocksize_16())
+            .field("l2_cache_blocksize_32", &self.l2_cache_blocksize_32())
+            .field("l2_cache_blocksize_64", &self.l2_cache_blocksize_64())
+            .field("l2_cache_blocksize_128", &self.l2_cache_blocksize_128())
+            .field("l2_cache_blocksize_256", &self.l2_cache_blocksize_256())
+            .finish()
+    }
+}
+#[doc = "L2 Cache BlockSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_blocksize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_BLOCKSIZE_CONF_SPEC;
+impl crate::RegisterSpec for L2_CACHE_BLOCKSIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_blocksize_conf::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_BLOCKSIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_BLOCKSIZE_CONF to value 0"]
+impl crate::Resettable for L2_CACHE_BLOCKSIZE_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_cachesize_conf.rs
+++ b/esp32h2/src/cache/l2_cache_cachesize_conf.rs
@@ -1,0 +1,124 @@
+#[doc = "Register `L2_CACHE_CACHESIZE_CONF` reader"]
+pub type R = crate::R<L2_CACHE_CACHESIZE_CONF_SPEC>;
+#[doc = "Field `L2_CACHE_CACHESIZE_1K` reader - The field is used to configure cachesize of L2-Cache as 1k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_1K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_2K` reader - The field is used to configure cachesize of L2-Cache as 2k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_2K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_4K` reader - The field is used to configure cachesize of L2-Cache as 4k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_4K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_8K` reader - The field is used to configure cachesize of L2-Cache as 8k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_8K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_16K` reader - The field is used to configure cachesize of L2-Cache as 16k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_16K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_32K` reader - The field is used to configure cachesize of L2-Cache as 32k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_32K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_64K` reader - The field is used to configure cachesize of L2-Cache as 64k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_64K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_128K` reader - The field is used to configure cachesize of L2-Cache as 128k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_128K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_256K` reader - The field is used to configure cachesize of L2-Cache as 256k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_256K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_512K` reader - The field is used to configure cachesize of L2-Cache as 512k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_512K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_1024K` reader - The field is used to configure cachesize of L2-Cache as 1024k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_1024K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_2048K` reader - The field is used to configure cachesize of L2-Cache as 2048k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_2048K_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_CACHESIZE_4096K` reader - The field is used to configure cachesize of L2-Cache as 4096k bytes. This field and all other fields within this register is onehot."]
+pub type L2_CACHE_CACHESIZE_4096K_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - The field is used to configure cachesize of L2-Cache as 1k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_1k(&self) -> L2_CACHE_CACHESIZE_1K_R {
+        L2_CACHE_CACHESIZE_1K_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The field is used to configure cachesize of L2-Cache as 2k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_2k(&self) -> L2_CACHE_CACHESIZE_2K_R {
+        L2_CACHE_CACHESIZE_2K_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The field is used to configure cachesize of L2-Cache as 4k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_4k(&self) -> L2_CACHE_CACHESIZE_4K_R {
+        L2_CACHE_CACHESIZE_4K_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - The field is used to configure cachesize of L2-Cache as 8k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_8k(&self) -> L2_CACHE_CACHESIZE_8K_R {
+        L2_CACHE_CACHESIZE_8K_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - The field is used to configure cachesize of L2-Cache as 16k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_16k(&self) -> L2_CACHE_CACHESIZE_16K_R {
+        L2_CACHE_CACHESIZE_16K_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - The field is used to configure cachesize of L2-Cache as 32k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_32k(&self) -> L2_CACHE_CACHESIZE_32K_R {
+        L2_CACHE_CACHESIZE_32K_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - The field is used to configure cachesize of L2-Cache as 64k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_64k(&self) -> L2_CACHE_CACHESIZE_64K_R {
+        L2_CACHE_CACHESIZE_64K_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - The field is used to configure cachesize of L2-Cache as 128k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_128k(&self) -> L2_CACHE_CACHESIZE_128K_R {
+        L2_CACHE_CACHESIZE_128K_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - The field is used to configure cachesize of L2-Cache as 256k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_256k(&self) -> L2_CACHE_CACHESIZE_256K_R {
+        L2_CACHE_CACHESIZE_256K_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - The field is used to configure cachesize of L2-Cache as 512k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_512k(&self) -> L2_CACHE_CACHESIZE_512K_R {
+        L2_CACHE_CACHESIZE_512K_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - The field is used to configure cachesize of L2-Cache as 1024k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_1024k(&self) -> L2_CACHE_CACHESIZE_1024K_R {
+        L2_CACHE_CACHESIZE_1024K_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - The field is used to configure cachesize of L2-Cache as 2048k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_2048k(&self) -> L2_CACHE_CACHESIZE_2048K_R {
+        L2_CACHE_CACHESIZE_2048K_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The field is used to configure cachesize of L2-Cache as 4096k bytes. This field and all other fields within this register is onehot."]
+    #[inline(always)]
+    pub fn l2_cache_cachesize_4096k(&self) -> L2_CACHE_CACHESIZE_4096K_R {
+        L2_CACHE_CACHESIZE_4096K_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_CACHESIZE_CONF")
+            .field("l2_cache_cachesize_1k", &self.l2_cache_cachesize_1k())
+            .field("l2_cache_cachesize_2k", &self.l2_cache_cachesize_2k())
+            .field("l2_cache_cachesize_4k", &self.l2_cache_cachesize_4k())
+            .field("l2_cache_cachesize_8k", &self.l2_cache_cachesize_8k())
+            .field("l2_cache_cachesize_16k", &self.l2_cache_cachesize_16k())
+            .field("l2_cache_cachesize_32k", &self.l2_cache_cachesize_32k())
+            .field("l2_cache_cachesize_64k", &self.l2_cache_cachesize_64k())
+            .field("l2_cache_cachesize_128k", &self.l2_cache_cachesize_128k())
+            .field("l2_cache_cachesize_256k", &self.l2_cache_cachesize_256k())
+            .field("l2_cache_cachesize_512k", &self.l2_cache_cachesize_512k())
+            .field("l2_cache_cachesize_1024k", &self.l2_cache_cachesize_1024k())
+            .field("l2_cache_cachesize_2048k", &self.l2_cache_cachesize_2048k())
+            .field("l2_cache_cachesize_4096k", &self.l2_cache_cachesize_4096k())
+            .finish()
+    }
+}
+#[doc = "L2 Cache CacheSize mode configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_cachesize_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_CACHESIZE_CONF_SPEC;
+impl crate::RegisterSpec for L2_CACHE_CACHESIZE_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_cachesize_conf::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_CACHESIZE_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_CACHESIZE_CONF to value 0"]
+impl crate::Resettable for L2_CACHE_CACHESIZE_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_ctrl.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_SHUT_DMA` reader - The bit is used to disable DMA access L2-Cache, 0: enable, 1: disable"]
+pub type L2_CACHE_SHUT_DMA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_UNDEF_OP` reader - Reserved"]
+pub type L2_CACHE_UNDEF_OP_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 4 - The bit is used to disable DMA access L2-Cache, 0: enable, 1: disable"]
+    #[inline(always)]
+    pub fn l2_cache_shut_dma(&self) -> L2_CACHE_SHUT_DMA_R {
+        L2_CACHE_SHUT_DMA_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bits 5:8 - Reserved"]
+    #[inline(always)]
+    pub fn l2_cache_undef_op(&self) -> L2_CACHE_UNDEF_OP_R {
+        L2_CACHE_UNDEF_OP_R::new(((self.bits >> 5) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_CTRL")
+            .field("l2_cache_shut_dma", &self.l2_cache_shut_dma())
+            .field("l2_cache_undef_op", &self.l2_cache_undef_op())
+            .finish()
+    }
+}
+#[doc = "L2 Cache(L2-Cache) control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_data_mem_acs_conf.rs
+++ b/esp32h2/src/cache/l2_cache_data_mem_acs_conf.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_DATA_MEM_ACS_CONF` reader"]
+pub type R = crate::R<L2_CACHE_DATA_MEM_ACS_CONF_SPEC>;
+#[doc = "Field `L2_CACHE_DATA_MEM_RD_EN` reader - The bit is used to enable config-bus read L2-Cache data memoryory. 0: disable, 1: enable."]
+pub type L2_CACHE_DATA_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_DATA_MEM_WR_EN` reader - The bit is used to enable config-bus write L2-Cache data memoryory. 0: disable, 1: enable."]
+pub type L2_CACHE_DATA_MEM_WR_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - The bit is used to enable config-bus read L2-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l2_cache_data_mem_rd_en(&self) -> L2_CACHE_DATA_MEM_RD_EN_R {
+        L2_CACHE_DATA_MEM_RD_EN_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - The bit is used to enable config-bus write L2-Cache data memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l2_cache_data_mem_wr_en(&self) -> L2_CACHE_DATA_MEM_WR_EN_R {
+        L2_CACHE_DATA_MEM_WR_EN_R::new(((self.bits >> 21) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_DATA_MEM_ACS_CONF")
+            .field("l2_cache_data_mem_rd_en", &self.l2_cache_data_mem_rd_en())
+            .field("l2_cache_data_mem_wr_en", &self.l2_cache_data_mem_wr_en())
+            .finish()
+    }
+}
+#[doc = "Cache data memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_data_mem_acs_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_DATA_MEM_ACS_CONF_SPEC;
+impl crate::RegisterSpec for L2_CACHE_DATA_MEM_ACS_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_data_mem_acs_conf::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_DATA_MEM_ACS_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_DATA_MEM_ACS_CONF to value 0"]
+impl crate::Resettable for L2_CACHE_DATA_MEM_ACS_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_data_mem_power_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_data_mem_power_ctrl.rs
@@ -1,0 +1,53 @@
+#[doc = "Register `L2_CACHE_DATA_MEM_POWER_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_DATA_MEM_POWER_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_DATA_MEM_FORCE_ON` reader - The bit is used to close clock gating of L2-Cache data memory. 1: close gating, 0: open clock gating."]
+pub type L2_CACHE_DATA_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_DATA_MEM_FORCE_PD` reader - The bit is used to power L2-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L2_CACHE_DATA_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_DATA_MEM_FORCE_PU` reader - The bit is used to power L2-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L2_CACHE_DATA_MEM_FORCE_PU_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - The bit is used to close clock gating of L2-Cache data memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l2_cache_data_mem_force_on(&self) -> L2_CACHE_DATA_MEM_FORCE_ON_R {
+        L2_CACHE_DATA_MEM_FORCE_ON_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - The bit is used to power L2-Cache data memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l2_cache_data_mem_force_pd(&self) -> L2_CACHE_DATA_MEM_FORCE_PD_R {
+        L2_CACHE_DATA_MEM_FORCE_PD_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - The bit is used to power L2-Cache data memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l2_cache_data_mem_force_pu(&self) -> L2_CACHE_DATA_MEM_FORCE_PU_R {
+        L2_CACHE_DATA_MEM_FORCE_PU_R::new(((self.bits >> 22) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_DATA_MEM_POWER_CTRL")
+            .field(
+                "l2_cache_data_mem_force_on",
+                &self.l2_cache_data_mem_force_on(),
+            )
+            .field(
+                "l2_cache_data_mem_force_pd",
+                &self.l2_cache_data_mem_force_pd(),
+            )
+            .field(
+                "l2_cache_data_mem_force_pu",
+                &self.l2_cache_data_mem_force_pu(),
+            )
+            .finish()
+    }
+}
+#[doc = "Cache data memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_data_mem_power_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_DATA_MEM_POWER_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_DATA_MEM_POWER_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_data_mem_power_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_DATA_MEM_POWER_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_DATA_MEM_POWER_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_DATA_MEM_POWER_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_debug_bus.rs
+++ b/esp32h2/src/cache/l2_cache_debug_bus.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `L2_CACHE_DEBUG_BUS` reader"]
+pub type R = crate::R<L2_CACHE_DEBUG_BUS_SPEC>;
+#[doc = "Field `L2_CACHE_DEBUG_BUS` reader - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+pub type L2_CACHE_DEBUG_BUS_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - This is a constant place where we can write data to or read data from the tag/data memory on the specified cache."]
+    #[inline(always)]
+    pub fn l2_cache_debug_bus(&self) -> L2_CACHE_DEBUG_BUS_R {
+        L2_CACHE_DEBUG_BUS_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_DEBUG_BUS")
+            .field("l2_cache_debug_bus", &self.l2_cache_debug_bus())
+            .finish()
+    }
+}
+#[doc = "Cache Tag/data memory content register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_debug_bus::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_DEBUG_BUS_SPEC;
+impl crate::RegisterSpec for L2_CACHE_DEBUG_BUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_debug_bus::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_DEBUG_BUS_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_DEBUG_BUS to value 0x03a4"]
+impl crate::Resettable for L2_CACHE_DEBUG_BUS_SPEC {
+    const RESET_VALUE: u32 = 0x03a4;
+}

--- a/esp32h2/src/cache/l2_cache_freeze_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_freeze_ctrl.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L2_CACHE_FREEZE_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_FREEZE_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_FREEZE_EN` reader - The bit is used to enable freeze operation on L2-Cache. It can be cleared by software."]
+pub type L2_CACHE_FREEZE_EN_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_FREEZE_MODE` reader - The bit is used to configure mode of freeze operation L2-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+pub type L2_CACHE_FREEZE_MODE_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_FREEZE_DONE` reader - The bit is used to indicate whether freeze operation on L2-Cache is finished or not. 0: not finished. 1: finished."]
+pub type L2_CACHE_FREEZE_DONE_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - The bit is used to enable freeze operation on L2-Cache. It can be cleared by software."]
+    #[inline(always)]
+    pub fn l2_cache_freeze_en(&self) -> L2_CACHE_FREEZE_EN_R {
+        L2_CACHE_FREEZE_EN_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - The bit is used to configure mode of freeze operation L2-Cache. 0: a miss-access will not stuck. 1: a miss-access will stuck."]
+    #[inline(always)]
+    pub fn l2_cache_freeze_mode(&self) -> L2_CACHE_FREEZE_MODE_R {
+        L2_CACHE_FREEZE_MODE_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - The bit is used to indicate whether freeze operation on L2-Cache is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l2_cache_freeze_done(&self) -> L2_CACHE_FREEZE_DONE_R {
+        L2_CACHE_FREEZE_DONE_R::new(((self.bits >> 22) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_FREEZE_CTRL")
+            .field("l2_cache_freeze_en", &self.l2_cache_freeze_en())
+            .field("l2_cache_freeze_mode", &self.l2_cache_freeze_mode())
+            .field("l2_cache_freeze_done", &self.l2_cache_freeze_done())
+            .finish()
+    }
+}
+#[doc = "Cache Freeze control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_freeze_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_FREEZE_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_FREEZE_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_freeze_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_FREEZE_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_FREEZE_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_FREEZE_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_object_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_object_ctrl.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_OBJECT_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_OBJECT_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_TAG_OBJECT` reader - Set this bit to set L2-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L2_CACHE_TAG_OBJECT_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_MEM_OBJECT` reader - Set this bit to set L2-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+pub type L2_CACHE_MEM_OBJECT_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - Set this bit to set L2-Cache tag memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l2_cache_tag_object(&self) -> L2_CACHE_TAG_OBJECT_R {
+        L2_CACHE_TAG_OBJECT_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Set this bit to set L2-Cache data memory as object. This bit should be onehot with the others fields inside this register."]
+    #[inline(always)]
+    pub fn l2_cache_mem_object(&self) -> L2_CACHE_MEM_OBJECT_R {
+        L2_CACHE_MEM_OBJECT_R::new(((self.bits >> 11) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_OBJECT_CTRL")
+            .field("l2_cache_tag_object", &self.l2_cache_tag_object())
+            .field("l2_cache_mem_object", &self.l2_cache_mem_object())
+            .finish()
+    }
+}
+#[doc = "Cache Tag and Data memory Object control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_object_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_OBJECT_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_OBJECT_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_object_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_OBJECT_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_OBJECT_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_OBJECT_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_preload_addr.rs
+++ b/esp32h2/src/cache/l2_cache_preload_addr.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_PRELOAD_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_PRELOAD_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOAD_ADDR` reader - Those bits are used to configure the start virtual address of preload on L2-Cache, which should be used together with L2_CACHE_PRELOAD_SIZE_REG"]
+pub type L2_CACHE_PRELOAD_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of preload on L2-Cache, which should be used together with L2_CACHE_PRELOAD_SIZE_REG"]
+    #[inline(always)]
+    pub fn l2_cache_preload_addr(&self) -> L2_CACHE_PRELOAD_ADDR_R {
+        L2_CACHE_PRELOAD_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOAD_ADDR")
+            .field("l2_cache_preload_addr", &self.l2_cache_preload_addr())
+            .finish()
+    }
+}
+#[doc = "L2 Cache preload address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOAD_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOAD_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_preload_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOAD_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOAD_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOAD_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_preload_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_preload_ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `L2_CACHE_PRELOAD_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "Register `L2_CACHE_PRELOAD_CTRL` writer"]
+pub type W = crate::W<L2_CACHE_PRELOAD_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOAD_ENA` reader - The bit is used to enable preload operation on L2-Cache. It will be cleared by hardware automatically after preload operation is done."]
+pub type L2_CACHE_PRELOAD_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PRELOAD_ENA` writer - The bit is used to enable preload operation on L2-Cache. It will be cleared by hardware automatically after preload operation is done."]
+pub type L2_CACHE_PRELOAD_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_CACHE_PRELOAD_DONE` reader - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+pub type L2_CACHE_PRELOAD_DONE_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PRELOAD_ORDER` reader - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+pub type L2_CACHE_PRELOAD_ORDER_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PRELOAD_RGID` reader - The bit is used to set the gid of l2 cache preload."]
+pub type L2_CACHE_PRELOAD_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L2-Cache. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_preload_ena(&self) -> L2_CACHE_PRELOAD_ENA_R {
+        L2_CACHE_PRELOAD_ENA_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to indicate whether preload operation is finished or not. 0: not finished. 1: finished."]
+    #[inline(always)]
+    pub fn l2_cache_preload_done(&self) -> L2_CACHE_PRELOAD_DONE_R {
+        L2_CACHE_PRELOAD_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - The bit is used to configure the direction of preload operation. 0: ascending, 1: descending."]
+    #[inline(always)]
+    pub fn l2_cache_preload_order(&self) -> L2_CACHE_PRELOAD_ORDER_R {
+        L2_CACHE_PRELOAD_ORDER_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bits 3:6 - The bit is used to set the gid of l2 cache preload."]
+    #[inline(always)]
+    pub fn l2_cache_preload_rgid(&self) -> L2_CACHE_PRELOAD_RGID_R {
+        L2_CACHE_PRELOAD_RGID_R::new(((self.bits >> 3) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOAD_CTRL")
+            .field("l2_cache_preload_ena", &self.l2_cache_preload_ena())
+            .field("l2_cache_preload_done", &self.l2_cache_preload_done())
+            .field("l2_cache_preload_order", &self.l2_cache_preload_order())
+            .field("l2_cache_preload_rgid", &self.l2_cache_preload_rgid())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - The bit is used to enable preload operation on L2-Cache. It will be cleared by hardware automatically after preload operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_preload_ena(
+        &mut self,
+    ) -> L2_CACHE_PRELOAD_ENA_W<'_, L2_CACHE_PRELOAD_CTRL_SPEC> {
+        L2_CACHE_PRELOAD_ENA_W::new(self, 0)
+    }
+}
+#[doc = "L2 Cache preload-operation control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_preload_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOAD_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOAD_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_preload_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOAD_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l2_cache_preload_ctrl::W`](W) writer structure"]
+impl crate::Writable for L2_CACHE_PRELOAD_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L2_CACHE_PRELOAD_CTRL to value 0x02"]
+impl crate::Resettable for L2_CACHE_PRELOAD_CTRL_SPEC {
+    const RESET_VALUE: u32 = 0x02;
+}

--- a/esp32h2/src/cache/l2_cache_preload_rst_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_preload_rst_ctrl.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_PRELOAD_RST_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_PRELOAD_RST_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_RST` reader - set this bit to reset preload-logic inside L2-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+pub type L2_CACHE_PLD_RST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - set this bit to reset preload-logic inside L2-Cache. Recommend that this should only be used to initialize preload-logic when some fatal error of preload-logic occurs."]
+    #[inline(always)]
+    pub fn l2_cache_pld_rst(&self) -> L2_CACHE_PLD_RST_R {
+        L2_CACHE_PLD_RST_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOAD_RST_CTRL")
+            .field("l2_cache_pld_rst", &self.l2_cache_pld_rst())
+            .finish()
+    }
+}
+#[doc = "Cache Preload Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_rst_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOAD_RST_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOAD_RST_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_preload_rst_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOAD_RST_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOAD_RST_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOAD_RST_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_preload_size.rs
+++ b/esp32h2/src/cache/l2_cache_preload_size.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_PRELOAD_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_PRELOAD_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOAD_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOAD_ADDR_REG"]
+pub type L2_CACHE_PRELOAD_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - Those bits are used to configure the size of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOAD_ADDR_REG"]
+    #[inline(always)]
+    pub fn l2_cache_preload_size(&self) -> L2_CACHE_PRELOAD_SIZE_R {
+        L2_CACHE_PRELOAD_SIZE_R::new((self.bits & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOAD_SIZE")
+            .field("l2_cache_preload_size", &self.l2_cache_preload_size())
+            .finish()
+    }
+}
+#[doc = "L2 Cache preload size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_preload_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOAD_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOAD_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_preload_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOAD_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOAD_SIZE to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOAD_SIZE_SPEC {}

--- a/esp32h2/src/cache/l2_cache_prelock_conf.rs
+++ b/esp32h2/src/cache/l2_cache_prelock_conf.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L2_CACHE_PRELOCK_CONF` reader"]
+pub type R = crate::R<L2_CACHE_PRELOCK_CONF_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT0_EN` reader - The bit is used to enable the first section of prelock function on L2-Cache."]
+pub type L2_CACHE_PRELOCK_SCT0_EN_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT1_EN` reader - The bit is used to enable the second section of prelock function on L2-Cache."]
+pub type L2_CACHE_PRELOCK_SCT1_EN_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PRELOCK_RGID` reader - The bit is used to set the gid of l2 cache prelock."]
+pub type L2_CACHE_PRELOCK_RGID_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - The bit is used to enable the first section of prelock function on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct0_en(&self) -> L2_CACHE_PRELOCK_SCT0_EN_R {
+        L2_CACHE_PRELOCK_SCT0_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - The bit is used to enable the second section of prelock function on L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct1_en(&self) -> L2_CACHE_PRELOCK_SCT1_EN_R {
+        L2_CACHE_PRELOCK_SCT1_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:5 - The bit is used to set the gid of l2 cache prelock."]
+    #[inline(always)]
+    pub fn l2_cache_prelock_rgid(&self) -> L2_CACHE_PRELOCK_RGID_R {
+        L2_CACHE_PRELOCK_RGID_R::new(((self.bits >> 2) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOCK_CONF")
+            .field("l2_cache_prelock_sct0_en", &self.l2_cache_prelock_sct0_en())
+            .field("l2_cache_prelock_sct1_en", &self.l2_cache_prelock_sct1_en())
+            .field("l2_cache_prelock_rgid", &self.l2_cache_prelock_rgid())
+            .finish()
+    }
+}
+#[doc = "L2 Cache prelock configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOCK_CONF_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOCK_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_prelock_conf::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOCK_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOCK_CONF to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOCK_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_prelock_sct0_addr.rs
+++ b/esp32h2/src/cache/l2_cache_prelock_sct0_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_PRELOCK_SCT0_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_PRELOCK_SCT0_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT0_ADDR` reader - Those bits are used to configure the start virtual address of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT0_SIZE_REG"]
+pub type L2_CACHE_PRELOCK_SCT0_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT0_SIZE_REG"]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct0_addr(&self) -> L2_CACHE_PRELOCK_SCT0_ADDR_R {
+        L2_CACHE_PRELOCK_SCT0_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOCK_SCT0_ADDR")
+            .field(
+                "l2_cache_prelock_sct0_addr",
+                &self.l2_cache_prelock_sct0_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache prelock section0 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct0_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOCK_SCT0_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOCK_SCT0_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_prelock_sct0_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOCK_SCT0_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOCK_SCT0_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOCK_SCT0_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_prelock_sct1_addr.rs
+++ b/esp32h2/src/cache/l2_cache_prelock_sct1_addr.rs
@@ -1,0 +1,31 @@
+#[doc = "Register `L2_CACHE_PRELOCK_SCT1_ADDR` reader"]
+pub type R = crate::R<L2_CACHE_PRELOCK_SCT1_ADDR_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT1_ADDR` reader - Those bits are used to configure the start virtual address of the second section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT1_SIZE_REG"]
+pub type L2_CACHE_PRELOCK_SCT1_ADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are used to configure the start virtual address of the second section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT1_SIZE_REG"]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct1_addr(&self) -> L2_CACHE_PRELOCK_SCT1_ADDR_R {
+        L2_CACHE_PRELOCK_SCT1_ADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOCK_SCT1_ADDR")
+            .field(
+                "l2_cache_prelock_sct1_addr",
+                &self.l2_cache_prelock_sct1_addr(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache prelock section1 address configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct1_addr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOCK_SCT1_ADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOCK_SCT1_ADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_prelock_sct1_addr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOCK_SCT1_ADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOCK_SCT1_ADDR to value 0"]
+impl crate::Resettable for L2_CACHE_PRELOCK_SCT1_ADDR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_prelock_sct_size.rs
+++ b/esp32h2/src/cache/l2_cache_prelock_sct_size.rs
@@ -1,0 +1,44 @@
+#[doc = "Register `L2_CACHE_PRELOCK_SCT_SIZE` reader"]
+pub type R = crate::R<L2_CACHE_PRELOCK_SCT_SIZE_SPEC>;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT0_SIZE` reader - Those bits are used to configure the size of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT0_ADDR_REG"]
+pub type L2_CACHE_PRELOCK_SCT0_SIZE_R = crate::FieldReader<u16>;
+#[doc = "Field `L2_CACHE_PRELOCK_SCT1_SIZE` reader - Those bits are used to configure the size of the second section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT1_ADDR_REG"]
+pub type L2_CACHE_PRELOCK_SCT1_SIZE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:15 - Those bits are used to configure the size of the first section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT0_ADDR_REG"]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct0_size(&self) -> L2_CACHE_PRELOCK_SCT0_SIZE_R {
+        L2_CACHE_PRELOCK_SCT0_SIZE_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - Those bits are used to configure the size of the second section of prelock on L2-Cache, which should be used together with L2_CACHE_PRELOCK_SCT1_ADDR_REG"]
+    #[inline(always)]
+    pub fn l2_cache_prelock_sct1_size(&self) -> L2_CACHE_PRELOCK_SCT1_SIZE_R {
+        L2_CACHE_PRELOCK_SCT1_SIZE_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_PRELOCK_SCT_SIZE")
+            .field(
+                "l2_cache_prelock_sct0_size",
+                &self.l2_cache_prelock_sct0_size(),
+            )
+            .field(
+                "l2_cache_prelock_sct1_size",
+                &self.l2_cache_prelock_sct1_size(),
+            )
+            .finish()
+    }
+}
+#[doc = "L2 Cache prelock section size configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_prelock_sct_size::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_PRELOCK_SCT_SIZE_SPEC;
+impl crate::RegisterSpec for L2_CACHE_PRELOCK_SCT_SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_prelock_sct_size::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_PRELOCK_SCT_SIZE_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_PRELOCK_SCT_SIZE to value 0xffff_ffff"]
+impl crate::Resettable for L2_CACHE_PRELOCK_SCT_SIZE_SPEC {
+    const RESET_VALUE: u32 = 0xffff_ffff;
+}

--- a/esp32h2/src/cache/l2_cache_sync_preload_exception.rs
+++ b/esp32h2/src/cache/l2_cache_sync_preload_exception.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_EXCEPTION` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_ERR_CODE` reader - The value 2 is Only available which means preload size is error in L2-Cache."]
+pub type L2_CACHE_PLD_ERR_CODE_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 10:11 - The value 2 is Only available which means preload size is error in L2-Cache."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_code(&self) -> L2_CACHE_PLD_ERR_CODE_R {
+        L2_CACHE_PLD_ERR_CODE_R::new(((self.bits >> 10) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_PRELOAD_EXCEPTION")
+            .field("l2_cache_pld_err_code", &self.l2_cache_pld_err_code())
+            .finish()
+    }
+}
+#[doc = "Cache Sync/Preload Operation exception register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_exception::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_preload_exception::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_PRELOAD_EXCEPTION to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_PRELOAD_EXCEPTION_SPEC {}

--- a/esp32h2/src/cache/l2_cache_sync_preload_int_clr.rs
+++ b/esp32h2/src/cache/l2_cache_sync_preload_int_clr.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_INT_CLR` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_DONE_INT_CLR` reader - The bit is used to clear interrupt that occurs only when L2-Cache preload-operation is done."]
+pub type L2_CACHE_PLD_DONE_INT_CLR_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PLD_ERR_INT_CLR` reader - The bit is used to clear interrupt of L2-Cache preload-operation error."]
+pub type L2_CACHE_PLD_ERR_INT_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to clear interrupt that occurs only when L2-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_pld_done_int_clr(&self) -> L2_CACHE_PLD_DONE_INT_CLR_R {
+        L2_CACHE_PLD_DONE_INT_CLR_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit is used to clear interrupt of L2-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_int_clr(&self) -> L2_CACHE_PLD_ERR_INT_CLR_R {
+        L2_CACHE_PLD_ERR_INT_CLR_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_PRELOAD_INT_CLR")
+            .field(
+                "l2_cache_pld_done_int_clr",
+                &self.l2_cache_pld_done_int_clr(),
+            )
+            .field("l2_cache_pld_err_int_clr", &self.l2_cache_pld_err_int_clr())
+            .finish()
+    }
+}
+#[doc = "Sync Preload operation Interrupt clear register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_clr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_preload_int_clr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_PRELOAD_INT_CLR to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_PRELOAD_INT_CLR_SPEC {}

--- a/esp32h2/src/cache/l2_cache_sync_preload_int_ena.rs
+++ b/esp32h2/src/cache/l2_cache_sync_preload_int_ena.rs
@@ -1,0 +1,39 @@
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_INT_ENA` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_DONE_INT_ENA` reader - The bit is used to enable interrupt of L2-Cache preload-operation done."]
+pub type L2_CACHE_PLD_DONE_INT_ENA_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PLD_ERR_INT_ENA` reader - The bit is used to enable interrupt of L2-Cache preload-operation error."]
+pub type L2_CACHE_PLD_ERR_INT_ENA_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to enable interrupt of L2-Cache preload-operation done."]
+    #[inline(always)]
+    pub fn l2_cache_pld_done_int_ena(&self) -> L2_CACHE_PLD_DONE_INT_ENA_R {
+        L2_CACHE_PLD_DONE_INT_ENA_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit is used to enable interrupt of L2-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_int_ena(&self) -> L2_CACHE_PLD_ERR_INT_ENA_R {
+        L2_CACHE_PLD_ERR_INT_ENA_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_PRELOAD_INT_ENA")
+            .field(
+                "l2_cache_pld_done_int_ena",
+                &self.l2_cache_pld_done_int_ena(),
+            )
+            .field("l2_cache_pld_err_int_ena", &self.l2_cache_pld_err_int_ena())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt enable register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_ena::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_preload_int_ena::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_PRELOAD_INT_ENA to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_PRELOAD_INT_ENA_SPEC {}

--- a/esp32h2/src/cache/l2_cache_sync_preload_int_raw.rs
+++ b/esp32h2/src/cache/l2_cache_sync_preload_int_raw.rs
@@ -1,0 +1,65 @@
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_INT_RAW` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_INT_RAW` writer"]
+pub type W = crate::W<L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_DONE_INT_RAW` reader - The raw bit of the interrupt that occurs only when L2-Cache preload-operation is done."]
+pub type L2_CACHE_PLD_DONE_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PLD_DONE_INT_RAW` writer - The raw bit of the interrupt that occurs only when L2-Cache preload-operation is done."]
+pub type L2_CACHE_PLD_DONE_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `L2_CACHE_PLD_ERR_INT_RAW` reader - The raw bit of the interrupt that occurs only when L2-Cache preload-operation error occurs."]
+pub type L2_CACHE_PLD_ERR_INT_RAW_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PLD_ERR_INT_RAW` writer - The raw bit of the interrupt that occurs only when L2-Cache preload-operation error occurs."]
+pub type L2_CACHE_PLD_ERR_INT_RAW_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 5 - The raw bit of the interrupt that occurs only when L2-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_pld_done_int_raw(&self) -> L2_CACHE_PLD_DONE_INT_RAW_R {
+        L2_CACHE_PLD_DONE_INT_RAW_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The raw bit of the interrupt that occurs only when L2-Cache preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_int_raw(&self) -> L2_CACHE_PLD_ERR_INT_RAW_R {
+        L2_CACHE_PLD_ERR_INT_RAW_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_PRELOAD_INT_RAW")
+            .field(
+                "l2_cache_pld_done_int_raw",
+                &self.l2_cache_pld_done_int_raw(),
+            )
+            .field("l2_cache_pld_err_int_raw", &self.l2_cache_pld_err_int_raw())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 5 - The raw bit of the interrupt that occurs only when L2-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_pld_done_int_raw(
+        &mut self,
+    ) -> L2_CACHE_PLD_DONE_INT_RAW_W<'_, L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L2_CACHE_PLD_DONE_INT_RAW_W::new(self, 5)
+    }
+    #[doc = "Bit 12 - The raw bit of the interrupt that occurs only when L2-Cache preload-operation error occurs."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_int_raw(
+        &mut self,
+    ) -> L2_CACHE_PLD_ERR_INT_RAW_W<'_, L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC> {
+        L2_CACHE_PLD_ERR_INT_RAW_W::new(self, 12)
+    }
+}
+#[doc = "Sync Preload operation Interrupt raw register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_raw::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`l2_cache_sync_preload_int_raw::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_preload_int_raw::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`l2_cache_sync_preload_int_raw::W`](W) writer structure"]
+impl crate::Writable for L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_PRELOAD_INT_RAW to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_PRELOAD_INT_RAW_SPEC {}

--- a/esp32h2/src/cache/l2_cache_sync_preload_int_st.rs
+++ b/esp32h2/src/cache/l2_cache_sync_preload_int_st.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_SYNC_PRELOAD_INT_ST` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC>;
+#[doc = "Field `L2_CACHE_PLD_DONE_INT_ST` reader - The bit indicates the status of the interrupt that occurs only when L2-Cache preload-operation is done."]
+pub type L2_CACHE_PLD_DONE_INT_ST_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_PLD_ERR_INT_ST` reader - The bit indicates the status of the interrupt of L2-Cache preload-operation error."]
+pub type L2_CACHE_PLD_ERR_INT_ST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit indicates the status of the interrupt that occurs only when L2-Cache preload-operation is done."]
+    #[inline(always)]
+    pub fn l2_cache_pld_done_int_st(&self) -> L2_CACHE_PLD_DONE_INT_ST_R {
+        L2_CACHE_PLD_DONE_INT_ST_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 12 - The bit indicates the status of the interrupt of L2-Cache preload-operation error."]
+    #[inline(always)]
+    pub fn l2_cache_pld_err_int_st(&self) -> L2_CACHE_PLD_ERR_INT_ST_R {
+        L2_CACHE_PLD_ERR_INT_ST_R::new(((self.bits >> 12) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_PRELOAD_INT_ST")
+            .field("l2_cache_pld_done_int_st", &self.l2_cache_pld_done_int_st())
+            .field("l2_cache_pld_err_int_st", &self.l2_cache_pld_err_int_st())
+            .finish()
+    }
+}
+#[doc = "L1-Cache Access Fail Interrupt status register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_preload_int_st::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_preload_int_st::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_PRELOAD_INT_ST to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_PRELOAD_INT_ST_SPEC {}

--- a/esp32h2/src/cache/l2_cache_sync_rst_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_sync_rst_ctrl.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_SYNC_RST_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_SYNC_RST_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_SYNC_RST` reader - set this bit to reset sync-logic inside L2-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+pub type L2_CACHE_SYNC_RST_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - set this bit to reset sync-logic inside L2-Cache. Recommend that this should only be used to initialize sync-logic when some fatal error of sync-logic occurs."]
+    #[inline(always)]
+    pub fn l2_cache_sync_rst(&self) -> L2_CACHE_SYNC_RST_R {
+        L2_CACHE_SYNC_RST_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_SYNC_RST_CTRL")
+            .field("l2_cache_sync_rst", &self.l2_cache_sync_rst())
+            .finish()
+    }
+}
+#[doc = "Cache Sync Reset control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_sync_rst_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_SYNC_RST_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_SYNC_RST_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_sync_rst_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_SYNC_RST_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_SYNC_RST_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_SYNC_RST_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_tag_mem_acs_conf.rs
+++ b/esp32h2/src/cache/l2_cache_tag_mem_acs_conf.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `L2_CACHE_TAG_MEM_ACS_CONF` reader"]
+pub type R = crate::R<L2_CACHE_TAG_MEM_ACS_CONF_SPEC>;
+#[doc = "Field `L2_CACHE_TAG_MEM_RD_EN` reader - The bit is used to enable config-bus read L2-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L2_CACHE_TAG_MEM_RD_EN_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_TAG_MEM_WR_EN` reader - The bit is used to enable config-bus write L2-Cache tag memoryory. 0: disable, 1: enable."]
+pub type L2_CACHE_TAG_MEM_WR_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - The bit is used to enable config-bus read L2-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l2_cache_tag_mem_rd_en(&self) -> L2_CACHE_TAG_MEM_RD_EN_R {
+        L2_CACHE_TAG_MEM_RD_EN_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - The bit is used to enable config-bus write L2-Cache tag memoryory. 0: disable, 1: enable."]
+    #[inline(always)]
+    pub fn l2_cache_tag_mem_wr_en(&self) -> L2_CACHE_TAG_MEM_WR_EN_R {
+        L2_CACHE_TAG_MEM_WR_EN_R::new(((self.bits >> 21) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_TAG_MEM_ACS_CONF")
+            .field("l2_cache_tag_mem_rd_en", &self.l2_cache_tag_mem_rd_en())
+            .field("l2_cache_tag_mem_wr_en", &self.l2_cache_tag_mem_wr_en())
+            .finish()
+    }
+}
+#[doc = "Cache tag memory access configure register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_tag_mem_acs_conf::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_TAG_MEM_ACS_CONF_SPEC;
+impl crate::RegisterSpec for L2_CACHE_TAG_MEM_ACS_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_tag_mem_acs_conf::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_TAG_MEM_ACS_CONF_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_TAG_MEM_ACS_CONF to value 0"]
+impl crate::Resettable for L2_CACHE_TAG_MEM_ACS_CONF_SPEC {}

--- a/esp32h2/src/cache/l2_cache_tag_mem_power_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_tag_mem_power_ctrl.rs
@@ -1,0 +1,53 @@
+#[doc = "Register `L2_CACHE_TAG_MEM_POWER_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_TAG_MEM_POWER_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_TAG_MEM_FORCE_ON` reader - The bit is used to close clock gating of L2-Cache tag memory. 1: close gating, 0: open clock gating."]
+pub type L2_CACHE_TAG_MEM_FORCE_ON_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_TAG_MEM_FORCE_PD` reader - The bit is used to power L2-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+pub type L2_CACHE_TAG_MEM_FORCE_PD_R = crate::BitReader;
+#[doc = "Field `L2_CACHE_TAG_MEM_FORCE_PU` reader - The bit is used to power L2-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+pub type L2_CACHE_TAG_MEM_FORCE_PU_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 20 - The bit is used to close clock gating of L2-Cache tag memory. 1: close gating, 0: open clock gating."]
+    #[inline(always)]
+    pub fn l2_cache_tag_mem_force_on(&self) -> L2_CACHE_TAG_MEM_FORCE_ON_R {
+        L2_CACHE_TAG_MEM_FORCE_ON_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - The bit is used to power L2-Cache tag memory down. 0: follow rtc_lslp, 1: power down"]
+    #[inline(always)]
+    pub fn l2_cache_tag_mem_force_pd(&self) -> L2_CACHE_TAG_MEM_FORCE_PD_R {
+        L2_CACHE_TAG_MEM_FORCE_PD_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - The bit is used to power L2-Cache tag memory up. 0: follow rtc_lslp, 1: power up"]
+    #[inline(always)]
+    pub fn l2_cache_tag_mem_force_pu(&self) -> L2_CACHE_TAG_MEM_FORCE_PU_R {
+        L2_CACHE_TAG_MEM_FORCE_PU_R::new(((self.bits >> 22) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_TAG_MEM_POWER_CTRL")
+            .field(
+                "l2_cache_tag_mem_force_on",
+                &self.l2_cache_tag_mem_force_on(),
+            )
+            .field(
+                "l2_cache_tag_mem_force_pd",
+                &self.l2_cache_tag_mem_force_pd(),
+            )
+            .field(
+                "l2_cache_tag_mem_force_pu",
+                &self.l2_cache_tag_mem_force_pu(),
+            )
+            .finish()
+    }
+}
+#[doc = "Cache tag memory power control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_tag_mem_power_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_TAG_MEM_POWER_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_TAG_MEM_POWER_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_tag_mem_power_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_TAG_MEM_POWER_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_TAG_MEM_POWER_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_TAG_MEM_POWER_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_cache_vaddr.rs
+++ b/esp32h2/src/cache/l2_cache_vaddr.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `L2_CACHE_VADDR` reader"]
+pub type R = crate::R<L2_CACHE_VADDR_SPEC>;
+#[doc = "Field `L2_CACHE_VADDR` reader - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+pub type L2_CACHE_VADDR_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits stores the virtual address which will decide where inside the specified tag memory object will be accessed."]
+    #[inline(always)]
+    pub fn l2_cache_vaddr(&self) -> L2_CACHE_VADDR_R {
+        L2_CACHE_VADDR_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_VADDR")
+            .field("l2_cache_vaddr", &self.l2_cache_vaddr())
+            .finish()
+    }
+}
+#[doc = "Cache Vaddr register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_vaddr::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_VADDR_SPEC;
+impl crate::RegisterSpec for L2_CACHE_VADDR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_vaddr::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_VADDR_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_VADDR to value 0x4000_0000"]
+impl crate::Resettable for L2_CACHE_VADDR_SPEC {
+    const RESET_VALUE: u32 = 0x4000_0000;
+}

--- a/esp32h2/src/cache/l2_cache_way_object.rs
+++ b/esp32h2/src/cache/l2_cache_way_object.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_WAY_OBJECT` reader"]
+pub type R = crate::R<L2_CACHE_WAY_OBJECT_SPEC>;
+#[doc = "Field `L2_CACHE_WAY_OBJECT` reader - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+pub type L2_CACHE_WAY_OBJECT_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:2 - Set this bits to select which way of the tag-object will be accessed. 0: way0, 1: way1, 2: way2, 3: way3, ?, 7: way7."]
+    #[inline(always)]
+    pub fn l2_cache_way_object(&self) -> L2_CACHE_WAY_OBJECT_R {
+        L2_CACHE_WAY_OBJECT_R::new((self.bits & 7) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_WAY_OBJECT")
+            .field("l2_cache_way_object", &self.l2_cache_way_object())
+            .finish()
+    }
+}
+#[doc = "Cache Tag and Data memory way register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_way_object::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_WAY_OBJECT_SPEC;
+impl crate::RegisterSpec for L2_CACHE_WAY_OBJECT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_way_object::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_WAY_OBJECT_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_WAY_OBJECT to value 0"]
+impl crate::Resettable for L2_CACHE_WAY_OBJECT_SPEC {}

--- a/esp32h2/src/cache/l2_cache_wrap_around_ctrl.rs
+++ b/esp32h2/src/cache/l2_cache_wrap_around_ctrl.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_CACHE_WRAP_AROUND_CTRL` reader"]
+pub type R = crate::R<L2_CACHE_WRAP_AROUND_CTRL_SPEC>;
+#[doc = "Field `L2_CACHE_WRAP` reader - Set this bit as 1 to enable L2-Cache wrap around mode."]
+pub type L2_CACHE_WRAP_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - Set this bit as 1 to enable L2-Cache wrap around mode."]
+    #[inline(always)]
+    pub fn l2_cache_wrap(&self) -> L2_CACHE_WRAP_R {
+        L2_CACHE_WRAP_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_CACHE_WRAP_AROUND_CTRL")
+            .field("l2_cache_wrap", &self.l2_cache_wrap())
+            .finish()
+    }
+}
+#[doc = "Cache wrap around control register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_cache_wrap_around_ctrl::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_CACHE_WRAP_AROUND_CTRL_SPEC;
+impl crate::RegisterSpec for L2_CACHE_WRAP_AROUND_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_cache_wrap_around_ctrl::R`](R) reader structure"]
+impl crate::Readable for L2_CACHE_WRAP_AROUND_CTRL_SPEC {}
+#[doc = "`reset()` method sets L2_CACHE_WRAP_AROUND_CTRL to value 0"]
+impl crate::Resettable for L2_CACHE_WRAP_AROUND_CTRL_SPEC {}

--- a/esp32h2/src/cache/l2_dbus0_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus0_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS0_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_DBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS0_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+pub type L2_DBUS0_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_conflict_cnt(&self) -> L2_DBUS0_CONFLICT_CNT_R {
+        L2_DBUS0_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS0_ACS_CONFLICT_CNT")
+            .field("l2_dbus0_conflict_cnt", &self.l2_dbus0_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS0_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS0_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus0_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS0_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS0_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS0_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus0_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus0_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS0_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_DBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS0_HIT_CNT` reader - The register records the number of hits when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+pub type L2_DBUS0_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_hit_cnt(&self) -> L2_DBUS0_HIT_CNT_R {
+        L2_DBUS0_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS0_ACS_HIT_CNT")
+            .field("l2_dbus0_hit_cnt", &self.l2_dbus0_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS0_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS0_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus0_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS0_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS0_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS0_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus0_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus0_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS0_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_DBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_DBUS0_MISS_CNT` reader - The register records the number of missing when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+pub type L2_DBUS0_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-DCache accesses L2-Cache due to bus0 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_miss_cnt(&self) -> L2_DBUS0_MISS_CNT_R {
+        L2_DBUS0_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS0_ACS_MISS_CNT")
+            .field("l2_dbus0_miss_cnt", &self.l2_dbus0_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS0_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS0_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus0_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS0_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS0_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_DBUS0_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus0_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus0_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS0_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_DBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_DBUS0_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus0 accessing L1-DCache."]
+pub type L2_DBUS0_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus0 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus0_nxtlvl_cnt(&self) -> L2_DBUS0_NXTLVL_CNT_R {
+        L2_DBUS0_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS0_ACS_NXTLVL_CNT")
+            .field("l2_dbus0_nxtlvl_cnt", &self.l2_dbus0_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus0_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS0_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS0_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus0_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS0_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS0_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_DBUS0_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus1_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus1_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS1_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_DBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS1_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+pub type L2_DBUS1_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_conflict_cnt(&self) -> L2_DBUS1_CONFLICT_CNT_R {
+        L2_DBUS1_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS1_ACS_CONFLICT_CNT")
+            .field("l2_dbus1_conflict_cnt", &self.l2_dbus1_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS1_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS1_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus1_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS1_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS1_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS1_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus1_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus1_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS1_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_DBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS1_HIT_CNT` reader - The register records the number of hits when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+pub type L2_DBUS1_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_hit_cnt(&self) -> L2_DBUS1_HIT_CNT_R {
+        L2_DBUS1_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS1_ACS_HIT_CNT")
+            .field("l2_dbus1_hit_cnt", &self.l2_dbus1_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS1_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS1_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus1_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS1_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS1_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS1_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus1_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus1_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS1_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_DBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_DBUS1_MISS_CNT` reader - The register records the number of missing when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+pub type L2_DBUS1_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-DCache accesses L2-Cache due to bus1 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_miss_cnt(&self) -> L2_DBUS1_MISS_CNT_R {
+        L2_DBUS1_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS1_ACS_MISS_CNT")
+            .field("l2_dbus1_miss_cnt", &self.l2_dbus1_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS1_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS1_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus1_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS1_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS1_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_DBUS1_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus1_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus1_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS1_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_DBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_DBUS1_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus1 accessing L1-DCache."]
+pub type L2_DBUS1_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus1 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus1_nxtlvl_cnt(&self) -> L2_DBUS1_NXTLVL_CNT_R {
+        L2_DBUS1_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS1_ACS_NXTLVL_CNT")
+            .field("l2_dbus1_nxtlvl_cnt", &self.l2_dbus1_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus1_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS1_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS1_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus1_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS1_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS1_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_DBUS1_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus2_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus2_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS2_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_DBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS2_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+pub type L2_DBUS2_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_conflict_cnt(&self) -> L2_DBUS2_CONFLICT_CNT_R {
+        L2_DBUS2_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS2_ACS_CONFLICT_CNT")
+            .field("l2_dbus2_conflict_cnt", &self.l2_dbus2_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS2_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS2_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus2_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS2_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS2_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS2_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus2_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus2_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS2_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_DBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS2_HIT_CNT` reader - The register records the number of hits when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+pub type L2_DBUS2_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_hit_cnt(&self) -> L2_DBUS2_HIT_CNT_R {
+        L2_DBUS2_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS2_ACS_HIT_CNT")
+            .field("l2_dbus2_hit_cnt", &self.l2_dbus2_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS2_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS2_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus2_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS2_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS2_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS2_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus2_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus2_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS2_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_DBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_DBUS2_MISS_CNT` reader - The register records the number of missing when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+pub type L2_DBUS2_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-DCache accesses L2-Cache due to bus2 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_miss_cnt(&self) -> L2_DBUS2_MISS_CNT_R {
+        L2_DBUS2_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS2_ACS_MISS_CNT")
+            .field("l2_dbus2_miss_cnt", &self.l2_dbus2_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS2_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS2_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus2_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS2_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS2_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_DBUS2_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus2_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus2_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS2_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_DBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_DBUS2_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus2 accessing L1-DCache."]
+pub type L2_DBUS2_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus2 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus2_nxtlvl_cnt(&self) -> L2_DBUS2_NXTLVL_CNT_R {
+        L2_DBUS2_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS2_ACS_NXTLVL_CNT")
+            .field("l2_dbus2_nxtlvl_cnt", &self.l2_dbus2_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus2_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS2_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS2_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus2_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS2_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS2_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_DBUS2_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus3_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus3_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS3_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_DBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS3_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+pub type L2_DBUS3_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_conflict_cnt(&self) -> L2_DBUS3_CONFLICT_CNT_R {
+        L2_DBUS3_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS3_ACS_CONFLICT_CNT")
+            .field("l2_dbus3_conflict_cnt", &self.l2_dbus3_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS3_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS3_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus3_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS3_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS3_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS3_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus3_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus3_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS3_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_DBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_DBUS3_HIT_CNT` reader - The register records the number of hits when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+pub type L2_DBUS3_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_hit_cnt(&self) -> L2_DBUS3_HIT_CNT_R {
+        L2_DBUS3_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS3_ACS_HIT_CNT")
+            .field("l2_dbus3_hit_cnt", &self.l2_dbus3_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS3_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS3_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus3_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS3_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS3_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_DBUS3_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus3_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus3_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS3_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_DBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_DBUS3_MISS_CNT` reader - The register records the number of missing when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+pub type L2_DBUS3_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-DCache accesses L2-Cache due to bus3 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_miss_cnt(&self) -> L2_DBUS3_MISS_CNT_R {
+        L2_DBUS3_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS3_ACS_MISS_CNT")
+            .field("l2_dbus3_miss_cnt", &self.l2_dbus3_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS3_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS3_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus3_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS3_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS3_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_DBUS3_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_dbus3_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_dbus3_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_DBUS3_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_DBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_DBUS3_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus3 accessing L1-DCache."]
+pub type L2_DBUS3_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-DCache accessing L2-Cache due to bus3 accessing L1-DCache."]
+    #[inline(always)]
+    pub fn l2_dbus3_nxtlvl_cnt(&self) -> L2_DBUS3_NXTLVL_CNT_R {
+        L2_DBUS3_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_DBUS3_ACS_NXTLVL_CNT")
+            .field("l2_dbus3_nxtlvl_cnt", &self.l2_dbus3_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_dbus3_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_DBUS3_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_DBUS3_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_dbus3_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_DBUS3_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_DBUS3_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_DBUS3_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus0_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus0_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS0_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_IBUS0_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS0_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+pub type L2_IBUS0_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_conflict_cnt(&self) -> L2_IBUS0_CONFLICT_CNT_R {
+        L2_IBUS0_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS0_ACS_CONFLICT_CNT")
+            .field("l2_ibus0_conflict_cnt", &self.l2_ibus0_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS0_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS0_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus0_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS0_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS0_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS0_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus0_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus0_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS0_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_IBUS0_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS0_HIT_CNT` reader - The register records the number of hits when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+pub type L2_IBUS0_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_hit_cnt(&self) -> L2_IBUS0_HIT_CNT_R {
+        L2_IBUS0_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS0_ACS_HIT_CNT")
+            .field("l2_ibus0_hit_cnt", &self.l2_ibus0_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS0_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS0_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus0_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS0_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS0_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS0_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus0_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus0_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS0_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_IBUS0_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_IBUS0_MISS_CNT` reader - The register records the number of missing when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+pub type L2_IBUS0_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-ICache0 accesses L2-Cache due to bus0 accessing L1-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_miss_cnt(&self) -> L2_IBUS0_MISS_CNT_R {
+        L2_IBUS0_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS0_ACS_MISS_CNT")
+            .field("l2_ibus0_miss_cnt", &self.l2_ibus0_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS0_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS0_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus0_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS0_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS0_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_IBUS0_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus0_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus0_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS0_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_IBUS0_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_IBUS0_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-ICache0 accessing L2-Cache due to bus0 accessing L1-ICache0."]
+pub type L2_IBUS0_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-ICache0 accessing L2-Cache due to bus0 accessing L1-ICache0."]
+    #[inline(always)]
+    pub fn l2_ibus0_nxtlvl_cnt(&self) -> L2_IBUS0_NXTLVL_CNT_R {
+        L2_IBUS0_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS0_ACS_NXTLVL_CNT")
+            .field("l2_ibus0_nxtlvl_cnt", &self.l2_ibus0_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus0 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus0_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS0_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS0_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus0_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS0_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS0_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_IBUS0_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus1_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus1_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS1_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_IBUS1_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS1_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+pub type L2_IBUS1_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_conflict_cnt(&self) -> L2_IBUS1_CONFLICT_CNT_R {
+        L2_IBUS1_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS1_ACS_CONFLICT_CNT")
+            .field("l2_ibus1_conflict_cnt", &self.l2_ibus1_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS1_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS1_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus1_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS1_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS1_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS1_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus1_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus1_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS1_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_IBUS1_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS1_HIT_CNT` reader - The register records the number of hits when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+pub type L2_IBUS1_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_hit_cnt(&self) -> L2_IBUS1_HIT_CNT_R {
+        L2_IBUS1_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS1_ACS_HIT_CNT")
+            .field("l2_ibus1_hit_cnt", &self.l2_ibus1_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS1_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS1_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus1_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS1_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS1_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS1_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus1_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus1_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS1_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_IBUS1_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_IBUS1_MISS_CNT` reader - The register records the number of missing when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+pub type L2_IBUS1_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-ICache1 accesses L2-Cache due to bus1 accessing L1-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_miss_cnt(&self) -> L2_IBUS1_MISS_CNT_R {
+        L2_IBUS1_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS1_ACS_MISS_CNT")
+            .field("l2_ibus1_miss_cnt", &self.l2_ibus1_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS1_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS1_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus1_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS1_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS1_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_IBUS1_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus1_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus1_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS1_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_IBUS1_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_IBUS1_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-ICache1 accessing L2-Cache due to bus1 accessing L1-ICache1."]
+pub type L2_IBUS1_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-ICache1 accessing L2-Cache due to bus1 accessing L1-ICache1."]
+    #[inline(always)]
+    pub fn l2_ibus1_nxtlvl_cnt(&self) -> L2_IBUS1_NXTLVL_CNT_R {
+        L2_IBUS1_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS1_ACS_NXTLVL_CNT")
+            .field("l2_ibus1_nxtlvl_cnt", &self.l2_ibus1_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus1 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus1_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS1_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS1_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus1_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS1_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS1_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_IBUS1_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus2_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus2_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS2_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_IBUS2_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS2_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+pub type L2_IBUS2_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_conflict_cnt(&self) -> L2_IBUS2_CONFLICT_CNT_R {
+        L2_IBUS2_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS2_ACS_CONFLICT_CNT")
+            .field("l2_ibus2_conflict_cnt", &self.l2_ibus2_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS2_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS2_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus2_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS2_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS2_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS2_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus2_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus2_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS2_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_IBUS2_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS2_HIT_CNT` reader - The register records the number of hits when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+pub type L2_IBUS2_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_hit_cnt(&self) -> L2_IBUS2_HIT_CNT_R {
+        L2_IBUS2_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS2_ACS_HIT_CNT")
+            .field("l2_ibus2_hit_cnt", &self.l2_ibus2_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS2_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS2_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus2_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS2_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS2_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS2_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus2_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus2_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS2_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_IBUS2_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_IBUS2_MISS_CNT` reader - The register records the number of missing when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+pub type L2_IBUS2_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-ICache2 accesses L2-Cache due to bus2 accessing L1-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_miss_cnt(&self) -> L2_IBUS2_MISS_CNT_R {
+        L2_IBUS2_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS2_ACS_MISS_CNT")
+            .field("l2_ibus2_miss_cnt", &self.l2_ibus2_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS2_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS2_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus2_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS2_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS2_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_IBUS2_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus2_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus2_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS2_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_IBUS2_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_IBUS2_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-ICache2 accessing L2-Cache due to bus2 accessing L1-ICache2."]
+pub type L2_IBUS2_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-ICache2 accessing L2-Cache due to bus2 accessing L1-ICache2."]
+    #[inline(always)]
+    pub fn l2_ibus2_nxtlvl_cnt(&self) -> L2_IBUS2_NXTLVL_CNT_R {
+        L2_IBUS2_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS2_ACS_NXTLVL_CNT")
+            .field("l2_ibus2_nxtlvl_cnt", &self.l2_ibus2_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus2 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus2_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS2_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS2_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus2_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS2_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS2_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_IBUS2_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus3_acs_conflict_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus3_acs_conflict_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS3_ACS_CONFLICT_CNT` reader"]
+pub type R = crate::R<L2_IBUS3_ACS_CONFLICT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS3_CONFLICT_CNT` reader - The register records the number of access-conflicts when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+pub type L2_IBUS3_CONFLICT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of access-conflicts when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_conflict_cnt(&self) -> L2_IBUS3_CONFLICT_CNT_R {
+        L2_IBUS3_CONFLICT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS3_ACS_CONFLICT_CNT")
+            .field("l2_ibus3_conflict_cnt", &self.l2_ibus3_conflict_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Conflict-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_conflict_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS3_ACS_CONFLICT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS3_ACS_CONFLICT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus3_acs_conflict_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS3_ACS_CONFLICT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS3_ACS_CONFLICT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS3_ACS_CONFLICT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus3_acs_hit_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus3_acs_hit_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS3_ACS_HIT_CNT` reader"]
+pub type R = crate::R<L2_IBUS3_ACS_HIT_CNT_SPEC>;
+#[doc = "Field `L2_IBUS3_HIT_CNT` reader - The register records the number of hits when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+pub type L2_IBUS3_HIT_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of hits when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_hit_cnt(&self) -> L2_IBUS3_HIT_CNT_R {
+        L2_IBUS3_HIT_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS3_ACS_HIT_CNT")
+            .field("l2_ibus3_hit_cnt", &self.l2_ibus3_hit_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Hit-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_hit_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS3_ACS_HIT_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS3_ACS_HIT_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus3_acs_hit_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS3_ACS_HIT_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS3_ACS_HIT_CNT to value 0"]
+impl crate::Resettable for L2_IBUS3_ACS_HIT_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus3_acs_miss_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus3_acs_miss_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS3_ACS_MISS_CNT` reader"]
+pub type R = crate::R<L2_IBUS3_ACS_MISS_CNT_SPEC>;
+#[doc = "Field `L2_IBUS3_MISS_CNT` reader - The register records the number of missing when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+pub type L2_IBUS3_MISS_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of missing when L1-ICache3 accesses L2-Cache due to bus3 accessing L1-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_miss_cnt(&self) -> L2_IBUS3_MISS_CNT_R {
+        L2_IBUS3_MISS_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS3_ACS_MISS_CNT")
+            .field("l2_ibus3_miss_cnt", &self.l2_ibus3_miss_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Miss-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_miss_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS3_ACS_MISS_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS3_ACS_MISS_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus3_acs_miss_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS3_ACS_MISS_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS3_ACS_MISS_CNT to value 0"]
+impl crate::Resettable for L2_IBUS3_ACS_MISS_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_ibus3_acs_nxtlvl_cnt.rs
+++ b/esp32h2/src/cache/l2_ibus3_acs_nxtlvl_cnt.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_IBUS3_ACS_NXTLVL_CNT` reader"]
+pub type R = crate::R<L2_IBUS3_ACS_NXTLVL_CNT_SPEC>;
+#[doc = "Field `L2_IBUS3_NXTLVL_CNT` reader - The register records the number of times that L2-Cache accesses external memory due to L1-ICache3 accessing L2-Cache due to bus3 accessing L1-ICache3."]
+pub type L2_IBUS3_NXTLVL_CNT_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - The register records the number of times that L2-Cache accesses external memory due to L1-ICache3 accessing L2-Cache due to bus3 accessing L1-ICache3."]
+    #[inline(always)]
+    pub fn l2_ibus3_nxtlvl_cnt(&self) -> L2_IBUS3_NXTLVL_CNT_R {
+        L2_IBUS3_NXTLVL_CNT_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_IBUS3_ACS_NXTLVL_CNT")
+            .field("l2_ibus3_nxtlvl_cnt", &self.l2_ibus3_nxtlvl_cnt())
+            .finish()
+    }
+}
+#[doc = "L2-Cache bus3 Next-Level-Access Counter register\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_ibus3_acs_nxtlvl_cnt::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_IBUS3_ACS_NXTLVL_CNT_SPEC;
+impl crate::RegisterSpec for L2_IBUS3_ACS_NXTLVL_CNT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_ibus3_acs_nxtlvl_cnt::R`](R) reader structure"]
+impl crate::Readable for L2_IBUS3_ACS_NXTLVL_CNT_SPEC {}
+#[doc = "`reset()` method sets L2_IBUS3_ACS_NXTLVL_CNT to value 0"]
+impl crate::Resettable for L2_IBUS3_ACS_NXTLVL_CNT_SPEC {}

--- a/esp32h2/src/cache/l2_unallocate_buffer_clear.rs
+++ b/esp32h2/src/cache/l2_unallocate_buffer_clear.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `L2_UNALLOCATE_BUFFER_CLEAR` reader"]
+pub type R = crate::R<L2_UNALLOCATE_BUFFER_CLEAR_SPEC>;
+#[doc = "Field `L2_CACHE_UNALLOC_CLR` reader - The bit is used to clear the unallocate request buffer of l2 icache where the unallocate request is responsed but not completed."]
+pub type L2_CACHE_UNALLOC_CLR_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 5 - The bit is used to clear the unallocate request buffer of l2 icache where the unallocate request is responsed but not completed."]
+    #[inline(always)]
+    pub fn l2_cache_unalloc_clr(&self) -> L2_CACHE_UNALLOC_CLR_R {
+        L2_CACHE_UNALLOC_CLR_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("L2_UNALLOCATE_BUFFER_CLEAR")
+            .field("l2_cache_unalloc_clr", &self.l2_cache_unalloc_clr())
+            .finish()
+    }
+}
+#[doc = "Unallocate request buffer clear registers\n\nYou can [`read`](crate::Reg::read) this register and get [`l2_unallocate_buffer_clear::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct L2_UNALLOCATE_BUFFER_CLEAR_SPEC;
+impl crate::RegisterSpec for L2_UNALLOCATE_BUFFER_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`l2_unallocate_buffer_clear::R`](R) reader structure"]
+impl crate::Readable for L2_UNALLOCATE_BUFFER_CLEAR_SPEC {}
+#[doc = "`reset()` method sets L2_UNALLOCATE_BUFFER_CLEAR to value 0"]
+impl crate::Resettable for L2_UNALLOCATE_BUFFER_CLEAR_SPEC {}

--- a/esp32h2/src/cache/level_split0.rs
+++ b/esp32h2/src/cache/level_split0.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `LEVEL_SPLIT0` reader"]
+pub type R = crate::R<LEVEL_SPLIT0_SPEC>;
+#[doc = "Field `LEVEL_SPLIT0` reader - Reserved"]
+pub type LEVEL_SPLIT0_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Reserved"]
+    #[inline(always)]
+    pub fn level_split0(&self) -> LEVEL_SPLIT0_R {
+        LEVEL_SPLIT0_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LEVEL_SPLIT0")
+            .field("level_split0", &self.level_split0())
+            .finish()
+    }
+}
+#[doc = "USED TO SPLIT L1 CACHE AND L2 CACHE\n\nYou can [`read`](crate::Reg::read) this register and get [`level_split0::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LEVEL_SPLIT0_SPEC;
+impl crate::RegisterSpec for LEVEL_SPLIT0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`level_split0::R`](R) reader structure"]
+impl crate::Readable for LEVEL_SPLIT0_SPEC {}
+#[doc = "`reset()` method sets LEVEL_SPLIT0 to value 0x0258"]
+impl crate::Resettable for LEVEL_SPLIT0_SPEC {
+    const RESET_VALUE: u32 = 0x0258;
+}

--- a/esp32h2/src/cache/level_split1.rs
+++ b/esp32h2/src/cache/level_split1.rs
@@ -1,0 +1,30 @@
+#[doc = "Register `LEVEL_SPLIT1` reader"]
+pub type R = crate::R<LEVEL_SPLIT1_SPEC>;
+#[doc = "Field `LEVEL_SPLIT1` reader - Reserved"]
+pub type LEVEL_SPLIT1_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Reserved"]
+    #[inline(always)]
+    pub fn level_split1(&self) -> LEVEL_SPLIT1_R {
+        LEVEL_SPLIT1_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LEVEL_SPLIT1")
+            .field("level_split1", &self.level_split1())
+            .finish()
+    }
+}
+#[doc = "USED TO SPLIT L1 CACHE AND L2 CACHE\n\nYou can [`read`](crate::Reg::read) this register and get [`level_split1::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LEVEL_SPLIT1_SPEC;
+impl crate::RegisterSpec for LEVEL_SPLIT1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`level_split1::R`](R) reader structure"]
+impl crate::Readable for LEVEL_SPLIT1_SPEC {}
+#[doc = "`reset()` method sets LEVEL_SPLIT1 to value 0x03a8"]
+impl crate::Resettable for LEVEL_SPLIT1_SPEC {
+    const RESET_VALUE: u32 = 0x03a8;
+}

--- a/esp32h2/src/cache/redundancy_sig0.rs
+++ b/esp32h2/src/cache/redundancy_sig0.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `REDUNDANCY_SIG0` reader"]
+pub type R = crate::R<REDUNDANCY_SIG0_SPEC>;
+#[doc = "Register `REDUNDANCY_SIG0` writer"]
+pub type W = crate::W<REDUNDANCY_SIG0_SPEC>;
+#[doc = "Field `CACHE_REDCY_SIG0` reader - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG0_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_REDCY_SIG0` writer - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig0(&self) -> CACHE_REDCY_SIG0_R {
+        CACHE_REDCY_SIG0_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REDUNDANCY_SIG0")
+            .field("cache_redcy_sig0", &self.cache_redcy_sig0())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig0(&mut self) -> CACHE_REDCY_SIG0_W<'_, REDUNDANCY_SIG0_SPEC> {
+        CACHE_REDCY_SIG0_W::new(self, 0)
+    }
+}
+#[doc = "Cache redundancy signal 0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig0::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig0::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REDUNDANCY_SIG0_SPEC;
+impl crate::RegisterSpec for REDUNDANCY_SIG0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`redundancy_sig0::R`](R) reader structure"]
+impl crate::Readable for REDUNDANCY_SIG0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`redundancy_sig0::W`](W) writer structure"]
+impl crate::Writable for REDUNDANCY_SIG0_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets REDUNDANCY_SIG0 to value 0"]
+impl crate::Resettable for REDUNDANCY_SIG0_SPEC {}

--- a/esp32h2/src/cache/redundancy_sig1.rs
+++ b/esp32h2/src/cache/redundancy_sig1.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `REDUNDANCY_SIG1` reader"]
+pub type R = crate::R<REDUNDANCY_SIG1_SPEC>;
+#[doc = "Register `REDUNDANCY_SIG1` writer"]
+pub type W = crate::W<REDUNDANCY_SIG1_SPEC>;
+#[doc = "Field `CACHE_REDCY_SIG1` reader - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG1_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_REDCY_SIG1` writer - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG1_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig1(&self) -> CACHE_REDCY_SIG1_R {
+        CACHE_REDCY_SIG1_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REDUNDANCY_SIG1")
+            .field("cache_redcy_sig1", &self.cache_redcy_sig1())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig1(&mut self) -> CACHE_REDCY_SIG1_W<'_, REDUNDANCY_SIG1_SPEC> {
+        CACHE_REDCY_SIG1_W::new(self, 0)
+    }
+}
+#[doc = "Cache redundancy signal 1 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig1::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig1::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REDUNDANCY_SIG1_SPEC;
+impl crate::RegisterSpec for REDUNDANCY_SIG1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`redundancy_sig1::R`](R) reader structure"]
+impl crate::Readable for REDUNDANCY_SIG1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`redundancy_sig1::W`](W) writer structure"]
+impl crate::Writable for REDUNDANCY_SIG1_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets REDUNDANCY_SIG1 to value 0"]
+impl crate::Resettable for REDUNDANCY_SIG1_SPEC {}

--- a/esp32h2/src/cache/redundancy_sig2.rs
+++ b/esp32h2/src/cache/redundancy_sig2.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `REDUNDANCY_SIG2` reader"]
+pub type R = crate::R<REDUNDANCY_SIG2_SPEC>;
+#[doc = "Register `REDUNDANCY_SIG2` writer"]
+pub type W = crate::W<REDUNDANCY_SIG2_SPEC>;
+#[doc = "Field `CACHE_REDCY_SIG2` reader - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG2_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_REDCY_SIG2` writer - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG2_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig2(&self) -> CACHE_REDCY_SIG2_R {
+        CACHE_REDCY_SIG2_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REDUNDANCY_SIG2")
+            .field("cache_redcy_sig2", &self.cache_redcy_sig2())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig2(&mut self) -> CACHE_REDCY_SIG2_W<'_, REDUNDANCY_SIG2_SPEC> {
+        CACHE_REDCY_SIG2_W::new(self, 0)
+    }
+}
+#[doc = "Cache redundancy signal 2 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig2::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig2::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REDUNDANCY_SIG2_SPEC;
+impl crate::RegisterSpec for REDUNDANCY_SIG2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`redundancy_sig2::R`](R) reader structure"]
+impl crate::Readable for REDUNDANCY_SIG2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`redundancy_sig2::W`](W) writer structure"]
+impl crate::Writable for REDUNDANCY_SIG2_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets REDUNDANCY_SIG2 to value 0"]
+impl crate::Resettable for REDUNDANCY_SIG2_SPEC {}

--- a/esp32h2/src/cache/redundancy_sig3.rs
+++ b/esp32h2/src/cache/redundancy_sig3.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `REDUNDANCY_SIG3` reader"]
+pub type R = crate::R<REDUNDANCY_SIG3_SPEC>;
+#[doc = "Register `REDUNDANCY_SIG3` writer"]
+pub type W = crate::W<REDUNDANCY_SIG3_SPEC>;
+#[doc = "Field `CACHE_REDCY_SIG3` reader - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG3_R = crate::FieldReader<u32>;
+#[doc = "Field `CACHE_REDCY_SIG3` writer - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG3_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig3(&self) -> CACHE_REDCY_SIG3_R {
+        CACHE_REDCY_SIG3_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REDUNDANCY_SIG3")
+            .field("cache_redcy_sig3", &self.cache_redcy_sig3())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig3(&mut self) -> CACHE_REDCY_SIG3_W<'_, REDUNDANCY_SIG3_SPEC> {
+        CACHE_REDCY_SIG3_W::new(self, 0)
+    }
+}
+#[doc = "Cache redundancy signal 3 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig3::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`redundancy_sig3::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REDUNDANCY_SIG3_SPEC;
+impl crate::RegisterSpec for REDUNDANCY_SIG3_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`redundancy_sig3::R`](R) reader structure"]
+impl crate::Readable for REDUNDANCY_SIG3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`redundancy_sig3::W`](W) writer structure"]
+impl crate::Writable for REDUNDANCY_SIG3_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets REDUNDANCY_SIG3 to value 0"]
+impl crate::Resettable for REDUNDANCY_SIG3_SPEC {}

--- a/esp32h2/src/cache/redundancy_sig4.rs
+++ b/esp32h2/src/cache/redundancy_sig4.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `REDUNDANCY_SIG4` reader"]
+pub type R = crate::R<REDUNDANCY_SIG4_SPEC>;
+#[doc = "Field `CACHE_REDCY_SIG4` reader - Those bits are prepared for ECO."]
+pub type CACHE_REDCY_SIG4_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - Those bits are prepared for ECO."]
+    #[inline(always)]
+    pub fn cache_redcy_sig4(&self) -> CACHE_REDCY_SIG4_R {
+        CACHE_REDCY_SIG4_R::new((self.bits & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("REDUNDANCY_SIG4")
+            .field("cache_redcy_sig4", &self.cache_redcy_sig4())
+            .finish()
+    }
+}
+#[doc = "Cache redundancy signal 0 register\n\nYou can [`read`](crate::Reg::read) this register and get [`redundancy_sig4::R`](R). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct REDUNDANCY_SIG4_SPEC;
+impl crate::RegisterSpec for REDUNDANCY_SIG4_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`redundancy_sig4::R`](R) reader structure"]
+impl crate::Readable for REDUNDANCY_SIG4_SPEC {}
+#[doc = "`reset()` method sets REDUNDANCY_SIG4 to value 0"]
+impl crate::Resettable for REDUNDANCY_SIG4_SPEC {}

--- a/esp32h2/src/lib.rs
+++ b/esp32h2/src/lib.rs
@@ -764,3 +764,12 @@ impl core::fmt::Debug for USB_DEVICE {
 }
 #[doc = "Full-speed USB Serial/JTAG Controller"]
 pub mod usb_device;
+#[doc = "L1 Cache Controller"]
+pub type CACHE = crate::Periph<cache::RegisterBlock, 0x600c_8000>;
+impl core::fmt::Debug for CACHE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CACHE").finish()
+    }
+}
+#[doc = "L1 Cache Controller"]
+pub mod cache;

--- a/esp32h2/src/plic_mx.rs
+++ b/esp32h2/src/plic_mx.rs
@@ -9,6 +9,8 @@ pub struct RegisterBlock {
     mxint_pri: [MXINT_PRI; 32],
     mxint_thresh: MXINT_THRESH,
     mxint_claim: MXINT_CLAIM,
+    _reserved7: [u8; 0x0364],
+    mxint_conf: MXINT_CONF,
 }
 impl RegisterBlock {
     #[doc = "0x00 - PLIC MX Interrupt Enable Register"]
@@ -212,6 +214,11 @@ impl RegisterBlock {
     pub const fn mxint_claim(&self) -> &MXINT_CLAIM {
         &self.mxint_claim
     }
+    #[doc = "0x3fc - PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)"]
+    #[inline(always)]
+    pub const fn mxint_conf(&self) -> &MXINT_CONF {
+        &self.mxint_conf
+    }
 }
 #[doc = "MXINT_ENABLE (rw) register accessor: PLIC MX Interrupt Enable Register\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_enable::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_enable::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mxint_enable`] module"]
 pub type MXINT_ENABLE = crate::Reg<mxint_enable::MXINT_ENABLE_SPEC>;
@@ -241,3 +248,7 @@ pub mod mxint_thresh;
 pub type MXINT_CLAIM = crate::Reg<mxint_claim::MXINT_CLAIM_SPEC>;
 #[doc = "PLIC MX Interrupt Claim Register"]
 pub mod mxint_claim;
+#[doc = "MXINT_CONF (rw) register accessor: PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mxint_conf`] module"]
+pub type MXINT_CONF = crate::Reg<mxint_conf::MXINT_CONF_SPEC>;
+#[doc = "PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)"]
+pub mod mxint_conf;

--- a/esp32h2/src/plic_mx/mxint_conf.rs
+++ b/esp32h2/src/plic_mx/mxint_conf.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `MXINT_CONF` reader"]
+pub type R = crate::R<MXINT_CONF_SPEC>;
+#[doc = "Register `MXINT_CONF` writer"]
+pub type W = crate::W<MXINT_CONF_SPEC>;
+#[doc = "Field `CPU_MXINT_CONF` reader - "]
+pub type CPU_MXINT_CONF_R = crate::FieldReader<u32>;
+#[doc = "Field `CPU_MXINT_CONF` writer - "]
+pub type CPU_MXINT_CONF_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_mxint_conf(&self) -> CPU_MXINT_CONF_R {
+        CPU_MXINT_CONF_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MXINT_CONF")
+            .field("cpu_mxint_conf", &self.cpu_mxint_conf())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_mxint_conf(&mut self) -> CPU_MXINT_CONF_W<'_, MXINT_CONF_SPEC> {
+        CPU_MXINT_CONF_W::new(self, 0)
+    }
+}
+#[doc = "PLIC MX Interrupt Configuration Register (PLIC_MXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`mxint_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mxint_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MXINT_CONF_SPEC;
+impl crate::RegisterSpec for MXINT_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mxint_conf::R`](R) reader structure"]
+impl crate::Readable for MXINT_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mxint_conf::W`](W) writer structure"]
+impl crate::Writable for MXINT_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets MXINT_CONF to value 0"]
+impl crate::Resettable for MXINT_CONF_SPEC {}

--- a/esp32h2/src/plic_ux.rs
+++ b/esp32h2/src/plic_ux.rs
@@ -9,6 +9,8 @@ pub struct RegisterBlock {
     uxint_pri: [UXINT_PRI; 32],
     uxint_thresh: UXINT_THRESH,
     uxint_claim: UXINT_CLAIM,
+    _reserved7: [u8; 0x0364],
+    uxint_conf: UXINT_CONF,
 }
 impl RegisterBlock {
     #[doc = "0x00 - PLIC UX Interrupt Enable Register"]
@@ -212,6 +214,11 @@ impl RegisterBlock {
     pub const fn uxint_claim(&self) -> &UXINT_CLAIM {
         &self.uxint_claim
     }
+    #[doc = "0x3fc - PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)"]
+    #[inline(always)]
+    pub const fn uxint_conf(&self) -> &UXINT_CONF {
+        &self.uxint_conf
+    }
 }
 #[doc = "UXINT_ENABLE (rw) register accessor: PLIC UX Interrupt Enable Register\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_enable::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_enable::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@uxint_enable`] module"]
 pub type UXINT_ENABLE = crate::Reg<uxint_enable::UXINT_ENABLE_SPEC>;
@@ -241,3 +248,7 @@ pub mod uxint_thresh;
 pub type UXINT_CLAIM = crate::Reg<uxint_claim::UXINT_CLAIM_SPEC>;
 #[doc = "PLIC UX Interrupt Claim Register"]
 pub mod uxint_claim;
+#[doc = "UXINT_CONF (rw) register accessor: PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_conf::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_conf::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@uxint_conf`] module"]
+pub type UXINT_CONF = crate::Reg<uxint_conf::UXINT_CONF_SPEC>;
+#[doc = "PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)"]
+pub mod uxint_conf;

--- a/esp32h2/src/plic_ux/uxint_conf.rs
+++ b/esp32h2/src/plic_ux/uxint_conf.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `UXINT_CONF` reader"]
+pub type R = crate::R<UXINT_CONF_SPEC>;
+#[doc = "Register `UXINT_CONF` writer"]
+pub type W = crate::W<UXINT_CONF_SPEC>;
+#[doc = "Field `CPU_UXINT_CONF` reader - "]
+pub type CPU_UXINT_CONF_R = crate::FieldReader<u32>;
+#[doc = "Field `CPU_UXINT_CONF` writer - "]
+pub type CPU_UXINT_CONF_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_uxint_conf(&self) -> CPU_UXINT_CONF_R {
+        CPU_UXINT_CONF_R::new(self.bits)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UXINT_CONF")
+            .field("cpu_uxint_conf", &self.cpu_uxint_conf())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn cpu_uxint_conf(&mut self) -> CPU_UXINT_CONF_W<'_, UXINT_CONF_SPEC> {
+        CPU_UXINT_CONF_W::new(self, 0)
+    }
+}
+#[doc = "PLIC UX Interrupt Configuration Register (PLIC_UXINT_CONF_REG)\n\nYou can [`read`](crate::Reg::read) this register and get [`uxint_conf::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`uxint_conf::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct UXINT_CONF_SPEC;
+impl crate::RegisterSpec for UXINT_CONF_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`uxint_conf::R`](R) reader structure"]
+impl crate::Readable for UXINT_CONF_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`uxint_conf::W`](W) writer structure"]
+impl crate::Writable for UXINT_CONF_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets UXINT_CONF to value 0"]
+impl crate::Resettable for UXINT_CONF_SPEC {}

--- a/esp32h2/src/spi1.rs
+++ b/esp32h2/src/spi1.rs
@@ -31,11 +31,40 @@ pub struct RegisterBlock {
     int_st: INT_ST,
     _reserved24: [u8; 0x04],
     ddr: DDR,
-    _reserved25: [u8; 0xa8],
+    spi_smem_ddr: SPI_SMEM_DDR,
+    _reserved26: [u8; 0x24],
+    spi_fmem_pms_attr: [SPI_FMEM_PMS_ATTR; 4],
+    spi_fmem_pms_addr: [SPI_FMEM_PMS_ADDR; 4],
+    spi_fmem_pms_size: [SPI_FMEM_PMS_SIZE; 4],
+    spi_smem_pms_attr: [SPI_SMEM_PMS_ATTR; 4],
+    spi_smem_pms_addr: [SPI_SMEM_PMS_ADDR; 4],
+    spi_smem_pms_size: [SPI_SMEM_PMS_SIZE; 4],
+    _reserved32: [u8; 0x04],
+    pms_reject: PMS_REJECT,
+    ecc_ctrl: ECC_CTRL,
+    ecc_err_addr: ECC_ERR_ADDR,
+    axi_err_addr: AXI_ERR_ADDR,
+    spi_smem_ecc_ctrl: SPI_SMEM_ECC_CTRL,
+    _reserved37: [u8; 0x08],
     timing_cali: TIMING_CALI,
-    _reserved26: [u8; 0x7c],
+    din_mode: DIN_MODE,
+    din_num: DIN_NUM,
+    dout_mode: DOUT_MODE,
+    spi_smem_timing_cali: SPI_SMEM_TIMING_CALI,
+    spi_smem_din_mode: SPI_SMEM_DIN_MODE,
+    spi_smem_din_num: SPI_SMEM_DIN_NUM,
+    spi_smem_dout_mode: SPI_SMEM_DOUT_MODE,
+    spi_smem_ac: SPI_SMEM_AC,
+    _reserved46: [u8; 0x5c],
     clock_gate: CLOCK_GATE,
-    _reserved27: [u8; 0x01f8],
+    _reserved47: [u8; 0x0178],
+    mmu_item_content: MMU_ITEM_CONTENT,
+    mmu_item_index: MMU_ITEM_INDEX,
+    mmu_power_ctrl: MMU_POWER_CTRL,
+    _reserved50: [u8; 0x68],
+    registerrnd_eco_high: REGISTERRND_ECO_HIGH,
+    registerrnd_eco_low: REGISTERRND_ECO_LOW,
+    _reserved52: [u8; 0x04],
     date: DATE,
 }
 impl RegisterBlock {
@@ -170,15 +199,296 @@ impl RegisterBlock {
     pub const fn ddr(&self) -> &DDR {
         &self.ddr
     }
+    #[doc = "0xd8 - MSPI external RAM DDR mode control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ddr(&self) -> &SPI_SMEM_DDR {
+        &self.spi_smem_ddr
+    }
+    #[doc = "0x100..0x110 - MSPI flash ACE section %s attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_attr(&self, n: usize) -> &SPI_FMEM_PMS_ATTR {
+        &self.spi_fmem_pms_attr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x100..0x110 - MSPI flash ACE section %s attribute register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_attr_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_ATTR> {
+        self.spi_fmem_pms_attr.iter()
+    }
+    #[doc = "0x100 - MSPI flash ACE section 0 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(0)
+    }
+    #[doc = "0x104 - MSPI flash ACE section 1 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(1)
+    }
+    #[doc = "0x108 - MSPI flash ACE section 2 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(2)
+    }
+    #[doc = "0x10c - MSPI flash ACE section 3 attribute register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_attr(&self) -> &SPI_FMEM_PMS_ATTR {
+        self.spi_fmem_pms_attr(3)
+    }
+    #[doc = "0x110..0x120 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_addr(&self, n: usize) -> &SPI_FMEM_PMS_ADDR {
+        &self.spi_fmem_pms_addr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x110..0x120 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_addr_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_ADDR> {
+        self.spi_fmem_pms_addr.iter()
+    }
+    #[doc = "0x110 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(0)
+    }
+    #[doc = "0x114 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(1)
+    }
+    #[doc = "0x118 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(2)
+    }
+    #[doc = "0x11c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_addr(&self) -> &SPI_FMEM_PMS_ADDR {
+        self.spi_fmem_pms_addr(3)
+    }
+    #[doc = "0x120..0x130 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms_size(&self, n: usize) -> &SPI_FMEM_PMS_SIZE {
+        &self.spi_fmem_pms_size[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x120..0x130 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_fmem_pms_size_iter(&self) -> impl Iterator<Item = &SPI_FMEM_PMS_SIZE> {
+        self.spi_fmem_pms_size.iter()
+    }
+    #[doc = "0x120 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms0_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(0)
+    }
+    #[doc = "0x124 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms1_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(1)
+    }
+    #[doc = "0x128 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms2_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(2)
+    }
+    #[doc = "0x12c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_fmem_pms3_size(&self) -> &SPI_FMEM_PMS_SIZE {
+        self.spi_fmem_pms_size(3)
+    }
+    #[doc = "0x130..0x140 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_attr(&self, n: usize) -> &SPI_SMEM_PMS_ATTR {
+        &self.spi_smem_pms_attr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x130..0x140 - SPI1 flash ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_attr_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_ATTR> {
+        self.spi_smem_pms_attr.iter()
+    }
+    #[doc = "0x130 - SPI1 flash ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(0)
+    }
+    #[doc = "0x134 - SPI1 flash ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(1)
+    }
+    #[doc = "0x138 - SPI1 flash ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(2)
+    }
+    #[doc = "0x13c - SPI1 flash ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_attr(&self) -> &SPI_SMEM_PMS_ATTR {
+        self.spi_smem_pms_attr(3)
+    }
+    #[doc = "0x140..0x150 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_addr(&self, n: usize) -> &SPI_SMEM_PMS_ADDR {
+        &self.spi_smem_pms_addr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x140..0x150 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_addr_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_ADDR> {
+        self.spi_smem_pms_addr.iter()
+    }
+    #[doc = "0x140 - SPI1 external RAM ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(0)
+    }
+    #[doc = "0x144 - SPI1 external RAM ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(1)
+    }
+    #[doc = "0x148 - SPI1 external RAM ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(2)
+    }
+    #[doc = "0x14c - SPI1 external RAM ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_addr(&self) -> &SPI_SMEM_PMS_ADDR {
+        self.spi_smem_pms_addr(3)
+    }
+    #[doc = "0x150..0x160 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms_size(&self, n: usize) -> &SPI_SMEM_PMS_SIZE {
+        &self.spi_smem_pms_size[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x150..0x160 - SPI1 external RAM ACE section %s start address register"]
+    #[inline(always)]
+    pub fn spi_smem_pms_size_iter(&self) -> impl Iterator<Item = &SPI_SMEM_PMS_SIZE> {
+        self.spi_smem_pms_size.iter()
+    }
+    #[doc = "0x150 - SPI1 external RAM ACE section 0 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms0_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(0)
+    }
+    #[doc = "0x154 - SPI1 external RAM ACE section 1 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms1_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(1)
+    }
+    #[doc = "0x158 - SPI1 external RAM ACE section 2 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms2_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(2)
+    }
+    #[doc = "0x15c - SPI1 external RAM ACE section 3 start address register"]
+    #[inline(always)]
+    pub const fn spi_smem_pms3_size(&self) -> &SPI_SMEM_PMS_SIZE {
+        self.spi_smem_pms_size(3)
+    }
+    #[doc = "0x164 - SPI1 access reject register"]
+    #[inline(always)]
+    pub const fn pms_reject(&self) -> &PMS_REJECT {
+        &self.pms_reject
+    }
+    #[doc = "0x168 - MSPI ECC control register"]
+    #[inline(always)]
+    pub const fn ecc_ctrl(&self) -> &ECC_CTRL {
+        &self.ecc_ctrl
+    }
+    #[doc = "0x16c - MSPI ECC error address register"]
+    #[inline(always)]
+    pub const fn ecc_err_addr(&self) -> &ECC_ERR_ADDR {
+        &self.ecc_err_addr
+    }
+    #[doc = "0x170 - MSPI AXI request error address"]
+    #[inline(always)]
+    pub const fn axi_err_addr(&self) -> &AXI_ERR_ADDR {
+        &self.axi_err_addr
+    }
+    #[doc = "0x174 - MSPI ECC control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ecc_ctrl(&self) -> &SPI_SMEM_ECC_CTRL {
+        &self.spi_smem_ecc_ctrl
+    }
     #[doc = "0x180 - SPI1 timing control register"]
     #[inline(always)]
     pub const fn timing_cali(&self) -> &TIMING_CALI {
         &self.timing_cali
     }
+    #[doc = "0x184 - MSPI flash input timing delay mode control register"]
+    #[inline(always)]
+    pub const fn din_mode(&self) -> &DIN_MODE {
+        &self.din_mode
+    }
+    #[doc = "0x188 - MSPI flash input timing delay number control register"]
+    #[inline(always)]
+    pub const fn din_num(&self) -> &DIN_NUM {
+        &self.din_num
+    }
+    #[doc = "0x18c - MSPI flash output timing adjustment control register"]
+    #[inline(always)]
+    pub const fn dout_mode(&self) -> &DOUT_MODE {
+        &self.dout_mode
+    }
+    #[doc = "0x190 - MSPI external RAM timing calibration register"]
+    #[inline(always)]
+    pub const fn spi_smem_timing_cali(&self) -> &SPI_SMEM_TIMING_CALI {
+        &self.spi_smem_timing_cali
+    }
+    #[doc = "0x194 - MSPI external RAM input timing delay mode control register"]
+    #[inline(always)]
+    pub const fn spi_smem_din_mode(&self) -> &SPI_SMEM_DIN_MODE {
+        &self.spi_smem_din_mode
+    }
+    #[doc = "0x198 - MSPI external RAM input timing delay number control register"]
+    #[inline(always)]
+    pub const fn spi_smem_din_num(&self) -> &SPI_SMEM_DIN_NUM {
+        &self.spi_smem_din_num
+    }
+    #[doc = "0x19c - MSPI external RAM output timing adjustment control register"]
+    #[inline(always)]
+    pub const fn spi_smem_dout_mode(&self) -> &SPI_SMEM_DOUT_MODE {
+        &self.spi_smem_dout_mode
+    }
+    #[doc = "0x1a0 - MSPI external RAM ECC and SPI CS timing control register"]
+    #[inline(always)]
+    pub const fn spi_smem_ac(&self) -> &SPI_SMEM_AC {
+        &self.spi_smem_ac
+    }
     #[doc = "0x200 - SPI1 clk_gate register"]
     #[inline(always)]
     pub const fn clock_gate(&self) -> &CLOCK_GATE {
         &self.clock_gate
+    }
+    #[doc = "0x37c - MSPI-MMU item content register"]
+    #[inline(always)]
+    pub const fn mmu_item_content(&self) -> &MMU_ITEM_CONTENT {
+        &self.mmu_item_content
+    }
+    #[doc = "0x380 - MSPI-MMU item index register"]
+    #[inline(always)]
+    pub const fn mmu_item_index(&self) -> &MMU_ITEM_INDEX {
+        &self.mmu_item_index
+    }
+    #[doc = "0x384 - MSPI MMU power control register"]
+    #[inline(always)]
+    pub const fn mmu_power_ctrl(&self) -> &MMU_POWER_CTRL {
+        &self.mmu_power_ctrl
+    }
+    #[doc = "0x3f0 - MSPI ECO high register"]
+    #[inline(always)]
+    pub const fn registerrnd_eco_high(&self) -> &REGISTERRND_ECO_HIGH {
+        &self.registerrnd_eco_high
+    }
+    #[doc = "0x3f4 - MSPI ECO low register"]
+    #[inline(always)]
+    pub const fn registerrnd_eco_low(&self) -> &REGISTERRND_ECO_LOW {
+        &self.registerrnd_eco_low
     }
     #[doc = "0x3fc - Version control register"]
     #[inline(always)]
@@ -294,4 +604,58 @@ pub mod timing_cali;
 pub type CLOCK_GATE = crate::Reg<clock_gate::CLOCK_GATE_SPEC>;
 #[doc = "SPI1 clk_gate register"]
 pub mod clock_gate;
-pub use crate::dma::{date, DATE};
+pub use crate::{
+    dma::{date, DATE},
+    spi0::{
+        axi_err_addr,
+        din_mode,
+        din_num,
+        dout_mode,
+        ecc_ctrl,
+        ecc_err_addr,
+        mmu_item_content,
+        mmu_item_index,
+        mmu_power_ctrl,
+        pms_reject,
+        registerrnd_eco_high,
+        registerrnd_eco_low,
+        spi_fmem_pms_addr,
+        spi_fmem_pms_attr,
+        spi_fmem_pms_size,
+        spi_smem_ac,
+        spi_smem_ddr,
+        spi_smem_din_mode,
+        spi_smem_din_num,
+        spi_smem_dout_mode,
+        spi_smem_ecc_ctrl,
+        spi_smem_pms_addr,
+        spi_smem_pms_attr,
+        spi_smem_pms_size,
+        spi_smem_timing_cali,
+        AXI_ERR_ADDR,
+        DIN_MODE,
+        DIN_NUM,
+        DOUT_MODE,
+        ECC_CTRL,
+        ECC_ERR_ADDR,
+        MMU_ITEM_CONTENT,
+        MMU_ITEM_INDEX,
+        MMU_POWER_CTRL,
+        PMS_REJECT,
+        REGISTERRND_ECO_HIGH,
+        REGISTERRND_ECO_LOW,
+        SPI_FMEM_PMS_ADDR,
+        SPI_FMEM_PMS_ATTR,
+        SPI_FMEM_PMS_SIZE,
+        SPI_SMEM_AC,
+        SPI_SMEM_DDR,
+        SPI_SMEM_DIN_MODE,
+        SPI_SMEM_DIN_NUM,
+        SPI_SMEM_DOUT_MODE,
+        SPI_SMEM_ECC_CTRL,
+        SPI_SMEM_PMS_ADDR,
+        SPI_SMEM_PMS_ATTR,
+        SPI_SMEM_PMS_SIZE,
+        SPI_SMEM_TIMING_CALI,
+    },
+};

--- a/esp32h2/svd/patches/_cache.yml
+++ b/esp32h2/svd/patches/_cache.yml
@@ -1,0 +1,14 @@
+# The H2's L1 cache controller is missing from the upstream SVD entirely, so it
+# was unreachable by name. It is the same block as the C6's EXTMEM: ESP-IDF's
+# `esp32h2/register/soc/cache_reg.h` describes the same 242 registers at the
+# same offsets, at the same base address (0x600C_8000). Copy it from the C6's
+# SVD and name it `CACHE`, matching both ESP-IDF's `DR_REG_CACHE_BASE` and the
+# newer chips' SVDs (C5, C61, P4).
+_copy:
+  CACHE:
+    from: ../../../esp32c6/svd/esp32c6.base.svd:EXTMEM
+
+_modify:
+  CACHE:
+    description: L1 Cache Controller
+    groupName: CACHE

--- a/esp32h2/svd/patches/esp32h2.yaml
+++ b/esp32h2/svd/patches/esp32h2.yaml
@@ -6,6 +6,7 @@ _include:
   - ../../../common_patches/twai.yaml
   - "_aes.yml"
   - "_assist_debug.yml"
+  - "_cache.yml"
   - "_date.yml"
   - "_dma.yml"
   - "_ds.yml"
@@ -960,6 +961,9 @@ INTPRI:
 
 PCR:
   _include: ../../../common_patches/pcr.yaml
+
+SPI1:
+  _include: ../../../common_patches/spi1_mspi_shared.yaml
 
 MCPWM0:
   _include: ../../../common_patches/mcpwm_collect.yaml


### PR DESCRIPTION
## Summary

Light-sleep TOP-domain retention in esp-hal (esp-rs/esp-hal#5874) has to back up whole register windows by name, and three areas were not described at all. Until now esp-hal reached them through hardcoded addresses, which is what [this review comment](https://github.com/esp-rs/esp-hal/pull/5874#discussion_r3663965581) asked to fix.

- **SPI1 MSPI windows.** SPI0 serves cache accesses and SPI1 serves CPU accesses, but both MSPI controllers implement the same permission (`SPI_FMEM_PMS*`/`SPI_SMEM_PMS*`), ECC, external-RAM timing and MMU registers; ESP-IDF's `spi_mem_reg.h` parameterises every one of them by controller index. The SVD only described them on SPI0, so `common_patches/spi1_mspi_shared.yaml` derives SPI1's copies from it. Being derived, the generated `spi1.rs` re-exports SPI0's types rather than duplicating them.
- **The H2's L1 cache controller**, which the base SVD omits entirely. It is the same block the C6 exposes as `EXTMEM` (242 registers at the same offsets, based at `0x600C_8000`), so `_cache.yml` copies that peripheral and gives it the H2's `CACHE` name. This follows the existing `esp32c5/svd/patches/_cache.yml` precedent.
- **`PLIC_MXINT_CONF` / `PLIC_UXINT_CONF`** at offset `0x3FC`. Reaching that offset also required widening both PLIC `addressBlock` sizes from `0x98` to `0x400`; the previous size stopped at `MXINT_CLAIM` (`0x94`) and would have made the new register fall outside the block.

Only the C6 and H2 include `plic.yaml` and the new `spi1_mspi_shared.yaml`, so no other chip's generated sources change.

## Test plan

- [x] `cargo xtask build ...` regenerates both PACs with no further diff
- [ ] Verified against esp-hal's retention code, where the derived spans reproduce the previously hardcoded window lengths (55/41/31 words) via compile-time assertions

Made with [Cursor](https://cursor.com)