### PR TITLE
esp32c5: add TWAI FD TX buffer memory

### DIFF
--- a/esp32c5/src/twai0.rs
+++ b/esp32c5/src/twai0.rs
@@ -41,7 +41,15 @@ pub struct RegisterBlock {
     yolo: YOLO,
     timestamp_low: TIMESTAMP_LOW,
     timestamp_high: TIMESTAMP_HIGH,
-    _reserved39: [u8; 0x0f38],
+    _reserved39: [u8; 0x64],
+    txtb1_data: [TXTB1_DATA; 20],
+    _reserved40: [u8; 0xb0],
+    txtb2_data: [TXTB2_DATA; 20],
+    _reserved41: [u8; 0xb0],
+    txtb3_data: [TXTB3_DATA; 20],
+    _reserved42: [u8; 0xb0],
+    txtb4_data: [TXTB4_DATA; 20],
+    _reserved43: [u8; 0x0b84],
     timer_clk_en: TIMER_CLK_EN,
     timer_int_raw: TIMER_INT_RAW,
     timer_int_st: TIMER_INT_ST,
@@ -249,6 +257,50 @@ impl RegisterBlock {
     #[inline(always)]
     pub const fn timestamp_high(&self) -> &TIMESTAMP_HIGH {
         &self.timestamp_high
+    }
+    #[doc = "0x100..0x150 - TX buffer 1 frame memory word"]
+    #[inline(always)]
+    pub const fn txtb1_data(&self, n: usize) -> &TXTB1_DATA {
+        &self.txtb1_data[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x100..0x150 - TX buffer 1 frame memory word"]
+    #[inline(always)]
+    pub fn txtb1_data_iter(&self) -> impl Iterator<Item = &TXTB1_DATA> {
+        self.txtb1_data.iter()
+    }
+    #[doc = "0x200..0x250 - TX buffer 2 frame memory word"]
+    #[inline(always)]
+    pub const fn txtb2_data(&self, n: usize) -> &TXTB2_DATA {
+        &self.txtb2_data[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x200..0x250 - TX buffer 2 frame memory word"]
+    #[inline(always)]
+    pub fn txtb2_data_iter(&self) -> impl Iterator<Item = &TXTB2_DATA> {
+        self.txtb2_data.iter()
+    }
+    #[doc = "0x300..0x350 - TX buffer 3 frame memory word"]
+    #[inline(always)]
+    pub const fn txtb3_data(&self, n: usize) -> &TXTB3_DATA {
+        &self.txtb3_data[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x300..0x350 - TX buffer 3 frame memory word"]
+    #[inline(always)]
+    pub fn txtb3_data_iter(&self) -> impl Iterator<Item = &TXTB3_DATA> {
+        self.txtb3_data.iter()
+    }
+    #[doc = "0x400..0x450 - TX buffer 4 frame memory word"]
+    #[inline(always)]
+    pub const fn txtb4_data(&self, n: usize) -> &TXTB4_DATA {
+        &self.txtb4_data[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x400..0x450 - TX buffer 4 frame memory word"]
+    #[inline(always)]
+    pub fn txtb4_data_iter(&self) -> impl Iterator<Item = &TXTB4_DATA> {
+        self.txtb4_data.iter()
     }
     #[doc = "0xfd4 - TWAIFD timer clock force enable register."]
     #[inline(always)]
@@ -464,6 +516,22 @@ pub mod timestamp_low;
 pub type TIMESTAMP_HIGH = crate::Reg<timestamp_high::TIMESTAMP_HIGH_SPEC>;
 #[doc = "TWAI FD transmitted frame counter register"]
 pub mod timestamp_high;
+#[doc = "TXTB1_DATA (w) register accessor: TX buffer 1 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb1_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@txtb1_data`] module"]
+pub type TXTB1_DATA = crate::Reg<txtb1_data::TXTB1_DATA_SPEC>;
+#[doc = "TX buffer 1 frame memory word"]
+pub mod txtb1_data;
+#[doc = "TXTB2_DATA (w) register accessor: TX buffer 2 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb2_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@txtb2_data`] module"]
+pub type TXTB2_DATA = crate::Reg<txtb2_data::TXTB2_DATA_SPEC>;
+#[doc = "TX buffer 2 frame memory word"]
+pub mod txtb2_data;
+#[doc = "TXTB3_DATA (w) register accessor: TX buffer 3 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb3_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@txtb3_data`] module"]
+pub type TXTB3_DATA = crate::Reg<txtb3_data::TXTB3_DATA_SPEC>;
+#[doc = "TX buffer 3 frame memory word"]
+pub mod txtb3_data;
+#[doc = "TXTB4_DATA (w) register accessor: TX buffer 4 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb4_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@txtb4_data`] module"]
+pub type TXTB4_DATA = crate::Reg<txtb4_data::TXTB4_DATA_SPEC>;
+#[doc = "TX buffer 4 frame memory word"]
+pub mod txtb4_data;
 #[doc = "TIMER_CLK_EN (rw) register accessor: TWAIFD timer clock force enable register.\n\nYou can [`read`](crate::Reg::read) this register and get [`timer_clk_en::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`timer_clk_en::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@timer_clk_en`] module"]
 pub type TIMER_CLK_EN = crate::Reg<timer_clk_en::TIMER_CLK_EN_SPEC>;
 #[doc = "TWAIFD timer clock force enable register."]

--- a/esp32c5/src/twai0/txtb1_data.rs
+++ b/esp32c5/src/twai0/txtb1_data.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `TXTB1_DATA%s` writer"]
+pub type W = crate::W<TXTB1_DATA_SPEC>;
+#[doc = "Field `DATA` writer - Frame buffer word"]
+pub type DATA_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<TXTB1_DATA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Frame buffer word"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W<'_, TXTB1_DATA_SPEC> {
+        DATA_W::new(self, 0)
+    }
+}
+#[doc = "TX buffer 1 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb1_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TXTB1_DATA_SPEC;
+impl crate::RegisterSpec for TXTB1_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`txtb1_data::W`](W) writer structure"]
+impl crate::Writable for TXTB1_DATA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TXTB1_DATA%s to value 0"]
+impl crate::Resettable for TXTB1_DATA_SPEC {}

--- a/esp32c5/src/twai0/txtb2_data.rs
+++ b/esp32c5/src/twai0/txtb2_data.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `TXTB2_DATA%s` writer"]
+pub type W = crate::W<TXTB2_DATA_SPEC>;
+#[doc = "Field `DATA` writer - Frame buffer word"]
+pub type DATA_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<TXTB2_DATA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Frame buffer word"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W<'_, TXTB2_DATA_SPEC> {
+        DATA_W::new(self, 0)
+    }
+}
+#[doc = "TX buffer 2 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb2_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TXTB2_DATA_SPEC;
+impl crate::RegisterSpec for TXTB2_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`txtb2_data::W`](W) writer structure"]
+impl crate::Writable for TXTB2_DATA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TXTB2_DATA%s to value 0"]
+impl crate::Resettable for TXTB2_DATA_SPEC {}

--- a/esp32c5/src/twai0/txtb3_data.rs
+++ b/esp32c5/src/twai0/txtb3_data.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `TXTB3_DATA%s` writer"]
+pub type W = crate::W<TXTB3_DATA_SPEC>;
+#[doc = "Field `DATA` writer - Frame buffer word"]
+pub type DATA_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<TXTB3_DATA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Frame buffer word"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W<'_, TXTB3_DATA_SPEC> {
+        DATA_W::new(self, 0)
+    }
+}
+#[doc = "TX buffer 3 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb3_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TXTB3_DATA_SPEC;
+impl crate::RegisterSpec for TXTB3_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`txtb3_data::W`](W) writer structure"]
+impl crate::Writable for TXTB3_DATA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TXTB3_DATA%s to value 0"]
+impl crate::Resettable for TXTB3_DATA_SPEC {}

--- a/esp32c5/src/twai0/txtb4_data.rs
+++ b/esp32c5/src/twai0/txtb4_data.rs
@@ -1,0 +1,28 @@
+#[doc = "Register `TXTB4_DATA%s` writer"]
+pub type W = crate::W<TXTB4_DATA_SPEC>;
+#[doc = "Field `DATA` writer - Frame buffer word"]
+pub type DATA_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for crate::generic::Reg<TXTB4_DATA_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "(not readable)")
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Frame buffer word"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W<'_, TXTB4_DATA_SPEC> {
+        DATA_W::new(self, 0)
+    }
+}
+#[doc = "TX buffer 4 frame memory word\n\nYou can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`txtb4_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TXTB4_DATA_SPEC;
+impl crate::RegisterSpec for TXTB4_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`txtb4_data::W`](W) writer structure"]
+impl crate::Writable for TXTB4_DATA_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TXTB4_DATA%s to value 0"]
+impl crate::Resettable for TXTB4_DATA_SPEC {}

--- a/esp32c5/svd/patches/_twai.yml
+++ b/esp32c5/svd/patches/_twai.yml
@@ -1,0 +1,74 @@
+# The TX buffer RAM is described in TRM 38.3.8 ("The CAN frame is stored to TX
+# buffers via TX buffer 1 - TX buffer 8 memory regions") but is absent from the
+# register summary in TRM 38.6, so it never made it into the base SVD. Without
+# it a driver cannot queue a frame at all.
+#
+# The ESP32-C5 implements 4 of the 8 buffers the CTU CAN FD core can be
+# synthesized with; TWAIFD_TX_COMMAND_TXTB_INFO_REG.TXT_BUFFER_COUNT reports the
+# actual number. Each buffer occupies a 0x100 region of which the first 20 words
+# are used: word 0 is the frame format, word 1 the identifier, words 2-3 the
+# timestamp, and words 4-19 the payload.
+#
+# TWAI1 is derivedFrom TWAI0, so this also applies there.
+TWAI0:
+  _add:
+    TXTB1_DATA%s:
+      description: TX buffer 1 frame memory word
+      addressOffset: 0x100
+      dim: 20
+      dimIndex: 0-19
+      dimIncrement: 0x4
+      size: 0x20
+      access: write-only
+      resetValue: 0x0
+      fields:
+        DATA:
+          description: Frame buffer word
+          bitOffset: 0
+          bitWidth: 32
+          access: write-only
+    TXTB2_DATA%s:
+      description: TX buffer 2 frame memory word
+      addressOffset: 0x200
+      dim: 20
+      dimIndex: 0-19
+      dimIncrement: 0x4
+      size: 0x20
+      access: write-only
+      resetValue: 0x0
+      fields:
+        DATA:
+          description: Frame buffer word
+          bitOffset: 0
+          bitWidth: 32
+          access: write-only
+    TXTB3_DATA%s:
+      description: TX buffer 3 frame memory word
+      addressOffset: 0x300
+      dim: 20
+      dimIndex: 0-19
+      dimIncrement: 0x4
+      size: 0x20
+      access: write-only
+      resetValue: 0x0
+      fields:
+        DATA:
+          description: Frame buffer word
+          bitOffset: 0
+          bitWidth: 32
+          access: write-only
+    TXTB4_DATA%s:
+      description: TX buffer 4 frame memory word
+      addressOffset: 0x400
+      dim: 20
+      dimIndex: 0-19
+      dimIncrement: 0x4
+      size: 0x20
+      access: write-only
+      resetValue: 0x0
+      fields:
+        DATA:
+          description: Frame buffer word
+          bitOffset: 0
+          bitWidth: 32
+          access: write-only

--- a/esp32c5/svd/patches/esp32c5.yaml
+++ b/esp32c5/svd/patches/esp32c5.yaml
@@ -23,6 +23,7 @@ _include:
   - _pcr.yml
   - _sha.yml
   - _rmt.yml
+  - _twai.yml
   - _uart.yml
   - _mmu_item_content.yml
 


### PR DESCRIPTION
The TX buffer memory of the ESP32-C5's CAN FD controller is missing from the SVD. TRM 38.3.8 describes it, but the register summary in 38.6 lists only the control registers, so it never made it in — and without it a driver cannot queue a frame at all, only reach the memory through a raw pointer.

- add `TXTB1_DATA` to `TXTB4_DATA` to `TWAI0`, 20 words each at 0x100, 0x200, 0x300 and 0x400, write-only per TRM 38.3.8
- `TWAI1` is `derivedFrom` `TWAI0` and inherits them

The ESP32-C5 implements four of the eight buffers the CTU CAN FD core can be synthesized with, and `TX_COMMAND_TXTB_INFO.TXT_BUFFER_COUNT` reports the number, so only four are added. The layout matches ESP-IDF's `twaifd_struct.h`, which places `txt_mem_cell` at the same offset and stride.

The same gap exists on the ESP32-H4 and ESP32-S31, whose ESP-IDF layouts are identical to the C5's. I left them out because I have no hardware to check them on, but I am happy to extend the patch if you would like it.

Testing: a CAN FD driver for esp-hal writes frames at these offsets and exchanges them between both controllers on an ESP32-C5, so the addresses are exercised on hardware. `cargo xtask build esp32c5` passes.