### PR TITLE
esp32c3: add the Wi-Fi MAC register block

### DIFF
--- a/esp32c3/src/lib.rs
+++ b/esp32c3/src/lib.rs
@@ -359,6 +359,15 @@ impl core::fmt::Debug for I2S0 {
 }
 #[doc = "I2S (Inter-IC Sound) Controller 0"]
 pub mod i2s0;
+#[doc = "MAC controller for Wi-Fi peripheral"]
+pub type WIFI = crate::Periph<wifi::RegisterBlock, 0x6003_3000>;
+impl core::fmt::Debug for WIFI {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WIFI").finish()
+    }
+}
+#[doc = "MAC controller for Wi-Fi peripheral"]
+pub mod wifi;
 #[doc = "Interrupt Controller (Core 0)"]
 pub type INTERRUPT_CORE0 = crate::Periph<interrupt_core0::RegisterBlock, 0x600c_2000>;
 impl core::fmt::Debug for INTERRUPT_CORE0 {

--- a/esp32c3/src/wifi.rs
+++ b/esp32c3/src/wifi.rs
@@ -1,0 +1,598 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Register block"]
+pub struct RegisterBlock {
+    filter_bank: [FILTER_BANK; 2],
+    _reserved1: [u8; 0x04],
+    rx_ctrl: RX_CTRL,
+    rx_dma_list: RX_DMA_LIST,
+    _reserved3: [u8; 0x44],
+    filter_control: [FILTER_CONTROL; 4],
+    _reserved4: [u8; 0x18],
+    rx_ctrl_filter: [RX_CTRL_FILTER; 4],
+    _reserved5: [u8; 0x06f0],
+    crypto_control: CRYPTO_CONTROL,
+    _reserved6: [u8; 0x0424],
+    mac_interrupt: MAC_INTERRUPT,
+    _reserved7: [u8; 0x5c],
+    ctrl: CTRL,
+    txq_state: TXQ_STATE,
+    _reserved9: [u8; 0x30],
+    tx_slot_config: [TX_SLOT_CONFIG; 5],
+    _reserved10: [u8; 0x04bc],
+    plcp1: (),
+    _reserved11: [u8; 0x04],
+    tx_pti: (),
+    _reserved12: [u8; 0x04],
+    ht_sig: (),
+    _reserved13: [u8; 0x10],
+    ht_unknown: (),
+    _reserved14: [u8; 0x04],
+    plcp2: (),
+    _reserved15: [u8; 0x04],
+    duration: (),
+    _reserved16: [u8; 0x08],
+    pmd: (),
+    _reserved17: [u8; 0x0210],
+    crypto_key_slot: [CRYPTO_KEY_SLOT; 25],
+    _reserved18: [u8; 0x0818],
+    mac_time: MAC_TIME,
+    _reserved19: [u8; 0x08],
+    tsf_ctrl: TSF_CTRL,
+    tsf_load_low: TSF_LOAD_LOW,
+    tsf_load_high: TSF_LOAD_HIGH,
+    tsf_time_low: TSF_TIME_LOW,
+    tsf_time_high: TSF_TIME_HIGH,
+    tbtt_start: TBTT_START,
+    _reserved25: [u8; 0x04],
+    tsf_cfg: (),
+    _reserved26: [u8; 0x08],
+    tbtt_cfg: (),
+    _reserved27: [u8; 0x2c],
+    tsf_timer_cfg: (),
+    _reserved28: [u8; 0x04],
+    tsf_timer_target: (),
+    _reserved29: [u8; 0xb0],
+    pwr_int_enable: PWR_INT_ENABLE,
+    _reserved30: [u8; 0x04],
+    pwr_interrupt: PWR_INTERRUPT,
+}
+impl RegisterBlock {
+    #[doc = "0x00..0x80 - Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA. Each filter bank has registers for four interfaces."]
+    #[inline(always)]
+    pub const fn filter_bank(&self, n: usize) -> &FILTER_BANK {
+        &self.filter_bank[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x00..0x80 - Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA. Each filter bank has registers for four interfaces."]
+    #[inline(always)]
+    pub fn filter_bank_iter(&self) -> impl Iterator<Item = &FILTER_BANK> {
+        self.filter_bank.iter()
+    }
+    #[doc = "0x84 - Controls the reception of frames"]
+    #[inline(always)]
+    pub const fn rx_ctrl(&self) -> &RX_CTRL {
+        &self.rx_ctrl
+    }
+    #[doc = "0x88..0x94 - RX_DMA_LIST"]
+    #[inline(always)]
+    pub const fn rx_dma_list(&self) -> &RX_DMA_LIST {
+        &self.rx_dma_list
+    }
+    #[doc = "0xd8..0xe8 - Controls the RX filter for an interface"]
+    #[inline(always)]
+    pub const fn filter_control(&self, n: usize) -> &FILTER_CONTROL {
+        &self.filter_control[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0xd8..0xe8 - Controls the RX filter for an interface"]
+    #[inline(always)]
+    pub fn filter_control_iter(&self) -> impl Iterator<Item = &FILTER_CONTROL> {
+        self.filter_control.iter()
+    }
+    #[doc = "0x100..0x110 - Configures which control frames pass the RX filter. Setting a bit lets that frame type pass the filter."]
+    #[inline(always)]
+    pub const fn rx_ctrl_filter(&self, n: usize) -> &RX_CTRL_FILTER {
+        &self.rx_ctrl_filter[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x100..0x110 - Configures which control frames pass the RX filter. Setting a bit lets that frame type pass the filter."]
+    #[inline(always)]
+    pub fn rx_ctrl_filter_iter(&self) -> impl Iterator<Item = &RX_CTRL_FILTER> {
+        self.rx_ctrl_filter.iter()
+    }
+    #[doc = "0x800..0x818 - Control registers for hardware crypto"]
+    #[inline(always)]
+    pub const fn crypto_control(&self) -> &CRYPTO_CONTROL {
+        &self.crypto_control
+    }
+    #[doc = "0xc3c..0xc44 - Status and clear for the WIFI_MAC interrupt"]
+    #[inline(always)]
+    pub const fn mac_interrupt(&self) -> &MAC_INTERRUPT {
+        &self.mac_interrupt
+    }
+    #[doc = "0xca0 - Exact name and meaning unknown, used for initializing the MAC"]
+    #[inline(always)]
+    pub const fn ctrl(&self) -> &CTRL {
+        &self.ctrl
+    }
+    #[doc = "0xca4..0xcb4 - State of transmission queues"]
+    #[inline(always)]
+    pub const fn txq_state(&self) -> &TXQ_STATE {
+        &self.txq_state
+    }
+    #[doc = "0xce4..0xd0c - Used to configure the TX slot."]
+    #[inline(always)]
+    pub const fn tx_slot_config(&self, n: usize) -> &TX_SLOT_CONFIG {
+        &self.tx_slot_config[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0xce4..0xd0c - Used to configure the TX slot."]
+    #[inline(always)]
+    pub fn tx_slot_config_iter(&self) -> impl Iterator<Item = &TX_SLOT_CONFIG> {
+        self.tx_slot_config.iter()
+    }
+    #[doc = "0x11c8..0x11dc - PLCP1"]
+    #[inline(always)]
+    pub const fn plcp1(&self, n: usize) -> &PLCP1 {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4552)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11c8..0x11dc - PLCP1"]
+    #[inline(always)]
+    pub fn plcp1_iter(&self) -> impl Iterator<Item = &PLCP1> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4552)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11cc..0x11e0 - Coexistence priorities of the TX slot, written by hal_set_tx_pti"]
+    #[inline(always)]
+    pub const fn tx_pti(&self, n: usize) -> &TX_PTI {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4556)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11cc..0x11e0 - Coexistence priorities of the TX slot, written by hal_set_tx_pti"]
+    #[inline(always)]
+    pub fn tx_pti_iter(&self) -> impl Iterator<Item = &TX_PTI> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4556)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11d0..0x11e4 - HT-SIG field in HT preamble"]
+    #[inline(always)]
+    pub const fn ht_sig(&self, n: usize) -> &HT_SIG {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4560)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11d0..0x11e4 - HT-SIG field in HT preamble"]
+    #[inline(always)]
+    pub fn ht_sig_iter(&self) -> impl Iterator<Item = &HT_SIG> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4560)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11e0..0x11f4 - exact meaning and name unknown, related to HT"]
+    #[inline(always)]
+    pub const fn ht_unknown(&self, n: usize) -> &HT_UNKNOWN {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4576)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11e0..0x11f4 - exact meaning and name unknown, related to HT"]
+    #[inline(always)]
+    pub fn ht_unknown_iter(&self) -> impl Iterator<Item = &HT_UNKNOWN> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4576)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11e4..0x11f8 - PLCP2"]
+    #[inline(always)]
+    pub const fn plcp2(&self, n: usize) -> &PLCP2 {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4580)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11e4..0x11f8 - PLCP2"]
+    #[inline(always)]
+    pub fn plcp2_iter(&self) -> impl Iterator<Item = &PLCP2> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4580)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11e8..0x11fc - duration of the frame exchange"]
+    #[inline(always)]
+    pub const fn duration(&self, n: usize) -> &DURATION {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4584)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11e8..0x11fc - duration of the frame exchange"]
+    #[inline(always)]
+    pub fn duration_iter(&self) -> impl Iterator<Item = &DURATION> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4584)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x11f0..0x1204 - TX result of the slot, read by hal_mac_get_txq_pmd"]
+    #[inline(always)]
+    pub const fn pmd(&self, n: usize) -> &PMD {
+        #[allow(clippy::no_effect)]
+        [(); 5][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4592)
+                .add(76 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x11f0..0x1204 - TX result of the slot, read by hal_mac_get_txq_pmd"]
+    #[inline(always)]
+    pub fn pmd_iter(&self) -> impl Iterator<Item = &PMD> {
+        (0..5).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4592)
+                .add(76 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x1400..0x17e8 - Cryptographic keys for MPDU encapsulation and decapsulation"]
+    #[inline(always)]
+    pub const fn crypto_key_slot(&self, n: usize) -> &CRYPTO_KEY_SLOT {
+        &self.crypto_key_slot[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x1400..0x17e8 - Cryptographic keys for MPDU encapsulation and decapsulation"]
+    #[inline(always)]
+    pub fn crypto_key_slot_iter(&self) -> impl Iterator<Item = &CRYPTO_KEY_SLOT> {
+        self.crypto_key_slot.iter()
+    }
+    #[doc = "0x2000 - Current value of the MAC timer"]
+    #[inline(always)]
+    pub const fn mac_time(&self) -> &MAC_TIME {
+        &self.mac_time
+    }
+    #[doc = "0x200c - Control for the per-interface TSF counters. Written by tsf_hal_get_counter_value, tsf_hal_set_counter_value and tsf_hal_set_tbtt_start_time."]
+    #[inline(always)]
+    pub const fn tsf_ctrl(&self) -> &TSF_CTRL {
+        &self.tsf_ctrl
+    }
+    #[doc = "0x2010 - Low word of the value loaded into a TSF counter"]
+    #[inline(always)]
+    pub const fn tsf_load_low(&self) -> &TSF_LOAD_LOW {
+        &self.tsf_load_low
+    }
+    #[doc = "0x2014 - High word of the value loaded into a TSF counter"]
+    #[inline(always)]
+    pub const fn tsf_load_high(&self) -> &TSF_LOAD_HIGH {
+        &self.tsf_load_high
+    }
+    #[doc = "0x2018 - Low word of the latched TSF counter"]
+    #[inline(always)]
+    pub const fn tsf_time_low(&self) -> &TSF_TIME_LOW {
+        &self.tsf_time_low
+    }
+    #[doc = "0x201c - High word of the latched TSF counter"]
+    #[inline(always)]
+    pub const fn tsf_time_high(&self) -> &TSF_TIME_HIGH {
+        &self.tsf_time_high
+    }
+    #[doc = "0x2020 - TBTT start time, loaded into an interface with TSF_CTRL.LOAD_TBTT_START"]
+    #[inline(always)]
+    pub const fn tbtt_start(&self) -> &TBTT_START {
+        &self.tbtt_start
+    }
+    #[doc = "0x2028..0x2038 - TSF and TBTT configuration of an interface"]
+    #[inline(always)]
+    pub const fn tsf_cfg(&self, n: usize) -> &TSF_CFG {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8232)
+                .add(12 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x2028..0x2038 - TSF and TBTT configuration of an interface"]
+    #[inline(always)]
+    pub fn tsf_cfg_iter(&self) -> impl Iterator<Item = &TSF_CFG> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8232)
+                .add(12 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x2030..0x2040 - TBTT interval and early time of an interface"]
+    #[inline(always)]
+    pub const fn tbtt_cfg(&self, n: usize) -> &TBTT_CFG {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8240)
+                .add(12 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x2030..0x2040 - TBTT interval and early time of an interface"]
+    #[inline(always)]
+    pub fn tbtt_cfg_iter(&self) -> impl Iterator<Item = &TBTT_CFG> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8240)
+                .add(12 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x205c..0x206c - Configuration of a TSF timer"]
+    #[inline(always)]
+    pub const fn tsf_timer_cfg(&self, n: usize) -> &TSF_TIMER_CFG {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8284)
+                .add(8 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x205c..0x206c - Configuration of a TSF timer"]
+    #[inline(always)]
+    pub fn tsf_timer_cfg_iter(&self) -> impl Iterator<Item = &TSF_TIMER_CFG> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8284)
+                .add(8 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x2060..0x2070 - Target of a TSF timer, written by tsf_hal_set_timer_target"]
+    #[inline(always)]
+    pub const fn tsf_timer_target(&self, n: usize) -> &TSF_TIMER_TARGET {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8288)
+                .add(8 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x2060..0x2070 - Target of a TSF timer, written by tsf_hal_set_timer_target"]
+    #[inline(always)]
+    pub fn tsf_timer_target_iter(&self) -> impl Iterator<Item = &TSF_TIMER_TARGET> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(8288)
+                .add(8 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x2110 - Interrupt enable for the WIFI_PWR interrupt. TBTT of interface n is bit (4 - n), TSF timer n is bit (8 - n)."]
+    #[inline(always)]
+    pub const fn pwr_int_enable(&self) -> &PWR_INT_ENABLE {
+        &self.pwr_int_enable
+    }
+    #[doc = "0x2118..0x2120 - Status and clear for the WIFI_PWR interrupt"]
+    #[inline(always)]
+    pub const fn pwr_interrupt(&self) -> &PWR_INTERRUPT {
+        &self.pwr_interrupt
+    }
+}
+#[doc = "Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA. Each filter bank has registers for four interfaces."]
+pub use self::filter_bank::FILTER_BANK;
+#[doc = r"Cluster"]
+#[doc = "Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA. Each filter bank has registers for four interfaces."]
+pub mod filter_bank;
+#[doc = "RX_CTRL (rw) register accessor: Controls the reception of frames\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_ctrl`] module"]
+pub type RX_CTRL = crate::Reg<rx_ctrl::RX_CTRL_SPEC>;
+#[doc = "Controls the reception of frames"]
+pub mod rx_ctrl;
+#[doc = "RX_DMA_LIST"]
+pub use self::rx_dma_list::RX_DMA_LIST;
+#[doc = r"Cluster"]
+#[doc = "RX_DMA_LIST"]
+pub mod rx_dma_list;
+#[doc = "FILTER_CONTROL (rw) register accessor: Controls the RX filter for an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`filter_control::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`filter_control::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@filter_control`] module"]
+pub type FILTER_CONTROL = crate::Reg<filter_control::FILTER_CONTROL_SPEC>;
+#[doc = "Controls the RX filter for an interface"]
+pub mod filter_control;
+#[doc = "RX_CTRL_FILTER (rw) register accessor: Configures which control frames pass the RX filter. Setting a bit lets that frame type pass the filter.\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_ctrl_filter::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_ctrl_filter::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_ctrl_filter`] module"]
+pub type RX_CTRL_FILTER = crate::Reg<rx_ctrl_filter::RX_CTRL_FILTER_SPEC>;
+#[doc = "Configures which control frames pass the RX filter. Setting a bit lets that frame type pass the filter."]
+pub mod rx_ctrl_filter;
+#[doc = "Control registers for hardware crypto"]
+pub use self::crypto_control::CRYPTO_CONTROL;
+#[doc = r"Cluster"]
+#[doc = "Control registers for hardware crypto"]
+pub mod crypto_control;
+#[doc = "Status and clear for the WIFI_MAC interrupt"]
+pub use self::mac_interrupt::MAC_INTERRUPT;
+#[doc = r"Cluster"]
+#[doc = "Status and clear for the WIFI_MAC interrupt"]
+pub mod mac_interrupt;
+#[doc = "CTRL (rw) register accessor: Exact name and meaning unknown, used for initializing the MAC\n\nYou can [`read`](crate::Reg::read) this register and get [`ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ctrl`] module"]
+pub type CTRL = crate::Reg<ctrl::CTRL_SPEC>;
+#[doc = "Exact name and meaning unknown, used for initializing the MAC"]
+pub mod ctrl;
+#[doc = "State of transmission queues"]
+pub use self::txq_state::TXQ_STATE;
+#[doc = r"Cluster"]
+#[doc = "State of transmission queues"]
+pub mod txq_state;
+#[doc = "Used to configure the TX slot."]
+pub use self::tx_slot_config::TX_SLOT_CONFIG;
+#[doc = r"Cluster"]
+#[doc = "Used to configure the TX slot."]
+pub mod tx_slot_config;
+#[doc = "PLCP1 (rw) register accessor: PLCP1\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp1::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp1::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@plcp1`] module"]
+pub type PLCP1 = crate::Reg<plcp1::PLCP1_SPEC>;
+#[doc = "PLCP1"]
+pub mod plcp1;
+#[doc = "HT_SIG (rw) register accessor: HT-SIG field in HT preamble\n\nYou can [`read`](crate::Reg::read) this register and get [`ht_sig::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ht_sig::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ht_sig`] module"]
+pub type HT_SIG = crate::Reg<ht_sig::HT_SIG_SPEC>;
+#[doc = "HT-SIG field in HT preamble"]
+pub mod ht_sig;
+#[doc = "HT_UNKNOWN (rw) register accessor: exact meaning and name unknown, related to HT\n\nYou can [`read`](crate::Reg::read) this register and get [`ht_unknown::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ht_unknown::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ht_unknown`] module"]
+pub type HT_UNKNOWN = crate::Reg<ht_unknown::HT_UNKNOWN_SPEC>;
+#[doc = "exact meaning and name unknown, related to HT"]
+pub mod ht_unknown;
+#[doc = "PLCP2 (rw) register accessor: PLCP2\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp2::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp2::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@plcp2`] module"]
+pub type PLCP2 = crate::Reg<plcp2::PLCP2_SPEC>;
+#[doc = "PLCP2"]
+pub mod plcp2;
+#[doc = "DURATION (rw) register accessor: duration of the frame exchange\n\nYou can [`read`](crate::Reg::read) this register and get [`duration::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`duration::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@duration`] module"]
+pub type DURATION = crate::Reg<duration::DURATION_SPEC>;
+#[doc = "duration of the frame exchange"]
+pub mod duration;
+#[doc = "PMD (rw) register accessor: TX result of the slot, read by hal_mac_get_txq_pmd\n\nYou can [`read`](crate::Reg::read) this register and get [`pmd::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pmd::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pmd`] module"]
+pub type PMD = crate::Reg<pmd::PMD_SPEC>;
+#[doc = "TX result of the slot, read by hal_mac_get_txq_pmd"]
+pub mod pmd;
+#[doc = "Cryptographic keys for MPDU encapsulation and decapsulation"]
+pub use self::crypto_key_slot::CRYPTO_KEY_SLOT;
+#[doc = r"Cluster"]
+#[doc = "Cryptographic keys for MPDU encapsulation and decapsulation"]
+pub mod crypto_key_slot;
+#[doc = "TX_PTI (rw) register accessor: Coexistence priorities of the TX slot, written by hal_set_tx_pti\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_pti::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_pti::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_pti`] module"]
+pub type TX_PTI = crate::Reg<tx_pti::TX_PTI_SPEC>;
+#[doc = "Coexistence priorities of the TX slot, written by hal_set_tx_pti"]
+pub mod tx_pti;
+#[doc = "MAC_TIME (rw) register accessor: Current value of the MAC timer\n\nYou can [`read`](crate::Reg::read) this register and get [`mac_time::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mac_time::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mac_time`] module"]
+pub type MAC_TIME = crate::Reg<mac_time::MAC_TIME_SPEC>;
+#[doc = "Current value of the MAC timer"]
+pub mod mac_time;
+#[doc = "TSF_CTRL (rw) register accessor: Control for the per-interface TSF counters. Written by tsf_hal_get_counter_value, tsf_hal_set_counter_value and tsf_hal_set_tbtt_start_time.\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_ctrl::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_ctrl::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_ctrl`] module"]
+pub type TSF_CTRL = crate::Reg<tsf_ctrl::TSF_CTRL_SPEC>;
+#[doc = "Control for the per-interface TSF counters. Written by tsf_hal_get_counter_value, tsf_hal_set_counter_value and tsf_hal_set_tbtt_start_time."]
+pub mod tsf_ctrl;
+#[doc = "TSF_LOAD_LOW (rw) register accessor: Low word of the value loaded into a TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_load_low::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_load_low::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_load_low`] module"]
+pub type TSF_LOAD_LOW = crate::Reg<tsf_load_low::TSF_LOAD_LOW_SPEC>;
+#[doc = "Low word of the value loaded into a TSF counter"]
+pub mod tsf_load_low;
+#[doc = "TSF_LOAD_HIGH (rw) register accessor: High word of the value loaded into a TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_load_high::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_load_high::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_load_high`] module"]
+pub type TSF_LOAD_HIGH = crate::Reg<tsf_load_high::TSF_LOAD_HIGH_SPEC>;
+#[doc = "High word of the value loaded into a TSF counter"]
+pub mod tsf_load_high;
+#[doc = "TSF_TIME_LOW (rw) register accessor: Low word of the latched TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_time_low::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_time_low::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_time_low`] module"]
+pub type TSF_TIME_LOW = crate::Reg<tsf_time_low::TSF_TIME_LOW_SPEC>;
+#[doc = "Low word of the latched TSF counter"]
+pub mod tsf_time_low;
+#[doc = "TSF_TIME_HIGH (rw) register accessor: High word of the latched TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_time_high::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_time_high::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_time_high`] module"]
+pub type TSF_TIME_HIGH = crate::Reg<tsf_time_high::TSF_TIME_HIGH_SPEC>;
+#[doc = "High word of the latched TSF counter"]
+pub mod tsf_time_high;
+#[doc = "TBTT_START (rw) register accessor: TBTT start time, loaded into an interface with TSF_CTRL.LOAD_TBTT_START\n\nYou can [`read`](crate::Reg::read) this register and get [`tbtt_start::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tbtt_start::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tbtt_start`] module"]
+pub type TBTT_START = crate::Reg<tbtt_start::TBTT_START_SPEC>;
+#[doc = "TBTT start time, loaded into an interface with TSF_CTRL.LOAD_TBTT_START"]
+pub mod tbtt_start;
+#[doc = "TSF_CFG (rw) register accessor: TSF and TBTT configuration of an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_cfg::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_cfg::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_cfg`] module"]
+pub type TSF_CFG = crate::Reg<tsf_cfg::TSF_CFG_SPEC>;
+#[doc = "TSF and TBTT configuration of an interface"]
+pub mod tsf_cfg;
+#[doc = "TBTT_CFG (rw) register accessor: TBTT interval and early time of an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`tbtt_cfg::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tbtt_cfg::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tbtt_cfg`] module"]
+pub type TBTT_CFG = crate::Reg<tbtt_cfg::TBTT_CFG_SPEC>;
+#[doc = "TBTT interval and early time of an interface"]
+pub mod tbtt_cfg;
+#[doc = "TSF_TIMER_CFG (rw) register accessor: Configuration of a TSF timer\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_timer_cfg::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_timer_cfg::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_timer_cfg`] module"]
+pub type TSF_TIMER_CFG = crate::Reg<tsf_timer_cfg::TSF_TIMER_CFG_SPEC>;
+#[doc = "Configuration of a TSF timer"]
+pub mod tsf_timer_cfg;
+#[doc = "TSF_TIMER_TARGET (rw) register accessor: Target of a TSF timer, written by tsf_hal_set_timer_target\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_timer_target::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_timer_target::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tsf_timer_target`] module"]
+pub type TSF_TIMER_TARGET = crate::Reg<tsf_timer_target::TSF_TIMER_TARGET_SPEC>;
+#[doc = "Target of a TSF timer, written by tsf_hal_set_timer_target"]
+pub mod tsf_timer_target;
+#[doc = "PWR_INT_ENABLE (rw) register accessor: Interrupt enable for the WIFI_PWR interrupt. TBTT of interface n is bit (4 - n), TSF timer n is bit (8 - n).\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_enable::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_enable::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pwr_int_enable`] module"]
+pub type PWR_INT_ENABLE = crate::Reg<pwr_int_enable::PWR_INT_ENABLE_SPEC>;
+#[doc = "Interrupt enable for the WIFI_PWR interrupt. TBTT of interface n is bit (4 - n), TSF timer n is bit (8 - n)."]
+pub mod pwr_int_enable;
+#[doc = "Status and clear for the WIFI_PWR interrupt"]
+pub use self::pwr_interrupt::PWR_INTERRUPT;
+#[doc = r"Cluster"]
+#[doc = "Status and clear for the WIFI_PWR interrupt"]
+pub mod pwr_interrupt;

--- a/esp32c3/src/wifi/crypto_control.rs
+++ b/esp32c3/src/wifi/crypto_control.rs
@@ -1,0 +1,44 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Control registers for hardware crypto"]
+pub struct CRYPTO_CONTROL {
+    interface_crypto_control: [INTERFACE_CRYPTO_CONTROL; 4],
+    general_crypto_control: GENERAL_CRYPTO_CONTROL,
+    crypto_key_slot_state: CRYPTO_KEY_SLOT_STATE,
+}
+impl CRYPTO_CONTROL {
+    #[doc = "0x00..0x10 - Control over cryptographic parameters for a specific interface"]
+    #[inline(always)]
+    pub const fn interface_crypto_control(&self, n: usize) -> &INTERFACE_CRYPTO_CONTROL {
+        &self.interface_crypto_control[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x00..0x10 - Control over cryptographic parameters for a specific interface"]
+    #[inline(always)]
+    pub fn interface_crypto_control_iter(&self) -> impl Iterator<Item = &INTERFACE_CRYPTO_CONTROL> {
+        self.interface_crypto_control.iter()
+    }
+    #[doc = "0x10 - Control over the whole crypto unit"]
+    #[inline(always)]
+    pub const fn general_crypto_control(&self) -> &GENERAL_CRYPTO_CONTROL {
+        &self.general_crypto_control
+    }
+    #[doc = "0x14 - State of cryptographic key slots"]
+    #[inline(always)]
+    pub const fn crypto_key_slot_state(&self) -> &CRYPTO_KEY_SLOT_STATE {
+        &self.crypto_key_slot_state
+    }
+}
+#[doc = "INTERFACE_CRYPTO_CONTROL (rw) register accessor: Control over cryptographic parameters for a specific interface\n\nYou can [`read`](crate::Reg::read) this register and get [`interface_crypto_control::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`interface_crypto_control::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@interface_crypto_control`] module"]
+pub type INTERFACE_CRYPTO_CONTROL =
+    crate::Reg<interface_crypto_control::INTERFACE_CRYPTO_CONTROL_SPEC>;
+#[doc = "Control over cryptographic parameters for a specific interface"]
+pub mod interface_crypto_control;
+#[doc = "GENERAL_CRYPTO_CONTROL (rw) register accessor: Control over the whole crypto unit\n\nYou can [`read`](crate::Reg::read) this register and get [`general_crypto_control::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`general_crypto_control::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@general_crypto_control`] module"]
+pub type GENERAL_CRYPTO_CONTROL = crate::Reg<general_crypto_control::GENERAL_CRYPTO_CONTROL_SPEC>;
+#[doc = "Control over the whole crypto unit"]
+pub mod general_crypto_control;
+#[doc = "CRYPTO_KEY_SLOT_STATE (rw) register accessor: State of cryptographic key slots\n\nYou can [`read`](crate::Reg::read) this register and get [`crypto_key_slot_state::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`crypto_key_slot_state::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@crypto_key_slot_state`] module"]
+pub type CRYPTO_KEY_SLOT_STATE = crate::Reg<crypto_key_slot_state::CRYPTO_KEY_SLOT_STATE_SPEC>;
+#[doc = "State of cryptographic key slots"]
+pub mod crypto_key_slot_state;

--- a/esp32c3/src/wifi/crypto_control/crypto_key_slot_state.rs
+++ b/esp32c3/src/wifi/crypto_control/crypto_key_slot_state.rs
@@ -1,0 +1,331 @@
+#[doc = "Register `CRYPTO_KEY_SLOT_STATE` reader"]
+pub type R = crate::R<CRYPTO_KEY_SLOT_STATE_SPEC>;
+#[doc = "Register `CRYPTO_KEY_SLOT_STATE` writer"]
+pub type W = crate::W<CRYPTO_KEY_SLOT_STATE_SPEC>;
+#[doc = "Field `KEY_SLOT_ENABLE(0-24)` reader - Enable the key slot corresponding to this bit"]
+pub type KEY_SLOT_ENABLE_R = crate::BitReader;
+#[doc = "Field `KEY_SLOT_ENABLE(0-24)` writer - Enable the key slot corresponding to this bit"]
+pub type KEY_SLOT_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Enable the key slot corresponding to this bit"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `KEY_SLOT_ENABLE0` field.</div>"]
+    #[inline(always)]
+    pub fn key_slot_enable(&self, n: u8) -> KEY_SLOT_ENABLE_R {
+        #[allow(clippy::no_effect)]
+        [(); 25][n as usize];
+        KEY_SLOT_ENABLE_R::new(((self.bits >> n) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable_iter(&self) -> impl Iterator<Item = KEY_SLOT_ENABLE_R> + '_ {
+        (0..25).map(move |n| KEY_SLOT_ENABLE_R::new(((self.bits >> n) & 1) != 0))
+    }
+    #[doc = "Bit 0 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable0(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable1(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable2(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable3(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable4(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable5(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable6(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable7(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable8(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable9(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable10(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 10) & 1) != 0)
+    }
+    #[doc = "Bit 11 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable11(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 11) & 1) != 0)
+    }
+    #[doc = "Bit 12 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable12(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 12) & 1) != 0)
+    }
+    #[doc = "Bit 13 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable13(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 13) & 1) != 0)
+    }
+    #[doc = "Bit 14 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable14(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 14) & 1) != 0)
+    }
+    #[doc = "Bit 15 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable15(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 15) & 1) != 0)
+    }
+    #[doc = "Bit 16 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable16(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable17(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable18(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable19(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable20(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable21(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable22(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable23(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable24(&self) -> KEY_SLOT_ENABLE_R {
+        KEY_SLOT_ENABLE_R::new(((self.bits >> 24) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CRYPTO_KEY_SLOT_STATE")
+            .field("key_slot_enable0", &self.key_slot_enable0())
+            .field("key_slot_enable1", &self.key_slot_enable1())
+            .field("key_slot_enable2", &self.key_slot_enable2())
+            .field("key_slot_enable3", &self.key_slot_enable3())
+            .field("key_slot_enable4", &self.key_slot_enable4())
+            .field("key_slot_enable5", &self.key_slot_enable5())
+            .field("key_slot_enable6", &self.key_slot_enable6())
+            .field("key_slot_enable7", &self.key_slot_enable7())
+            .field("key_slot_enable8", &self.key_slot_enable8())
+            .field("key_slot_enable9", &self.key_slot_enable9())
+            .field("key_slot_enable10", &self.key_slot_enable10())
+            .field("key_slot_enable11", &self.key_slot_enable11())
+            .field("key_slot_enable12", &self.key_slot_enable12())
+            .field("key_slot_enable13", &self.key_slot_enable13())
+            .field("key_slot_enable14", &self.key_slot_enable14())
+            .field("key_slot_enable15", &self.key_slot_enable15())
+            .field("key_slot_enable16", &self.key_slot_enable16())
+            .field("key_slot_enable17", &self.key_slot_enable17())
+            .field("key_slot_enable18", &self.key_slot_enable18())
+            .field("key_slot_enable19", &self.key_slot_enable19())
+            .field("key_slot_enable20", &self.key_slot_enable20())
+            .field("key_slot_enable21", &self.key_slot_enable21())
+            .field("key_slot_enable22", &self.key_slot_enable22())
+            .field("key_slot_enable23", &self.key_slot_enable23())
+            .field("key_slot_enable24", &self.key_slot_enable24())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Enable the key slot corresponding to this bit"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `KEY_SLOT_ENABLE0` field.</div>"]
+    #[inline(always)]
+    pub fn key_slot_enable(&mut self, n: u8) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 25][n as usize];
+        KEY_SLOT_ENABLE_W::new(self, n)
+    }
+    #[doc = "Bit 0 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable0(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable1(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable2(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable3(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable4(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 4)
+    }
+    #[doc = "Bit 5 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable5(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable6(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 6)
+    }
+    #[doc = "Bit 7 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable7(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 7)
+    }
+    #[doc = "Bit 8 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable8(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable9(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 9)
+    }
+    #[doc = "Bit 10 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable10(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 10)
+    }
+    #[doc = "Bit 11 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable11(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 11)
+    }
+    #[doc = "Bit 12 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable12(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 12)
+    }
+    #[doc = "Bit 13 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable13(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 13)
+    }
+    #[doc = "Bit 14 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable14(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 14)
+    }
+    #[doc = "Bit 15 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable15(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 15)
+    }
+    #[doc = "Bit 16 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable16(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable17(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable18(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 18)
+    }
+    #[doc = "Bit 19 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable19(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 19)
+    }
+    #[doc = "Bit 20 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable20(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 20)
+    }
+    #[doc = "Bit 21 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable21(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable22(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 22)
+    }
+    #[doc = "Bit 23 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable23(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 23)
+    }
+    #[doc = "Bit 24 - Enable the key slot corresponding to this bit"]
+    #[inline(always)]
+    pub fn key_slot_enable24(&mut self) -> KEY_SLOT_ENABLE_W<'_, CRYPTO_KEY_SLOT_STATE_SPEC> {
+        KEY_SLOT_ENABLE_W::new(self, 24)
+    }
+}
+#[doc = "State of cryptographic key slots\n\nYou can [`read`](crate::Reg::read) this register and get [`crypto_key_slot_state::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`crypto_key_slot_state::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CRYPTO_KEY_SLOT_STATE_SPEC;
+impl crate::RegisterSpec for CRYPTO_KEY_SLOT_STATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`crypto_key_slot_state::R`](R) reader structure"]
+impl crate::Readable for CRYPTO_KEY_SLOT_STATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`crypto_key_slot_state::W`](W) writer structure"]
+impl crate::Writable for CRYPTO_KEY_SLOT_STATE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CRYPTO_KEY_SLOT_STATE to value 0"]
+impl crate::Resettable for CRYPTO_KEY_SLOT_STATE_SPEC {}

--- a/esp32c3/src/wifi/crypto_control/general_crypto_control.rs
+++ b/esp32c3/src/wifi/crypto_control/general_crypto_control.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `GENERAL_CRYPTO_CONTROL` reader"]
+pub type R = crate::R<GENERAL_CRYPTO_CONTROL_SPEC>;
+#[doc = "Register `GENERAL_CRYPTO_CONTROL` writer"]
+pub type W = crate::W<GENERAL_CRYPTO_CONTROL_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Control over the whole crypto unit\n\nYou can [`read`](crate::Reg::read) this register and get [`general_crypto_control::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`general_crypto_control::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GENERAL_CRYPTO_CONTROL_SPEC;
+impl crate::RegisterSpec for GENERAL_CRYPTO_CONTROL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`general_crypto_control::R`](R) reader structure"]
+impl crate::Readable for GENERAL_CRYPTO_CONTROL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`general_crypto_control::W`](W) writer structure"]
+impl crate::Writable for GENERAL_CRYPTO_CONTROL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets GENERAL_CRYPTO_CONTROL to value 0"]
+impl crate::Resettable for GENERAL_CRYPTO_CONTROL_SPEC {}

--- a/esp32c3/src/wifi/crypto_control/interface_crypto_control.rs
+++ b/esp32c3/src/wifi/crypto_control/interface_crypto_control.rs
@@ -1,0 +1,88 @@
+#[doc = "Register `INTERFACE_CRYPTO_CONTROL%s` reader"]
+pub type R = crate::R<INTERFACE_CRYPTO_CONTROL_SPEC>;
+#[doc = "Register `INTERFACE_CRYPTO_CONTROL%s` writer"]
+pub type W = crate::W<INTERFACE_CRYPTO_CONTROL_SPEC>;
+#[doc = "Field `SPP_ENABLE` reader - Enable Signaling and Payload Protection (SPP) for A-MSDUs"]
+pub type SPP_ENABLE_R = crate::BitReader;
+#[doc = "Field `SPP_ENABLE` writer - Enable Signaling and Payload Protection (SPP) for A-MSDUs"]
+pub type SPP_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PMF_DISABLE` reader - Disable Protected Management Frames (PMF)"]
+pub type PMF_DISABLE_R = crate::BitReader;
+#[doc = "Field `PMF_DISABLE` writer - Disable Protected Management Frames (PMF)"]
+pub type PMF_DISABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `AEAD_CIPHER` reader - Does the cipher employ Authenticated Encryption with Associated Data (AEAD)"]
+pub type AEAD_CIPHER_R = crate::BitReader;
+#[doc = "Field `AEAD_CIPHER` writer - Does the cipher employ Authenticated Encryption with Associated Data (AEAD)"]
+pub type AEAD_CIPHER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SMS4` reader - Cipher is SMS4"]
+pub type SMS4_R = crate::BitReader;
+#[doc = "Field `SMS4` writer - Cipher is SMS4"]
+pub type SMS4_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 9 - Enable Signaling and Payload Protection (SPP) for A-MSDUs"]
+    #[inline(always)]
+    pub fn spp_enable(&self) -> SPP_ENABLE_R {
+        SPP_ENABLE_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 17 - Disable Protected Management Frames (PMF)"]
+    #[inline(always)]
+    pub fn pmf_disable(&self) -> PMF_DISABLE_R {
+        PMF_DISABLE_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 28 - Does the cipher employ Authenticated Encryption with Associated Data (AEAD)"]
+    #[inline(always)]
+    pub fn aead_cipher(&self) -> AEAD_CIPHER_R {
+        AEAD_CIPHER_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Cipher is SMS4"]
+    #[inline(always)]
+    pub fn sms4(&self) -> SMS4_R {
+        SMS4_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("INTERFACE_CRYPTO_CONTROL")
+            .field("spp_enable", &self.spp_enable())
+            .field("pmf_disable", &self.pmf_disable())
+            .field("aead_cipher", &self.aead_cipher())
+            .field("sms4", &self.sms4())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 9 - Enable Signaling and Payload Protection (SPP) for A-MSDUs"]
+    #[inline(always)]
+    pub fn spp_enable(&mut self) -> SPP_ENABLE_W<'_, INTERFACE_CRYPTO_CONTROL_SPEC> {
+        SPP_ENABLE_W::new(self, 9)
+    }
+    #[doc = "Bit 17 - Disable Protected Management Frames (PMF)"]
+    #[inline(always)]
+    pub fn pmf_disable(&mut self) -> PMF_DISABLE_W<'_, INTERFACE_CRYPTO_CONTROL_SPEC> {
+        PMF_DISABLE_W::new(self, 17)
+    }
+    #[doc = "Bit 28 - Does the cipher employ Authenticated Encryption with Associated Data (AEAD)"]
+    #[inline(always)]
+    pub fn aead_cipher(&mut self) -> AEAD_CIPHER_W<'_, INTERFACE_CRYPTO_CONTROL_SPEC> {
+        AEAD_CIPHER_W::new(self, 28)
+    }
+    #[doc = "Bit 31 - Cipher is SMS4"]
+    #[inline(always)]
+    pub fn sms4(&mut self) -> SMS4_W<'_, INTERFACE_CRYPTO_CONTROL_SPEC> {
+        SMS4_W::new(self, 31)
+    }
+}
+#[doc = "Control over cryptographic parameters for a specific interface\n\nYou can [`read`](crate::Reg::read) this register and get [`interface_crypto_control::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`interface_crypto_control::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INTERFACE_CRYPTO_CONTROL_SPEC;
+impl crate::RegisterSpec for INTERFACE_CRYPTO_CONTROL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`interface_crypto_control::R`](R) reader structure"]
+impl crate::Readable for INTERFACE_CRYPTO_CONTROL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`interface_crypto_control::W`](W) writer structure"]
+impl crate::Writable for INTERFACE_CRYPTO_CONTROL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets INTERFACE_CRYPTO_CONTROL%s to value 0"]
+impl crate::Resettable for INTERFACE_CRYPTO_CONTROL_SPEC {}

--- a/esp32c3/src/wifi/crypto_key_slot.rs
+++ b/esp32c3/src/wifi/crypto_key_slot.rs
@@ -1,0 +1,43 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Cryptographic keys for MPDU encapsulation and decapsulation"]
+pub struct CRYPTO_KEY_SLOT {
+    addr_low: ADDR_LOW,
+    addr_high: ADDR_HIGH,
+    key_value: [KEY_VALUE; 8],
+}
+impl CRYPTO_KEY_SLOT {
+    #[doc = "0x00 - Lower four octets of the MAC address"]
+    #[inline(always)]
+    pub const fn addr_low(&self) -> &ADDR_LOW {
+        &self.addr_low
+    }
+    #[doc = "0x04 - Higher two octets of the MAC address and config bits"]
+    #[inline(always)]
+    pub const fn addr_high(&self) -> &ADDR_HIGH {
+        &self.addr_high
+    }
+    #[doc = "0x08..0x28 - Actual key data"]
+    #[inline(always)]
+    pub const fn key_value(&self, n: usize) -> &KEY_VALUE {
+        &self.key_value[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x08..0x28 - Actual key data"]
+    #[inline(always)]
+    pub fn key_value_iter(&self) -> impl Iterator<Item = &KEY_VALUE> {
+        self.key_value.iter()
+    }
+}
+#[doc = "ADDR_LOW (rw) register accessor: Lower four octets of the MAC address\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_low::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_low::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@addr_low`] module"]
+pub type ADDR_LOW = crate::Reg<addr_low::ADDR_LOW_SPEC>;
+#[doc = "Lower four octets of the MAC address"]
+pub mod addr_low;
+#[doc = "ADDR_HIGH (rw) register accessor: Higher two octets of the MAC address and config bits\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_high::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_high::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@addr_high`] module"]
+pub type ADDR_HIGH = crate::Reg<addr_high::ADDR_HIGH_SPEC>;
+#[doc = "Higher two octets of the MAC address and config bits"]
+pub mod addr_high;
+#[doc = "KEY_VALUE (rw) register accessor: Actual key data\n\nYou can [`read`](crate::Reg::read) this register and get [`key_value::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`key_value::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@key_value`] module"]
+pub type KEY_VALUE = crate::Reg<key_value::KEY_VALUE_SPEC>;
+#[doc = "Actual key data"]
+pub mod key_value;

--- a/esp32c3/src/wifi/crypto_key_slot/addr_high.rs
+++ b/esp32c3/src/wifi/crypto_key_slot/addr_high.rs
@@ -1,0 +1,163 @@
+#[doc = "Register `ADDR_HIGH` reader"]
+pub type R = crate::R<ADDR_HIGH_SPEC>;
+#[doc = "Register `ADDR_HIGH` writer"]
+pub type W = crate::W<ADDR_HIGH_SPEC>;
+#[doc = "Field `ADDR` reader - Higher two octets of the MAC address"]
+pub type ADDR_R = crate::FieldReader<u16>;
+#[doc = "Field `ADDR` writer - Higher two octets of the MAC address"]
+pub type ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `WEP_104` reader - Is the cipher WEP104"]
+pub type WEP_104_R = crate::BitReader;
+#[doc = "Field `WEP_104` writer - Is the cipher WEP104"]
+pub type WEP_104_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ALGORITHM` reader - In use algorithm"]
+pub type ALGORITHM_R = crate::FieldReader;
+#[doc = "Field `ALGORITHM` writer - In use algorithm"]
+pub type ALGORITHM_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `PAIRWISE_KEY` reader - Is this a pairwise key"]
+pub type PAIRWISE_KEY_R = crate::BitReader;
+#[doc = "Field `PAIRWISE_KEY` writer - Is this a pairwise key"]
+pub type PAIRWISE_KEY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `UNKNOWN` reader - Meaning unknown set to 1 for all algorithms"]
+pub type UNKNOWN_R = crate::BitReader;
+#[doc = "Field `UNKNOWN` writer - Meaning unknown set to 1 for all algorithms"]
+pub type UNKNOWN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `GROUP_KEY` reader - Is this a group key"]
+pub type GROUP_KEY_R = crate::BitReader;
+#[doc = "Field `GROUP_KEY` writer - Is this a group key"]
+pub type GROUP_KEY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `INTERFACE_ID` reader - Index of the interface using the key"]
+pub type INTERFACE_ID_R = crate::FieldReader;
+#[doc = "Field `INTERFACE_ID` writer - Index of the interface using the key"]
+pub type INTERFACE_ID_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `BITS_256` reader - Key length is 256 bits"]
+pub type BITS_256_R = crate::BitReader;
+#[doc = "Field `BITS_256` writer - Key length is 256 bits"]
+pub type BITS_256_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `KEY_ID` reader - Protocol identifier of the key"]
+pub type KEY_ID_R = crate::FieldReader;
+#[doc = "Field `KEY_ID` writer - Protocol identifier of the key"]
+pub type KEY_ID_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 0:15 - Higher two octets of the MAC address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 16 - Is the cipher WEP104"]
+    #[inline(always)]
+    pub fn wep_104(&self) -> WEP_104_R {
+        WEP_104_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bits 18:20 - In use algorithm"]
+    #[inline(always)]
+    pub fn algorithm(&self) -> ALGORITHM_R {
+        ALGORITHM_R::new(((self.bits >> 18) & 7) as u8)
+    }
+    #[doc = "Bit 21 - Is this a pairwise key"]
+    #[inline(always)]
+    pub fn pairwise_key(&self) -> PAIRWISE_KEY_R {
+        PAIRWISE_KEY_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - Meaning unknown set to 1 for all algorithms"]
+    #[inline(always)]
+    pub fn unknown(&self) -> UNKNOWN_R {
+        UNKNOWN_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - Is this a group key"]
+    #[inline(always)]
+    pub fn group_key(&self) -> GROUP_KEY_R {
+        GROUP_KEY_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bits 24:25 - Index of the interface using the key"]
+    #[inline(always)]
+    pub fn interface_id(&self) -> INTERFACE_ID_R {
+        INTERFACE_ID_R::new(((self.bits >> 24) & 3) as u8)
+    }
+    #[doc = "Bit 26 - Key length is 256 bits"]
+    #[inline(always)]
+    pub fn bits_256(&self) -> BITS_256_R {
+        BITS_256_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bits 30:31 - Protocol identifier of the key"]
+    #[inline(always)]
+    pub fn key_id(&self) -> KEY_ID_R {
+        KEY_ID_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ADDR_HIGH")
+            .field("addr", &self.addr())
+            .field("wep_104", &self.wep_104())
+            .field("algorithm", &self.algorithm())
+            .field("pairwise_key", &self.pairwise_key())
+            .field("unknown", &self.unknown())
+            .field("group_key", &self.group_key())
+            .field("interface_id", &self.interface_id())
+            .field("bits_256", &self.bits_256())
+            .field("key_id", &self.key_id())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Higher two octets of the MAC address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W<'_, ADDR_HIGH_SPEC> {
+        ADDR_W::new(self, 0)
+    }
+    #[doc = "Bit 16 - Is the cipher WEP104"]
+    #[inline(always)]
+    pub fn wep_104(&mut self) -> WEP_104_W<'_, ADDR_HIGH_SPEC> {
+        WEP_104_W::new(self, 16)
+    }
+    #[doc = "Bits 18:20 - In use algorithm"]
+    #[inline(always)]
+    pub fn algorithm(&mut self) -> ALGORITHM_W<'_, ADDR_HIGH_SPEC> {
+        ALGORITHM_W::new(self, 18)
+    }
+    #[doc = "Bit 21 - Is this a pairwise key"]
+    #[inline(always)]
+    pub fn pairwise_key(&mut self) -> PAIRWISE_KEY_W<'_, ADDR_HIGH_SPEC> {
+        PAIRWISE_KEY_W::new(self, 21)
+    }
+    #[doc = "Bit 22 - Meaning unknown set to 1 for all algorithms"]
+    #[inline(always)]
+    pub fn unknown(&mut self) -> UNKNOWN_W<'_, ADDR_HIGH_SPEC> {
+        UNKNOWN_W::new(self, 22)
+    }
+    #[doc = "Bit 23 - Is this a group key"]
+    #[inline(always)]
+    pub fn group_key(&mut self) -> GROUP_KEY_W<'_, ADDR_HIGH_SPEC> {
+        GROUP_KEY_W::new(self, 23)
+    }
+    #[doc = "Bits 24:25 - Index of the interface using the key"]
+    #[inline(always)]
+    pub fn interface_id(&mut self) -> INTERFACE_ID_W<'_, ADDR_HIGH_SPEC> {
+        INTERFACE_ID_W::new(self, 24)
+    }
+    #[doc = "Bit 26 - Key length is 256 bits"]
+    #[inline(always)]
+    pub fn bits_256(&mut self) -> BITS_256_W<'_, ADDR_HIGH_SPEC> {
+        BITS_256_W::new(self, 26)
+    }
+    #[doc = "Bits 30:31 - Protocol identifier of the key"]
+    #[inline(always)]
+    pub fn key_id(&mut self) -> KEY_ID_W<'_, ADDR_HIGH_SPEC> {
+        KEY_ID_W::new(self, 30)
+    }
+}
+#[doc = "Higher two octets of the MAC address and config bits\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_high::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_high::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ADDR_HIGH_SPEC;
+impl crate::RegisterSpec for ADDR_HIGH_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`addr_high::R`](R) reader structure"]
+impl crate::Readable for ADDR_HIGH_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`addr_high::W`](W) writer structure"]
+impl crate::Writable for ADDR_HIGH_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets ADDR_HIGH to value 0"]
+impl crate::Resettable for ADDR_HIGH_SPEC {}

--- a/esp32c3/src/wifi/crypto_key_slot/addr_low.rs
+++ b/esp32c3/src/wifi/crypto_key_slot/addr_low.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `ADDR_LOW` reader"]
+pub type R = crate::R<ADDR_LOW_SPEC>;
+#[doc = "Register `ADDR_LOW` writer"]
+pub type W = crate::W<ADDR_LOW_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Lower four octets of the MAC address\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_low::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_low::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ADDR_LOW_SPEC;
+impl crate::RegisterSpec for ADDR_LOW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`addr_low::R`](R) reader structure"]
+impl crate::Readable for ADDR_LOW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`addr_low::W`](W) writer structure"]
+impl crate::Writable for ADDR_LOW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets ADDR_LOW to value 0"]
+impl crate::Resettable for ADDR_LOW_SPEC {}

--- a/esp32c3/src/wifi/crypto_key_slot/key_value.rs
+++ b/esp32c3/src/wifi/crypto_key_slot/key_value.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `KEY_VALUE%s` reader"]
+pub type R = crate::R<KEY_VALUE_SPEC>;
+#[doc = "Register `KEY_VALUE%s` writer"]
+pub type W = crate::W<KEY_VALUE_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Actual key data\n\nYou can [`read`](crate::Reg::read) this register and get [`key_value::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`key_value::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct KEY_VALUE_SPEC;
+impl crate::RegisterSpec for KEY_VALUE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`key_value::R`](R) reader structure"]
+impl crate::Readable for KEY_VALUE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`key_value::W`](W) writer structure"]
+impl crate::Writable for KEY_VALUE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets KEY_VALUE%s to value 0"]
+impl crate::Resettable for KEY_VALUE_SPEC {}

--- a/esp32c3/src/wifi/ctrl.rs
+++ b/esp32c3/src/wifi/ctrl.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `CTRL` reader"]
+pub type R = crate::R<CTRL_SPEC>;
+#[doc = "Register `CTRL` writer"]
+pub type W = crate::W<CTRL_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Exact name and meaning unknown, used for initializing the MAC\n\nYou can [`read`](crate::Reg::read) this register and get [`ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CTRL_SPEC;
+impl crate::RegisterSpec for CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ctrl::R`](R) reader structure"]
+impl crate::Readable for CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ctrl::W`](W) writer structure"]
+impl crate::Writable for CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CTRL to value 0"]
+impl crate::Resettable for CTRL_SPEC {}

--- a/esp32c3/src/wifi/duration.rs
+++ b/esp32c3/src/wifi/duration.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `DURATION%s` reader"]
+pub type R = crate::R<DURATION_SPEC>;
+#[doc = "Register `DURATION%s` writer"]
+pub type W = crate::W<DURATION_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "duration of the frame exchange\n\nYou can [`read`](crate::Reg::read) this register and get [`duration::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`duration::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct DURATION_SPEC;
+impl crate::RegisterSpec for DURATION_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`duration::R`](R) reader structure"]
+impl crate::Readable for DURATION_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`duration::W`](W) writer structure"]
+impl crate::Writable for DURATION_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets DURATION%s to value 0"]
+impl crate::Resettable for DURATION_SPEC {}

--- a/esp32c3/src/wifi/filter_bank.rs
+++ b/esp32c3/src/wifi/filter_bank.rs
@@ -1,0 +1,119 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA. Each filter bank has registers for four interfaces."]
+pub struct FILTER_BANK {
+    addr_low: (),
+    _reserved1: [u8; 0x04],
+    addr_high: (),
+    _reserved2: [u8; 0x1c],
+    mask_low: (),
+    _reserved3: [u8; 0x04],
+    mask_high: (),
+    _reserved_end: [u8; 0x1c],
+}
+impl FILTER_BANK {
+    #[doc = "0x00..0x10 - First 4 bytes of BSSID MAC address filter"]
+    #[inline(always)]
+    pub const fn addr_low(&self, n: usize) -> &ADDR_LOW {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(8 * n).cast() }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x00..0x10 - First 4 bytes of BSSID MAC address filter"]
+    #[inline(always)]
+    pub fn addr_low_iter(&self) -> impl Iterator<Item = &ADDR_LOW> {
+        (0..4).map(move |n| unsafe { &*core::ptr::from_ref(self).cast::<u8>().add(8 * n).cast() })
+    }
+    #[doc = "0x04..0x14 - last 2 bytes of BSSID MAC address filter"]
+    #[inline(always)]
+    pub const fn addr_high(&self, n: usize) -> &ADDR_HIGH {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4)
+                .add(8 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x04..0x14 - last 2 bytes of BSSID MAC address filter"]
+    #[inline(always)]
+    pub fn addr_high_iter(&self) -> impl Iterator<Item = &ADDR_HIGH> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(4)
+                .add(8 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x20..0x30 - First 4 bytes of BSSID MAC address filter mask"]
+    #[inline(always)]
+    pub const fn mask_low(&self, n: usize) -> &MASK_LOW {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(32)
+                .add(8 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x20..0x30 - First 4 bytes of BSSID MAC address filter mask"]
+    #[inline(always)]
+    pub fn mask_low_iter(&self) -> impl Iterator<Item = &MASK_LOW> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(32)
+                .add(8 * n)
+                .cast()
+        })
+    }
+    #[doc = "0x24..0x34 - last 2 bytes of BSSID MAC address filter mask"]
+    #[inline(always)]
+    pub const fn mask_high(&self, n: usize) -> &MASK_HIGH {
+        #[allow(clippy::no_effect)]
+        [(); 4][n];
+        unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(36)
+                .add(8 * n)
+                .cast()
+        }
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x24..0x34 - last 2 bytes of BSSID MAC address filter mask"]
+    #[inline(always)]
+    pub fn mask_high_iter(&self) -> impl Iterator<Item = &MASK_HIGH> {
+        (0..4).map(move |n| unsafe {
+            &*core::ptr::from_ref(self)
+                .cast::<u8>()
+                .add(36)
+                .add(8 * n)
+                .cast()
+        })
+    }
+}
+#[doc = "ADDR_LOW (rw) register accessor: First 4 bytes of BSSID MAC address filter\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_low::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_low::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@addr_low`] module"]
+pub type ADDR_LOW = crate::Reg<addr_low::ADDR_LOW_SPEC>;
+#[doc = "First 4 bytes of BSSID MAC address filter"]
+pub mod addr_low;
+#[doc = "ADDR_HIGH (rw) register accessor: last 2 bytes of BSSID MAC address filter\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_high::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_high::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@addr_high`] module"]
+pub type ADDR_HIGH = crate::Reg<addr_high::ADDR_HIGH_SPEC>;
+#[doc = "last 2 bytes of BSSID MAC address filter"]
+pub mod addr_high;
+#[doc = "MASK_LOW (rw) register accessor: First 4 bytes of BSSID MAC address filter mask\n\nYou can [`read`](crate::Reg::read) this register and get [`mask_low::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mask_low::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mask_low`] module"]
+pub type MASK_LOW = crate::Reg<mask_low::MASK_LOW_SPEC>;
+#[doc = "First 4 bytes of BSSID MAC address filter mask"]
+pub mod mask_low;
+#[doc = "MASK_HIGH (rw) register accessor: last 2 bytes of BSSID MAC address filter mask\n\nYou can [`read`](crate::Reg::read) this register and get [`mask_high::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mask_high::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@mask_high`] module"]
+pub type MASK_HIGH = crate::Reg<mask_high::MASK_HIGH_SPEC>;
+#[doc = "last 2 bytes of BSSID MAC address filter mask"]
+pub mod mask_high;

--- a/esp32c3/src/wifi/filter_bank/addr_high.rs
+++ b/esp32c3/src/wifi/filter_bank/addr_high.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `ADDR_HIGH%s` reader"]
+pub type R = crate::R<ADDR_HIGH_SPEC>;
+#[doc = "Register `ADDR_HIGH%s` writer"]
+pub type W = crate::W<ADDR_HIGH_SPEC>;
+#[doc = "Field `ADDR` reader - "]
+pub type ADDR_R = crate::FieldReader<u16>;
+#[doc = "Field `ADDR` writer - "]
+pub type ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+impl R {
+    #[doc = "Bits 0:15"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ADDR_HIGH")
+            .field("addr", &self.addr())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:15"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W<'_, ADDR_HIGH_SPEC> {
+        ADDR_W::new(self, 0)
+    }
+}
+#[doc = "last 2 bytes of BSSID MAC address filter\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_high::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_high::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ADDR_HIGH_SPEC;
+impl crate::RegisterSpec for ADDR_HIGH_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`addr_high::R`](R) reader structure"]
+impl crate::Readable for ADDR_HIGH_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`addr_high::W`](W) writer structure"]
+impl crate::Writable for ADDR_HIGH_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets ADDR_HIGH%s to value 0"]
+impl crate::Resettable for ADDR_HIGH_SPEC {}

--- a/esp32c3/src/wifi/filter_bank/addr_low.rs
+++ b/esp32c3/src/wifi/filter_bank/addr_low.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `ADDR_LOW%s` reader"]
+pub type R = crate::R<ADDR_LOW_SPEC>;
+#[doc = "Register `ADDR_LOW%s` writer"]
+pub type W = crate::W<ADDR_LOW_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "First 4 bytes of BSSID MAC address filter\n\nYou can [`read`](crate::Reg::read) this register and get [`addr_low::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`addr_low::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ADDR_LOW_SPEC;
+impl crate::RegisterSpec for ADDR_LOW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`addr_low::R`](R) reader structure"]
+impl crate::Readable for ADDR_LOW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`addr_low::W`](W) writer structure"]
+impl crate::Writable for ADDR_LOW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets ADDR_LOW%s to value 0"]
+impl crate::Resettable for ADDR_LOW_SPEC {}

--- a/esp32c3/src/wifi/filter_bank/mask_high.rs
+++ b/esp32c3/src/wifi/filter_bank/mask_high.rs
@@ -1,0 +1,58 @@
+#[doc = "Register `MASK_HIGH%s` reader"]
+pub type R = crate::R<MASK_HIGH_SPEC>;
+#[doc = "Register `MASK_HIGH%s` writer"]
+pub type W = crate::W<MASK_HIGH_SPEC>;
+#[doc = "Field `MASK` reader - "]
+pub type MASK_R = crate::FieldReader<u16>;
+#[doc = "Field `MASK` writer - "]
+pub type MASK_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `ENABLED` reader - "]
+pub type ENABLED_R = crate::BitReader;
+#[doc = "Field `ENABLED` writer - "]
+pub type ENABLED_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 0:15"]
+    #[inline(always)]
+    pub fn mask(&self) -> MASK_R {
+        MASK_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 16"]
+    #[inline(always)]
+    pub fn enabled(&self) -> ENABLED_R {
+        ENABLED_R::new(((self.bits >> 16) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MASK_HIGH")
+            .field("mask", &self.mask())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:15"]
+    #[inline(always)]
+    pub fn mask(&mut self) -> MASK_W<'_, MASK_HIGH_SPEC> {
+        MASK_W::new(self, 0)
+    }
+    #[doc = "Bit 16"]
+    #[inline(always)]
+    pub fn enabled(&mut self) -> ENABLED_W<'_, MASK_HIGH_SPEC> {
+        ENABLED_W::new(self, 16)
+    }
+}
+#[doc = "last 2 bytes of BSSID MAC address filter mask\n\nYou can [`read`](crate::Reg::read) this register and get [`mask_high::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mask_high::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MASK_HIGH_SPEC;
+impl crate::RegisterSpec for MASK_HIGH_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mask_high::R`](R) reader structure"]
+impl crate::Readable for MASK_HIGH_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mask_high::W`](W) writer structure"]
+impl crate::Writable for MASK_HIGH_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets MASK_HIGH%s to value 0"]
+impl crate::Resettable for MASK_HIGH_SPEC {}

--- a/esp32c3/src/wifi/filter_bank/mask_low.rs
+++ b/esp32c3/src/wifi/filter_bank/mask_low.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `MASK_LOW%s` reader"]
+pub type R = crate::R<MASK_LOW_SPEC>;
+#[doc = "Register `MASK_LOW%s` writer"]
+pub type W = crate::W<MASK_LOW_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "First 4 bytes of BSSID MAC address filter mask\n\nYou can [`read`](crate::Reg::read) this register and get [`mask_low::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mask_low::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MASK_LOW_SPEC;
+impl crate::RegisterSpec for MASK_LOW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mask_low::R`](R) reader structure"]
+impl crate::Readable for MASK_LOW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mask_low::W`](W) writer structure"]
+impl crate::Writable for MASK_LOW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets MASK_LOW%s to value 0"]
+impl crate::Resettable for MASK_LOW_SPEC {}

--- a/esp32c3/src/wifi/filter_control.rs
+++ b/esp32c3/src/wifi/filter_control.rs
@@ -1,0 +1,103 @@
+#[doc = "Register `FILTER_CONTROL%s` reader"]
+pub type R = crate::R<FILTER_CONTROL_SPEC>;
+#[doc = "Register `FILTER_CONTROL%s` writer"]
+pub type W = crate::W<FILTER_CONTROL_SPEC>;
+#[doc = "Field `BLOCK_UNICAST` reader - Block unicast frames not matching the address filter"]
+pub type BLOCK_UNICAST_R = crate::BitReader;
+#[doc = "Field `BLOCK_UNICAST` writer - Block unicast frames not matching the address filter"]
+pub type BLOCK_UNICAST_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `BSSID_CHECK` reader - Check BSSID for filtering"]
+pub type BSSID_CHECK_R = crate::BitReader;
+#[doc = "Field `BSSID_CHECK` writer - Check BSSID for filtering"]
+pub type BSSID_CHECK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `BLOCK_MULTICAST` reader - Block multicast frames not matching the address filter"]
+pub type BLOCK_MULTICAST_R = crate::BitReader;
+#[doc = "Field `BLOCK_MULTICAST` writer - Block multicast frames not matching the address filter"]
+pub type BLOCK_MULTICAST_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SCAN_MODE` reader - Receive beacon frames"]
+pub type SCAN_MODE_R = crate::BitReader;
+#[doc = "Field `SCAN_MODE` writer - Receive beacon frames"]
+pub type SCAN_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `DATA_AND_MGMT_MODE` reader - Receive everything except control frames"]
+pub type DATA_AND_MGMT_MODE_R = crate::BitReader;
+#[doc = "Field `DATA_AND_MGMT_MODE` writer - Receive everything except control frames"]
+pub type DATA_AND_MGMT_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Block unicast frames not matching the address filter"]
+    #[inline(always)]
+    pub fn block_unicast(&self) -> BLOCK_UNICAST_R {
+        BLOCK_UNICAST_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Check BSSID for filtering"]
+    #[inline(always)]
+    pub fn bssid_check(&self) -> BSSID_CHECK_R {
+        BSSID_CHECK_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Block multicast frames not matching the address filter"]
+    #[inline(always)]
+    pub fn block_multicast(&self) -> BLOCK_MULTICAST_R {
+        BLOCK_MULTICAST_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Receive beacon frames"]
+    #[inline(always)]
+    pub fn scan_mode(&self) -> SCAN_MODE_R {
+        SCAN_MODE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Receive everything except control frames"]
+    #[inline(always)]
+    pub fn data_and_mgmt_mode(&self) -> DATA_AND_MGMT_MODE_R {
+        DATA_AND_MGMT_MODE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FILTER_CONTROL")
+            .field("block_unicast", &self.block_unicast())
+            .field("bssid_check", &self.bssid_check())
+            .field("block_multicast", &self.block_multicast())
+            .field("scan_mode", &self.scan_mode())
+            .field("data_and_mgmt_mode", &self.data_and_mgmt_mode())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Block unicast frames not matching the address filter"]
+    #[inline(always)]
+    pub fn block_unicast(&mut self) -> BLOCK_UNICAST_W<'_, FILTER_CONTROL_SPEC> {
+        BLOCK_UNICAST_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Check BSSID for filtering"]
+    #[inline(always)]
+    pub fn bssid_check(&mut self) -> BSSID_CHECK_W<'_, FILTER_CONTROL_SPEC> {
+        BSSID_CHECK_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Block multicast frames not matching the address filter"]
+    #[inline(always)]
+    pub fn block_multicast(&mut self) -> BLOCK_MULTICAST_W<'_, FILTER_CONTROL_SPEC> {
+        BLOCK_MULTICAST_W::new(self, 2)
+    }
+    #[doc = "Bit 4 - Receive beacon frames"]
+    #[inline(always)]
+    pub fn scan_mode(&mut self) -> SCAN_MODE_W<'_, FILTER_CONTROL_SPEC> {
+        SCAN_MODE_W::new(self, 4)
+    }
+    #[doc = "Bit 8 - Receive everything except control frames"]
+    #[inline(always)]
+    pub fn data_and_mgmt_mode(&mut self) -> DATA_AND_MGMT_MODE_W<'_, FILTER_CONTROL_SPEC> {
+        DATA_AND_MGMT_MODE_W::new(self, 8)
+    }
+}
+#[doc = "Controls the RX filter for an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`filter_control::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`filter_control::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct FILTER_CONTROL_SPEC;
+impl crate::RegisterSpec for FILTER_CONTROL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`filter_control::R`](R) reader structure"]
+impl crate::Readable for FILTER_CONTROL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`filter_control::W`](W) writer structure"]
+impl crate::Writable for FILTER_CONTROL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets FILTER_CONTROL%s to value 0"]
+impl crate::Resettable for FILTER_CONTROL_SPEC {}

--- a/esp32c3/src/wifi/ht_sig.rs
+++ b/esp32c3/src/wifi/ht_sig.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `HT_SIG%s` reader"]
+pub type R = crate::R<HT_SIG_SPEC>;
+#[doc = "Register `HT_SIG%s` writer"]
+pub type W = crate::W<HT_SIG_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "HT-SIG field in HT preamble\n\nYou can [`read`](crate::Reg::read) this register and get [`ht_sig::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ht_sig::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HT_SIG_SPEC;
+impl crate::RegisterSpec for HT_SIG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ht_sig::R`](R) reader structure"]
+impl crate::Readable for HT_SIG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ht_sig::W`](W) writer structure"]
+impl crate::Writable for HT_SIG_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets HT_SIG%s to value 0"]
+impl crate::Resettable for HT_SIG_SPEC {}

--- a/esp32c3/src/wifi/ht_unknown.rs
+++ b/esp32c3/src/wifi/ht_unknown.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `HT_UNKNOWN%s` reader"]
+pub type R = crate::R<HT_UNKNOWN_SPEC>;
+#[doc = "Register `HT_UNKNOWN%s` writer"]
+pub type W = crate::W<HT_UNKNOWN_SPEC>;
+#[doc = "Field `LENGTH` reader - The length of the PPDU"]
+pub type LENGTH_R = crate::FieldReader<u32>;
+#[doc = "Field `LENGTH` writer - The length of the PPDU"]
+pub type LENGTH_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+impl R {
+    #[doc = "Bits 0:19 - The length of the PPDU"]
+    #[inline(always)]
+    pub fn length(&self) -> LENGTH_R {
+        LENGTH_R::new(self.bits & 0x000f_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HT_UNKNOWN")
+            .field("length", &self.length())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:19 - The length of the PPDU"]
+    #[inline(always)]
+    pub fn length(&mut self) -> LENGTH_W<'_, HT_UNKNOWN_SPEC> {
+        LENGTH_W::new(self, 0)
+    }
+}
+#[doc = "exact meaning and name unknown, related to HT\n\nYou can [`read`](crate::Reg::read) this register and get [`ht_unknown::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`ht_unknown::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HT_UNKNOWN_SPEC;
+impl crate::RegisterSpec for HT_UNKNOWN_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ht_unknown::R`](R) reader structure"]
+impl crate::Readable for HT_UNKNOWN_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ht_unknown::W`](W) writer structure"]
+impl crate::Writable for HT_UNKNOWN_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets HT_UNKNOWN%s to value 0"]
+impl crate::Resettable for HT_UNKNOWN_SPEC {}

--- a/esp32c3/src/wifi/mac_interrupt.rs
+++ b/esp32c3/src/wifi/mac_interrupt.rs
@@ -1,0 +1,27 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Status and clear for the WIFI_MAC interrupt"]
+pub struct MAC_INTERRUPT {
+    wifi_int_status: WIFI_INT_STATUS,
+    wifi_int_clear: WIFI_INT_CLEAR,
+}
+impl MAC_INTERRUPT {
+    #[doc = "0x00 - Interrupt status of WIFI peripheral"]
+    #[inline(always)]
+    pub const fn wifi_int_status(&self) -> &WIFI_INT_STATUS {
+        &self.wifi_int_status
+    }
+    #[doc = "0x04 - Interrupt status clear of WIFI peripheral"]
+    #[inline(always)]
+    pub const fn wifi_int_clear(&self) -> &WIFI_INT_CLEAR {
+        &self.wifi_int_clear
+    }
+}
+#[doc = "WIFI_INT_STATUS (rw) register accessor: Interrupt status of WIFI peripheral\n\nYou can [`read`](crate::Reg::read) this register and get [`wifi_int_status::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wifi_int_status::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wifi_int_status`] module"]
+pub type WIFI_INT_STATUS = crate::Reg<wifi_int_status::WIFI_INT_STATUS_SPEC>;
+#[doc = "Interrupt status of WIFI peripheral"]
+pub mod wifi_int_status;
+#[doc = "WIFI_INT_CLEAR (rw) register accessor: Interrupt status clear of WIFI peripheral\n\nYou can [`read`](crate::Reg::read) this register and get [`wifi_int_clear::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wifi_int_clear::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@wifi_int_clear`] module"]
+pub type WIFI_INT_CLEAR = crate::Reg<wifi_int_clear::WIFI_INT_CLEAR_SPEC>;
+#[doc = "Interrupt status clear of WIFI peripheral"]
+pub mod wifi_int_clear;

--- a/esp32c3/src/wifi/mac_interrupt/wifi_int_clear.rs
+++ b/esp32c3/src/wifi/mac_interrupt/wifi_int_clear.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `WIFI_INT_CLEAR` reader"]
+pub type R = crate::R<WIFI_INT_CLEAR_SPEC>;
+#[doc = "Register `WIFI_INT_CLEAR` writer"]
+pub type W = crate::W<WIFI_INT_CLEAR_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Interrupt status clear of WIFI peripheral\n\nYou can [`read`](crate::Reg::read) this register and get [`wifi_int_clear::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wifi_int_clear::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct WIFI_INT_CLEAR_SPEC;
+impl crate::RegisterSpec for WIFI_INT_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`wifi_int_clear::R`](R) reader structure"]
+impl crate::Readable for WIFI_INT_CLEAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`wifi_int_clear::W`](W) writer structure"]
+impl crate::Writable for WIFI_INT_CLEAR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets WIFI_INT_CLEAR to value 0"]
+impl crate::Resettable for WIFI_INT_CLEAR_SPEC {}

--- a/esp32c3/src/wifi/mac_interrupt/wifi_int_status.rs
+++ b/esp32c3/src/wifi/mac_interrupt/wifi_int_status.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `WIFI_INT_STATUS` reader"]
+pub type R = crate::R<WIFI_INT_STATUS_SPEC>;
+#[doc = "Register `WIFI_INT_STATUS` writer"]
+pub type W = crate::W<WIFI_INT_STATUS_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Interrupt status of WIFI peripheral\n\nYou can [`read`](crate::Reg::read) this register and get [`wifi_int_status::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`wifi_int_status::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct WIFI_INT_STATUS_SPEC;
+impl crate::RegisterSpec for WIFI_INT_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`wifi_int_status::R`](R) reader structure"]
+impl crate::Readable for WIFI_INT_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`wifi_int_status::W`](W) writer structure"]
+impl crate::Writable for WIFI_INT_STATUS_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets WIFI_INT_STATUS to value 0"]
+impl crate::Resettable for WIFI_INT_STATUS_SPEC {}

--- a/esp32c3/src/wifi/mac_time.rs
+++ b/esp32c3/src/wifi/mac_time.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `MAC_TIME` reader"]
+pub type R = crate::R<MAC_TIME_SPEC>;
+#[doc = "Register `MAC_TIME` writer"]
+pub type W = crate::W<MAC_TIME_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Current value of the MAC timer\n\nYou can [`read`](crate::Reg::read) this register and get [`mac_time::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`mac_time::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MAC_TIME_SPEC;
+impl crate::RegisterSpec for MAC_TIME_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mac_time::R`](R) reader structure"]
+impl crate::Readable for MAC_TIME_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mac_time::W`](W) writer structure"]
+impl crate::Writable for MAC_TIME_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets MAC_TIME to value 0"]
+impl crate::Resettable for MAC_TIME_SPEC {}

--- a/esp32c3/src/wifi/plcp1.rs
+++ b/esp32c3/src/wifi/plcp1.rs
@@ -1,0 +1,118 @@
+#[doc = "Register `PLCP1%s` reader"]
+pub type R = crate::R<PLCP1_SPEC>;
+#[doc = "Register `PLCP1%s` writer"]
+pub type W = crate::W<PLCP1_SPEC>;
+#[doc = "Field `LEN` reader - Length of packet (in bytes)"]
+pub type LEN_R = crate::FieldReader<u16>;
+#[doc = "Field `LEN` writer - Length of packet (in bytes)"]
+pub type LEN_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
+#[doc = "Field `RATE` reader - Packet rate (see wifi_phy_rate_t)"]
+pub type RATE_R = crate::FieldReader;
+#[doc = "Field `RATE` writer - Packet rate (see wifi_phy_rate_t)"]
+pub type RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `KEY_SLOT_ID` reader - Key slot to use for encryption"]
+pub type KEY_SLOT_ID_R = crate::FieldReader;
+#[doc = "Field `KEY_SLOT_ID` writer - Key slot to use for encryption"]
+pub type KEY_SLOT_ID_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `IS_80211_N` reader - Bit indicating if this is 802.11n"]
+pub type IS_80211_N_R = crate::BitReader;
+#[doc = "Field `IS_80211_N` writer - Bit indicating if this is 802.11n"]
+pub type IS_80211_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `BANDWIDTH` reader - Zero indicates 20MHz and one indicates 40MHz"]
+pub type BANDWIDTH_R = crate::BitReader;
+#[doc = "Field `BANDWIDTH` writer - Zero indicates 20MHz and one indicates 40MHz"]
+pub type BANDWIDTH_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `INTERFACE_ID` reader - ID of the interface this transmission is from"]
+pub type INTERFACE_ID_R = crate::FieldReader;
+#[doc = "Field `INTERFACE_ID` writer - ID of the interface this transmission is from"]
+pub type INTERFACE_ID_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+impl R {
+    #[doc = "Bits 0:11 - Length of packet (in bytes)"]
+    #[inline(always)]
+    pub fn len(&self) -> LEN_R {
+        LEN_R::new((self.bits & 0x0fff) as u16)
+    }
+    #[doc = "Bits 12:16 - Packet rate (see wifi_phy_rate_t)"]
+    #[inline(always)]
+    pub fn rate(&self) -> RATE_R {
+        RATE_R::new(((self.bits >> 12) & 0x1f) as u8)
+    }
+    #[doc = "Bits 17:21 - Key slot to use for encryption"]
+    #[inline(always)]
+    pub fn key_slot_id(&self) -> KEY_SLOT_ID_R {
+        KEY_SLOT_ID_R::new(((self.bits >> 17) & 0x1f) as u8)
+    }
+    #[doc = "Bit 25 - Bit indicating if this is 802.11n"]
+    #[inline(always)]
+    pub fn is_80211_n(&self) -> IS_80211_N_R {
+        IS_80211_N_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 28 - Zero indicates 20MHz and one indicates 40MHz"]
+    #[inline(always)]
+    pub fn bandwidth(&self) -> BANDWIDTH_R {
+        BANDWIDTH_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bits 30:31 - ID of the interface this transmission is from"]
+    #[inline(always)]
+    pub fn interface_id(&self) -> INTERFACE_ID_R {
+        INTERFACE_ID_R::new(((self.bits >> 30) & 3) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLCP1")
+            .field("len", &self.len())
+            .field("rate", &self.rate())
+            .field("key_slot_id", &self.key_slot_id())
+            .field("is_80211_n", &self.is_80211_n())
+            .field("bandwidth", &self.bandwidth())
+            .field("interface_id", &self.interface_id())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:11 - Length of packet (in bytes)"]
+    #[inline(always)]
+    pub fn len(&mut self) -> LEN_W<'_, PLCP1_SPEC> {
+        LEN_W::new(self, 0)
+    }
+    #[doc = "Bits 12:16 - Packet rate (see wifi_phy_rate_t)"]
+    #[inline(always)]
+    pub fn rate(&mut self) -> RATE_W<'_, PLCP1_SPEC> {
+        RATE_W::new(self, 12)
+    }
+    #[doc = "Bits 17:21 - Key slot to use for encryption"]
+    #[inline(always)]
+    pub fn key_slot_id(&mut self) -> KEY_SLOT_ID_W<'_, PLCP1_SPEC> {
+        KEY_SLOT_ID_W::new(self, 17)
+    }
+    #[doc = "Bit 25 - Bit indicating if this is 802.11n"]
+    #[inline(always)]
+    pub fn is_80211_n(&mut self) -> IS_80211_N_W<'_, PLCP1_SPEC> {
+        IS_80211_N_W::new(self, 25)
+    }
+    #[doc = "Bit 28 - Zero indicates 20MHz and one indicates 40MHz"]
+    #[inline(always)]
+    pub fn bandwidth(&mut self) -> BANDWIDTH_W<'_, PLCP1_SPEC> {
+        BANDWIDTH_W::new(self, 28)
+    }
+    #[doc = "Bits 30:31 - ID of the interface this transmission is from"]
+    #[inline(always)]
+    pub fn interface_id(&mut self) -> INTERFACE_ID_W<'_, PLCP1_SPEC> {
+        INTERFACE_ID_W::new(self, 30)
+    }
+}
+#[doc = "PLCP1\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp1::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp1::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PLCP1_SPEC;
+impl crate::RegisterSpec for PLCP1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`plcp1::R`](R) reader structure"]
+impl crate::Readable for PLCP1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`plcp1::W`](W) writer structure"]
+impl crate::Writable for PLCP1_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PLCP1%s to value 0"]
+impl crate::Resettable for PLCP1_SPEC {}

--- a/esp32c3/src/wifi/plcp2.rs
+++ b/esp32c3/src/wifi/plcp2.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `PLCP2%s` reader"]
+pub type R = crate::R<PLCP2_SPEC>;
+#[doc = "Register `PLCP2%s` writer"]
+pub type W = crate::W<PLCP2_SPEC>;
+#[doc = "Field `UNKNOWN` reader - meaning unknown, set to one for TX"]
+pub type UNKNOWN_R = crate::BitReader;
+#[doc = "Field `UNKNOWN` writer - meaning unknown, set to one for TX"]
+pub type UNKNOWN_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 5 - meaning unknown, set to one for TX"]
+    #[inline(always)]
+    pub fn unknown(&self) -> UNKNOWN_R {
+        UNKNOWN_R::new(((self.bits >> 5) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLCP2")
+            .field("unknown", &self.unknown())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 5 - meaning unknown, set to one for TX"]
+    #[inline(always)]
+    pub fn unknown(&mut self) -> UNKNOWN_W<'_, PLCP2_SPEC> {
+        UNKNOWN_W::new(self, 5)
+    }
+}
+#[doc = "PLCP2\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp2::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp2::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PLCP2_SPEC;
+impl crate::RegisterSpec for PLCP2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`plcp2::R`](R) reader structure"]
+impl crate::Readable for PLCP2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`plcp2::W`](W) writer structure"]
+impl crate::Writable for PLCP2_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PLCP2%s to value 0"]
+impl crate::Resettable for PLCP2_SPEC {}

--- a/esp32c3/src/wifi/pmd.rs
+++ b/esp32c3/src/wifi/pmd.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `PMD%s` reader"]
+pub type R = crate::R<PMD_SPEC>;
+#[doc = "Register `PMD%s` writer"]
+pub type W = crate::W<PMD_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "TX result of the slot, read by hal_mac_get_txq_pmd\n\nYou can [`read`](crate::Reg::read) this register and get [`pmd::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pmd::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PMD_SPEC;
+impl crate::RegisterSpec for PMD_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pmd::R`](R) reader structure"]
+impl crate::Readable for PMD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pmd::W`](W) writer structure"]
+impl crate::Writable for PMD_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PMD%s to value 0"]
+impl crate::Resettable for PMD_SPEC {}

--- a/esp32c3/src/wifi/pwr_int_enable.rs
+++ b/esp32c3/src/wifi/pwr_int_enable.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `PWR_INT_ENABLE` reader"]
+pub type R = crate::R<PWR_INT_ENABLE_SPEC>;
+#[doc = "Register `PWR_INT_ENABLE` writer"]
+pub type W = crate::W<PWR_INT_ENABLE_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Interrupt enable for the WIFI_PWR interrupt. TBTT of interface n is bit (4 - n), TSF timer n is bit (8 - n).\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_enable::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_enable::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PWR_INT_ENABLE_SPEC;
+impl crate::RegisterSpec for PWR_INT_ENABLE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pwr_int_enable::R`](R) reader structure"]
+impl crate::Readable for PWR_INT_ENABLE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pwr_int_enable::W`](W) writer structure"]
+impl crate::Writable for PWR_INT_ENABLE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PWR_INT_ENABLE to value 0"]
+impl crate::Resettable for PWR_INT_ENABLE_SPEC {}

--- a/esp32c3/src/wifi/pwr_interrupt.rs
+++ b/esp32c3/src/wifi/pwr_interrupt.rs
@@ -1,0 +1,27 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Status and clear for the WIFI_PWR interrupt"]
+pub struct PWR_INTERRUPT {
+    pwr_int_status: PWR_INT_STATUS,
+    pwr_int_clear: PWR_INT_CLEAR,
+}
+impl PWR_INTERRUPT {
+    #[doc = "0x00 - Interrupt status for the WIFI_PWR interrupt"]
+    #[inline(always)]
+    pub const fn pwr_int_status(&self) -> &PWR_INT_STATUS {
+        &self.pwr_int_status
+    }
+    #[doc = "0x04 - Interrupt status clear for the WIFI_PWR interrupt"]
+    #[inline(always)]
+    pub const fn pwr_int_clear(&self) -> &PWR_INT_CLEAR {
+        &self.pwr_int_clear
+    }
+}
+#[doc = "PWR_INT_STATUS (rw) register accessor: Interrupt status for the WIFI_PWR interrupt\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_status::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_status::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pwr_int_status`] module"]
+pub type PWR_INT_STATUS = crate::Reg<pwr_int_status::PWR_INT_STATUS_SPEC>;
+#[doc = "Interrupt status for the WIFI_PWR interrupt"]
+pub mod pwr_int_status;
+#[doc = "PWR_INT_CLEAR (rw) register accessor: Interrupt status clear for the WIFI_PWR interrupt\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_clear::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_clear::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pwr_int_clear`] module"]
+pub type PWR_INT_CLEAR = crate::Reg<pwr_int_clear::PWR_INT_CLEAR_SPEC>;
+#[doc = "Interrupt status clear for the WIFI_PWR interrupt"]
+pub mod pwr_int_clear;

--- a/esp32c3/src/wifi/pwr_interrupt/pwr_int_clear.rs
+++ b/esp32c3/src/wifi/pwr_interrupt/pwr_int_clear.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `PWR_INT_CLEAR` reader"]
+pub type R = crate::R<PWR_INT_CLEAR_SPEC>;
+#[doc = "Register `PWR_INT_CLEAR` writer"]
+pub type W = crate::W<PWR_INT_CLEAR_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Interrupt status clear for the WIFI_PWR interrupt\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_clear::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_clear::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PWR_INT_CLEAR_SPEC;
+impl crate::RegisterSpec for PWR_INT_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pwr_int_clear::R`](R) reader structure"]
+impl crate::Readable for PWR_INT_CLEAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pwr_int_clear::W`](W) writer structure"]
+impl crate::Writable for PWR_INT_CLEAR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PWR_INT_CLEAR to value 0"]
+impl crate::Resettable for PWR_INT_CLEAR_SPEC {}

--- a/esp32c3/src/wifi/pwr_interrupt/pwr_int_status.rs
+++ b/esp32c3/src/wifi/pwr_interrupt/pwr_int_status.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `PWR_INT_STATUS` reader"]
+pub type R = crate::R<PWR_INT_STATUS_SPEC>;
+#[doc = "Register `PWR_INT_STATUS` writer"]
+pub type W = crate::W<PWR_INT_STATUS_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Interrupt status for the WIFI_PWR interrupt\n\nYou can [`read`](crate::Reg::read) this register and get [`pwr_int_status::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`pwr_int_status::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PWR_INT_STATUS_SPEC;
+impl crate::RegisterSpec for PWR_INT_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pwr_int_status::R`](R) reader structure"]
+impl crate::Readable for PWR_INT_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pwr_int_status::W`](W) writer structure"]
+impl crate::Writable for PWR_INT_STATUS_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PWR_INT_STATUS to value 0"]
+impl crate::Resettable for PWR_INT_STATUS_SPEC {}

--- a/esp32c3/src/wifi/rx_ctrl.rs
+++ b/esp32c3/src/wifi/rx_ctrl.rs
@@ -1,0 +1,58 @@
+#[doc = "Register `RX_CTRL` reader"]
+pub type R = crate::R<RX_CTRL_SPEC>;
+#[doc = "Register `RX_CTRL` writer"]
+pub type W = crate::W<RX_CTRL_SPEC>;
+#[doc = "Field `RX_DESCR_RELOAD` reader - Instruct the hardware to reload the RX descriptors"]
+pub type RX_DESCR_RELOAD_R = crate::BitReader;
+#[doc = "Field `RX_DESCR_RELOAD` writer - Instruct the hardware to reload the RX descriptors"]
+pub type RX_DESCR_RELOAD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `RX_ENABLE` reader - Enable frame reception"]
+pub type RX_ENABLE_R = crate::BitReader;
+#[doc = "Field `RX_ENABLE` writer - Enable frame reception"]
+pub type RX_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Instruct the hardware to reload the RX descriptors"]
+    #[inline(always)]
+    pub fn rx_descr_reload(&self) -> RX_DESCR_RELOAD_R {
+        RX_DESCR_RELOAD_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 31 - Enable frame reception"]
+    #[inline(always)]
+    pub fn rx_enable(&self) -> RX_ENABLE_R {
+        RX_ENABLE_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX_CTRL")
+            .field("rx_descr_reload", &self.rx_descr_reload())
+            .field("rx_enable", &self.rx_enable())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Instruct the hardware to reload the RX descriptors"]
+    #[inline(always)]
+    pub fn rx_descr_reload(&mut self) -> RX_DESCR_RELOAD_W<'_, RX_CTRL_SPEC> {
+        RX_DESCR_RELOAD_W::new(self, 0)
+    }
+    #[doc = "Bit 31 - Enable frame reception"]
+    #[inline(always)]
+    pub fn rx_enable(&mut self) -> RX_ENABLE_W<'_, RX_CTRL_SPEC> {
+        RX_ENABLE_W::new(self, 31)
+    }
+}
+#[doc = "Controls the reception of frames\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_CTRL_SPEC;
+impl crate::RegisterSpec for RX_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_ctrl::R`](R) reader structure"]
+impl crate::Readable for RX_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rx_ctrl::W`](W) writer structure"]
+impl crate::Writable for RX_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets RX_CTRL to value 0"]
+impl crate::Resettable for RX_CTRL_SPEC {}

--- a/esp32c3/src/wifi/rx_ctrl_filter.rs
+++ b/esp32c3/src/wifi/rx_ctrl_filter.rs
@@ -1,0 +1,163 @@
+#[doc = "Register `RX_CTRL_FILTER%s` reader"]
+pub type R = crate::R<RX_CTRL_FILTER_SPEC>;
+#[doc = "Register `RX_CTRL_FILTER%s` writer"]
+pub type W = crate::W<RX_CTRL_FILTER_SPEC>;
+#[doc = "Field `CONTROL_WRAPPER` reader - Filter Control Wrapper frames"]
+pub type CONTROL_WRAPPER_R = crate::BitReader;
+#[doc = "Field `CONTROL_WRAPPER` writer - Filter Control Wrapper frames"]
+pub type CONTROL_WRAPPER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `BLOCK_ACK_REQUEST` reader - Filter Block ACK Request frames"]
+pub type BLOCK_ACK_REQUEST_R = crate::BitReader;
+#[doc = "Field `BLOCK_ACK_REQUEST` writer - Filter Block ACK Request frames"]
+pub type BLOCK_ACK_REQUEST_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `BLOCK_ACK` reader - Filter Block ACK frames"]
+pub type BLOCK_ACK_R = crate::BitReader;
+#[doc = "Field `BLOCK_ACK` writer - Filter Block ACK frames"]
+pub type BLOCK_ACK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `PS_POLL` reader - Filter PS-Poll frames"]
+pub type PS_POLL_R = crate::BitReader;
+#[doc = "Field `PS_POLL` writer - Filter PS-Poll frames"]
+pub type PS_POLL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `RTS` reader - Filter RTS frames"]
+pub type RTS_R = crate::BitReader;
+#[doc = "Field `RTS` writer - Filter RTS frames"]
+pub type RTS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CTS` reader - Filter CTS frames"]
+pub type CTS_R = crate::BitReader;
+#[doc = "Field `CTS` writer - Filter CTS frames"]
+pub type CTS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ACK` reader - Filter ACK frames"]
+pub type ACK_R = crate::BitReader;
+#[doc = "Field `ACK` writer - Filter ACK frames"]
+pub type ACK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CF_END` reader - Filter CF-End frames"]
+pub type CF_END_R = crate::BitReader;
+#[doc = "Field `CF_END` writer - Filter CF-End frames"]
+pub type CF_END_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `CF_END_CF_ACK` reader - Filter CF-End+CF-Ack frames"]
+pub type CF_END_CF_ACK_R = crate::BitReader;
+#[doc = "Field `CF_END_CF_ACK` writer - Filter CF-End+CF-Ack frames"]
+pub type CF_END_CF_ACK_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 23 - Filter Control Wrapper frames"]
+    #[inline(always)]
+    pub fn control_wrapper(&self) -> CONTROL_WRAPPER_R {
+        CONTROL_WRAPPER_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 24 - Filter Block ACK Request frames"]
+    #[inline(always)]
+    pub fn block_ack_request(&self) -> BLOCK_ACK_REQUEST_R {
+        BLOCK_ACK_REQUEST_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 25 - Filter Block ACK frames"]
+    #[inline(always)]
+    pub fn block_ack(&self) -> BLOCK_ACK_R {
+        BLOCK_ACK_R::new(((self.bits >> 25) & 1) != 0)
+    }
+    #[doc = "Bit 26 - Filter PS-Poll frames"]
+    #[inline(always)]
+    pub fn ps_poll(&self) -> PS_POLL_R {
+        PS_POLL_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bit 27 - Filter RTS frames"]
+    #[inline(always)]
+    pub fn rts(&self) -> RTS_R {
+        RTS_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 28 - Filter CTS frames"]
+    #[inline(always)]
+    pub fn cts(&self) -> CTS_R {
+        CTS_R::new(((self.bits >> 28) & 1) != 0)
+    }
+    #[doc = "Bit 29 - Filter ACK frames"]
+    #[inline(always)]
+    pub fn ack(&self) -> ACK_R {
+        ACK_R::new(((self.bits >> 29) & 1) != 0)
+    }
+    #[doc = "Bit 30 - Filter CF-End frames"]
+    #[inline(always)]
+    pub fn cf_end(&self) -> CF_END_R {
+        CF_END_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Filter CF-End+CF-Ack frames"]
+    #[inline(always)]
+    pub fn cf_end_cf_ack(&self) -> CF_END_CF_ACK_R {
+        CF_END_CF_ACK_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX_CTRL_FILTER")
+            .field("control_wrapper", &self.control_wrapper())
+            .field("block_ack_request", &self.block_ack_request())
+            .field("block_ack", &self.block_ack())
+            .field("ps_poll", &self.ps_poll())
+            .field("rts", &self.rts())
+            .field("cts", &self.cts())
+            .field("ack", &self.ack())
+            .field("cf_end", &self.cf_end())
+            .field("cf_end_cf_ack", &self.cf_end_cf_ack())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 23 - Filter Control Wrapper frames"]
+    #[inline(always)]
+    pub fn control_wrapper(&mut self) -> CONTROL_WRAPPER_W<'_, RX_CTRL_FILTER_SPEC> {
+        CONTROL_WRAPPER_W::new(self, 23)
+    }
+    #[doc = "Bit 24 - Filter Block ACK Request frames"]
+    #[inline(always)]
+    pub fn block_ack_request(&mut self) -> BLOCK_ACK_REQUEST_W<'_, RX_CTRL_FILTER_SPEC> {
+        BLOCK_ACK_REQUEST_W::new(self, 24)
+    }
+    #[doc = "Bit 25 - Filter Block ACK frames"]
+    #[inline(always)]
+    pub fn block_ack(&mut self) -> BLOCK_ACK_W<'_, RX_CTRL_FILTER_SPEC> {
+        BLOCK_ACK_W::new(self, 25)
+    }
+    #[doc = "Bit 26 - Filter PS-Poll frames"]
+    #[inline(always)]
+    pub fn ps_poll(&mut self) -> PS_POLL_W<'_, RX_CTRL_FILTER_SPEC> {
+        PS_POLL_W::new(self, 26)
+    }
+    #[doc = "Bit 27 - Filter RTS frames"]
+    #[inline(always)]
+    pub fn rts(&mut self) -> RTS_W<'_, RX_CTRL_FILTER_SPEC> {
+        RTS_W::new(self, 27)
+    }
+    #[doc = "Bit 28 - Filter CTS frames"]
+    #[inline(always)]
+    pub fn cts(&mut self) -> CTS_W<'_, RX_CTRL_FILTER_SPEC> {
+        CTS_W::new(self, 28)
+    }
+    #[doc = "Bit 29 - Filter ACK frames"]
+    #[inline(always)]
+    pub fn ack(&mut self) -> ACK_W<'_, RX_CTRL_FILTER_SPEC> {
+        ACK_W::new(self, 29)
+    }
+    #[doc = "Bit 30 - Filter CF-End frames"]
+    #[inline(always)]
+    pub fn cf_end(&mut self) -> CF_END_W<'_, RX_CTRL_FILTER_SPEC> {
+        CF_END_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - Filter CF-End+CF-Ack frames"]
+    #[inline(always)]
+    pub fn cf_end_cf_ack(&mut self) -> CF_END_CF_ACK_W<'_, RX_CTRL_FILTER_SPEC> {
+        CF_END_CF_ACK_W::new(self, 31)
+    }
+}
+#[doc = "Configures which control frames pass the RX filter. Setting a bit lets that frame type pass the filter.\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_ctrl_filter::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_ctrl_filter::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_CTRL_FILTER_SPEC;
+impl crate::RegisterSpec for RX_CTRL_FILTER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_ctrl_filter::R`](R) reader structure"]
+impl crate::Readable for RX_CTRL_FILTER_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rx_ctrl_filter::W`](W) writer structure"]
+impl crate::Writable for RX_CTRL_FILTER_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets RX_CTRL_FILTER%s to value 0"]
+impl crate::Resettable for RX_CTRL_FILTER_SPEC {}

--- a/esp32c3/src/wifi/rx_dma_list.rs
+++ b/esp32c3/src/wifi/rx_dma_list.rs
@@ -1,0 +1,37 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "RX_DMA_LIST"]
+pub struct RX_DMA_LIST {
+    rx_descr_base: RX_DESCR_BASE,
+    rx_descr_next: RX_DESCR_NEXT,
+    rx_descr_last: RX_DESCR_LAST,
+}
+impl RX_DMA_LIST {
+    #[doc = "0x00 - base address of the RX DMA list"]
+    #[inline(always)]
+    pub const fn rx_descr_base(&self) -> &RX_DESCR_BASE {
+        &self.rx_descr_base
+    }
+    #[doc = "0x04 - next item in the RX DMA list"]
+    #[inline(always)]
+    pub const fn rx_descr_next(&self) -> &RX_DESCR_NEXT {
+        &self.rx_descr_next
+    }
+    #[doc = "0x08 - last item in RX DMA list"]
+    #[inline(always)]
+    pub const fn rx_descr_last(&self) -> &RX_DESCR_LAST {
+        &self.rx_descr_last
+    }
+}
+#[doc = "RX_DESCR_BASE (rw) register accessor: base address of the RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_base::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_base::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_descr_base`] module"]
+pub type RX_DESCR_BASE = crate::Reg<rx_descr_base::RX_DESCR_BASE_SPEC>;
+#[doc = "base address of the RX DMA list"]
+pub mod rx_descr_base;
+#[doc = "RX_DESCR_NEXT (rw) register accessor: next item in the RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_next::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_next::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_descr_next`] module"]
+pub type RX_DESCR_NEXT = crate::Reg<rx_descr_next::RX_DESCR_NEXT_SPEC>;
+#[doc = "next item in the RX DMA list"]
+pub mod rx_descr_next;
+#[doc = "RX_DESCR_LAST (rw) register accessor: last item in RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_last::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_last::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_descr_last`] module"]
+pub type RX_DESCR_LAST = crate::Reg<rx_descr_last::RX_DESCR_LAST_SPEC>;
+#[doc = "last item in RX DMA list"]
+pub mod rx_descr_last;

--- a/esp32c3/src/wifi/rx_dma_list/rx_descr_base.rs
+++ b/esp32c3/src/wifi/rx_dma_list/rx_descr_base.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `RX_DESCR_BASE` reader"]
+pub type R = crate::R<RX_DESCR_BASE_SPEC>;
+#[doc = "Register `RX_DESCR_BASE` writer"]
+pub type W = crate::W<RX_DESCR_BASE_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "base address of the RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_base::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_base::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_DESCR_BASE_SPEC;
+impl crate::RegisterSpec for RX_DESCR_BASE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_descr_base::R`](R) reader structure"]
+impl crate::Readable for RX_DESCR_BASE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rx_descr_base::W`](W) writer structure"]
+impl crate::Writable for RX_DESCR_BASE_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets RX_DESCR_BASE to value 0"]
+impl crate::Resettable for RX_DESCR_BASE_SPEC {}

--- a/esp32c3/src/wifi/rx_dma_list/rx_descr_last.rs
+++ b/esp32c3/src/wifi/rx_dma_list/rx_descr_last.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `RX_DESCR_LAST` reader"]
+pub type R = crate::R<RX_DESCR_LAST_SPEC>;
+#[doc = "Register `RX_DESCR_LAST` writer"]
+pub type W = crate::W<RX_DESCR_LAST_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "last item in RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_last::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_last::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_DESCR_LAST_SPEC;
+impl crate::RegisterSpec for RX_DESCR_LAST_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_descr_last::R`](R) reader structure"]
+impl crate::Readable for RX_DESCR_LAST_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rx_descr_last::W`](W) writer structure"]
+impl crate::Writable for RX_DESCR_LAST_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets RX_DESCR_LAST to value 0"]
+impl crate::Resettable for RX_DESCR_LAST_SPEC {}

--- a/esp32c3/src/wifi/rx_dma_list/rx_descr_next.rs
+++ b/esp32c3/src/wifi/rx_dma_list/rx_descr_next.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `RX_DESCR_NEXT` reader"]
+pub type R = crate::R<RX_DESCR_NEXT_SPEC>;
+#[doc = "Register `RX_DESCR_NEXT` writer"]
+pub type W = crate::W<RX_DESCR_NEXT_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "next item in the RX DMA list\n\nYou can [`read`](crate::Reg::read) this register and get [`rx_descr_next::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`rx_descr_next::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_DESCR_NEXT_SPEC;
+impl crate::RegisterSpec for RX_DESCR_NEXT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_descr_next::R`](R) reader structure"]
+impl crate::Readable for RX_DESCR_NEXT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rx_descr_next::W`](W) writer structure"]
+impl crate::Writable for RX_DESCR_NEXT_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets RX_DESCR_NEXT to value 0"]
+impl crate::Resettable for RX_DESCR_NEXT_SPEC {}

--- a/esp32c3/src/wifi/tbtt_cfg.rs
+++ b/esp32c3/src/wifi/tbtt_cfg.rs
@@ -1,0 +1,58 @@
+#[doc = "Register `TBTT_CFG%s` reader"]
+pub type R = crate::R<TBTT_CFG_SPEC>;
+#[doc = "Register `TBTT_CFG%s` writer"]
+pub type W = crate::W<TBTT_CFG_SPEC>;
+#[doc = "Field `INTERVAL` reader - Beacon interval in TUs (the blob shifts microseconds right by 10)"]
+pub type INTERVAL_R = crate::FieldReader<u16>;
+#[doc = "Field `INTERVAL` writer - Beacon interval in TUs (the blob shifts microseconds right by 10)"]
+pub type INTERVAL_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `EARLY_TIME` reader - How much earlier than the TBTT the interrupt fires, set by tsf_hal_set_tbtt_early_time"]
+pub type EARLY_TIME_R = crate::FieldReader<u16>;
+#[doc = "Field `EARLY_TIME` writer - How much earlier than the TBTT the interrupt fires, set by tsf_hal_set_tbtt_early_time"]
+pub type EARLY_TIME_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Beacon interval in TUs (the blob shifts microseconds right by 10)"]
+    #[inline(always)]
+    pub fn interval(&self) -> INTERVAL_R {
+        INTERVAL_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:31 - How much earlier than the TBTT the interrupt fires, set by tsf_hal_set_tbtt_early_time"]
+    #[inline(always)]
+    pub fn early_time(&self) -> EARLY_TIME_R {
+        EARLY_TIME_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TBTT_CFG")
+            .field("interval", &self.interval())
+            .field("early_time", &self.early_time())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Beacon interval in TUs (the blob shifts microseconds right by 10)"]
+    #[inline(always)]
+    pub fn interval(&mut self) -> INTERVAL_W<'_, TBTT_CFG_SPEC> {
+        INTERVAL_W::new(self, 0)
+    }
+    #[doc = "Bits 16:31 - How much earlier than the TBTT the interrupt fires, set by tsf_hal_set_tbtt_early_time"]
+    #[inline(always)]
+    pub fn early_time(&mut self) -> EARLY_TIME_W<'_, TBTT_CFG_SPEC> {
+        EARLY_TIME_W::new(self, 16)
+    }
+}
+#[doc = "TBTT interval and early time of an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`tbtt_cfg::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tbtt_cfg::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TBTT_CFG_SPEC;
+impl crate::RegisterSpec for TBTT_CFG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tbtt_cfg::R`](R) reader structure"]
+impl crate::Readable for TBTT_CFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tbtt_cfg::W`](W) writer structure"]
+impl crate::Writable for TBTT_CFG_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TBTT_CFG%s to value 0"]
+impl crate::Resettable for TBTT_CFG_SPEC {}

--- a/esp32c3/src/wifi/tbtt_start.rs
+++ b/esp32c3/src/wifi/tbtt_start.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `TBTT_START` reader"]
+pub type R = crate::R<TBTT_START_SPEC>;
+#[doc = "Register `TBTT_START` writer"]
+pub type W = crate::W<TBTT_START_SPEC>;
+#[doc = "Field `START_TIME` reader - "]
+pub type START_TIME_R = crate::FieldReader<u32>;
+#[doc = "Field `START_TIME` writer - "]
+pub type START_TIME_W<'a, REG> = crate::FieldWriter<'a, REG, 26, u32>;
+impl R {
+    #[doc = "Bits 0:25"]
+    #[inline(always)]
+    pub fn start_time(&self) -> START_TIME_R {
+        START_TIME_R::new(self.bits & 0x03ff_ffff)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TBTT_START")
+            .field("start_time", &self.start_time())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:25"]
+    #[inline(always)]
+    pub fn start_time(&mut self) -> START_TIME_W<'_, TBTT_START_SPEC> {
+        START_TIME_W::new(self, 0)
+    }
+}
+#[doc = "TBTT start time, loaded into an interface with TSF_CTRL.LOAD_TBTT_START\n\nYou can [`read`](crate::Reg::read) this register and get [`tbtt_start::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tbtt_start::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TBTT_START_SPEC;
+impl crate::RegisterSpec for TBTT_START_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tbtt_start::R`](R) reader structure"]
+impl crate::Readable for TBTT_START_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tbtt_start::W`](W) writer structure"]
+impl crate::Writable for TBTT_START_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TBTT_START to value 0"]
+impl crate::Resettable for TBTT_START_SPEC {}

--- a/esp32c3/src/wifi/tsf_cfg.rs
+++ b/esp32c3/src/wifi/tsf_cfg.rs
@@ -1,0 +1,73 @@
+#[doc = "Register `TSF_CFG%s` reader"]
+pub type R = crate::R<TSF_CFG_SPEC>;
+#[doc = "Register `TSF_CFG%s` writer"]
+pub type W = crate::W<TSF_CFG_SPEC>;
+#[doc = "Field `TBTT_ENABLE` reader - Set by tsf_hal_set_tbtt_enable"]
+pub type TBTT_ENABLE_R = crate::BitReader;
+#[doc = "Field `TBTT_ENABLE` writer - Set by tsf_hal_set_tbtt_enable"]
+pub type TBTT_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `TSF_ENABLE_AUX` reader - Bits 27 and 28 are set together with TSF_ENABLE by tsf_hal_set_tsf_enable, meaning unknown"]
+pub type TSF_ENABLE_AUX_R = crate::FieldReader;
+#[doc = "Field `TSF_ENABLE_AUX` writer - Bits 27 and 28 are set together with TSF_ENABLE by tsf_hal_set_tsf_enable, meaning unknown"]
+pub type TSF_ENABLE_AUX_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `TSF_ENABLE` reader - Enables the TSF counter, checked by tsf_hal_is_tsf_enabled"]
+pub type TSF_ENABLE_R = crate::BitReader;
+#[doc = "Field `TSF_ENABLE` writer - Enables the TSF counter, checked by tsf_hal_is_tsf_enabled"]
+pub type TSF_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 26 - Set by tsf_hal_set_tbtt_enable"]
+    #[inline(always)]
+    pub fn tbtt_enable(&self) -> TBTT_ENABLE_R {
+        TBTT_ENABLE_R::new(((self.bits >> 26) & 1) != 0)
+    }
+    #[doc = "Bits 27:28 - Bits 27 and 28 are set together with TSF_ENABLE by tsf_hal_set_tsf_enable, meaning unknown"]
+    #[inline(always)]
+    pub fn tsf_enable_aux(&self) -> TSF_ENABLE_AUX_R {
+        TSF_ENABLE_AUX_R::new(((self.bits >> 27) & 3) as u8)
+    }
+    #[doc = "Bit 31 - Enables the TSF counter, checked by tsf_hal_is_tsf_enabled"]
+    #[inline(always)]
+    pub fn tsf_enable(&self) -> TSF_ENABLE_R {
+        TSF_ENABLE_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TSF_CFG")
+            .field("tbtt_enable", &self.tbtt_enable())
+            .field("tsf_enable_aux", &self.tsf_enable_aux())
+            .field("tsf_enable", &self.tsf_enable())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 26 - Set by tsf_hal_set_tbtt_enable"]
+    #[inline(always)]
+    pub fn tbtt_enable(&mut self) -> TBTT_ENABLE_W<'_, TSF_CFG_SPEC> {
+        TBTT_ENABLE_W::new(self, 26)
+    }
+    #[doc = "Bits 27:28 - Bits 27 and 28 are set together with TSF_ENABLE by tsf_hal_set_tsf_enable, meaning unknown"]
+    #[inline(always)]
+    pub fn tsf_enable_aux(&mut self) -> TSF_ENABLE_AUX_W<'_, TSF_CFG_SPEC> {
+        TSF_ENABLE_AUX_W::new(self, 27)
+    }
+    #[doc = "Bit 31 - Enables the TSF counter, checked by tsf_hal_is_tsf_enabled"]
+    #[inline(always)]
+    pub fn tsf_enable(&mut self) -> TSF_ENABLE_W<'_, TSF_CFG_SPEC> {
+        TSF_ENABLE_W::new(self, 31)
+    }
+}
+#[doc = "TSF and TBTT configuration of an interface\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_cfg::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_cfg::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_CFG_SPEC;
+impl crate::RegisterSpec for TSF_CFG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_cfg::R`](R) reader structure"]
+impl crate::Readable for TSF_CFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_cfg::W`](W) writer structure"]
+impl crate::Writable for TSF_CFG_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_CFG%s to value 0"]
+impl crate::Resettable for TSF_CFG_SPEC {}

--- a/esp32c3/src/wifi/tsf_ctrl.rs
+++ b/esp32c3/src/wifi/tsf_ctrl.rs
@@ -1,0 +1,73 @@
+#[doc = "Register `TSF_CTRL` reader"]
+pub type R = crate::R<TSF_CTRL_SPEC>;
+#[doc = "Register `TSF_CTRL` writer"]
+pub type W = crate::W<TSF_CTRL_SPEC>;
+#[doc = "Field `LATCH` reader - Bit n latches the TSF counter of interface n into TSF_TIME for reading. Cleared again after the read."]
+pub type LATCH_R = crate::FieldReader;
+#[doc = "Field `LATCH` writer - Bit n latches the TSF counter of interface n into TSF_TIME for reading. Cleared again after the read."]
+pub type LATCH_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `LOAD` reader - Bit n loads the TSF counter of interface n from TSF_LOAD."]
+pub type LOAD_R = crate::FieldReader;
+#[doc = "Field `LOAD` writer - Bit n loads the TSF counter of interface n from TSF_LOAD."]
+pub type LOAD_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `LOAD_TBTT_START` reader - Bit n loads the TBTT start time of interface n from TBTT_START."]
+pub type LOAD_TBTT_START_R = crate::FieldReader;
+#[doc = "Field `LOAD_TBTT_START` writer - Bit n loads the TBTT start time of interface n from TBTT_START."]
+pub type LOAD_TBTT_START_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 0:3 - Bit n latches the TSF counter of interface n into TSF_TIME for reading. Cleared again after the read."]
+    #[inline(always)]
+    pub fn latch(&self) -> LATCH_R {
+        LATCH_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Bit n loads the TSF counter of interface n from TSF_LOAD."]
+    #[inline(always)]
+    pub fn load(&self) -> LOAD_R {
+        LOAD_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+    #[doc = "Bits 8:11 - Bit n loads the TBTT start time of interface n from TBTT_START."]
+    #[inline(always)]
+    pub fn load_tbtt_start(&self) -> LOAD_TBTT_START_R {
+        LOAD_TBTT_START_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TSF_CTRL")
+            .field("latch", &self.latch())
+            .field("load", &self.load())
+            .field("load_tbtt_start", &self.load_tbtt_start())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Bit n latches the TSF counter of interface n into TSF_TIME for reading. Cleared again after the read."]
+    #[inline(always)]
+    pub fn latch(&mut self) -> LATCH_W<'_, TSF_CTRL_SPEC> {
+        LATCH_W::new(self, 0)
+    }
+    #[doc = "Bits 4:7 - Bit n loads the TSF counter of interface n from TSF_LOAD."]
+    #[inline(always)]
+    pub fn load(&mut self) -> LOAD_W<'_, TSF_CTRL_SPEC> {
+        LOAD_W::new(self, 4)
+    }
+    #[doc = "Bits 8:11 - Bit n loads the TBTT start time of interface n from TBTT_START."]
+    #[inline(always)]
+    pub fn load_tbtt_start(&mut self) -> LOAD_TBTT_START_W<'_, TSF_CTRL_SPEC> {
+        LOAD_TBTT_START_W::new(self, 8)
+    }
+}
+#[doc = "Control for the per-interface TSF counters. Written by tsf_hal_get_counter_value, tsf_hal_set_counter_value and tsf_hal_set_tbtt_start_time.\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_ctrl::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_ctrl::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_CTRL_SPEC;
+impl crate::RegisterSpec for TSF_CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_ctrl::R`](R) reader structure"]
+impl crate::Readable for TSF_CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_ctrl::W`](W) writer structure"]
+impl crate::Writable for TSF_CTRL_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_CTRL to value 0"]
+impl crate::Resettable for TSF_CTRL_SPEC {}

--- a/esp32c3/src/wifi/tsf_load_high.rs
+++ b/esp32c3/src/wifi/tsf_load_high.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TSF_LOAD_HIGH` reader"]
+pub type R = crate::R<TSF_LOAD_HIGH_SPEC>;
+#[doc = "Register `TSF_LOAD_HIGH` writer"]
+pub type W = crate::W<TSF_LOAD_HIGH_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "High word of the value loaded into a TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_load_high::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_load_high::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_LOAD_HIGH_SPEC;
+impl crate::RegisterSpec for TSF_LOAD_HIGH_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_load_high::R`](R) reader structure"]
+impl crate::Readable for TSF_LOAD_HIGH_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_load_high::W`](W) writer structure"]
+impl crate::Writable for TSF_LOAD_HIGH_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_LOAD_HIGH to value 0"]
+impl crate::Resettable for TSF_LOAD_HIGH_SPEC {}

--- a/esp32c3/src/wifi/tsf_load_low.rs
+++ b/esp32c3/src/wifi/tsf_load_low.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TSF_LOAD_LOW` reader"]
+pub type R = crate::R<TSF_LOAD_LOW_SPEC>;
+#[doc = "Register `TSF_LOAD_LOW` writer"]
+pub type W = crate::W<TSF_LOAD_LOW_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Low word of the value loaded into a TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_load_low::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_load_low::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_LOAD_LOW_SPEC;
+impl crate::RegisterSpec for TSF_LOAD_LOW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_load_low::R`](R) reader structure"]
+impl crate::Readable for TSF_LOAD_LOW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_load_low::W`](W) writer structure"]
+impl crate::Writable for TSF_LOAD_LOW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_LOAD_LOW to value 0"]
+impl crate::Resettable for TSF_LOAD_LOW_SPEC {}

--- a/esp32c3/src/wifi/tsf_time_high.rs
+++ b/esp32c3/src/wifi/tsf_time_high.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TSF_TIME_HIGH` reader"]
+pub type R = crate::R<TSF_TIME_HIGH_SPEC>;
+#[doc = "Register `TSF_TIME_HIGH` writer"]
+pub type W = crate::W<TSF_TIME_HIGH_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "High word of the latched TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_time_high::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_time_high::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_TIME_HIGH_SPEC;
+impl crate::RegisterSpec for TSF_TIME_HIGH_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_time_high::R`](R) reader structure"]
+impl crate::Readable for TSF_TIME_HIGH_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_time_high::W`](W) writer structure"]
+impl crate::Writable for TSF_TIME_HIGH_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_TIME_HIGH to value 0"]
+impl crate::Resettable for TSF_TIME_HIGH_SPEC {}

--- a/esp32c3/src/wifi/tsf_time_low.rs
+++ b/esp32c3/src/wifi/tsf_time_low.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TSF_TIME_LOW` reader"]
+pub type R = crate::R<TSF_TIME_LOW_SPEC>;
+#[doc = "Register `TSF_TIME_LOW` writer"]
+pub type W = crate::W<TSF_TIME_LOW_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Low word of the latched TSF counter\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_time_low::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_time_low::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_TIME_LOW_SPEC;
+impl crate::RegisterSpec for TSF_TIME_LOW_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_time_low::R`](R) reader structure"]
+impl crate::Readable for TSF_TIME_LOW_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_time_low::W`](W) writer structure"]
+impl crate::Writable for TSF_TIME_LOW_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_TIME_LOW to value 0"]
+impl crate::Resettable for TSF_TIME_LOW_SPEC {}

--- a/esp32c3/src/wifi/tsf_timer_cfg.rs
+++ b/esp32c3/src/wifi/tsf_timer_cfg.rs
@@ -1,0 +1,58 @@
+#[doc = "Register `TSF_TIMER_CFG%s` reader"]
+pub type R = crate::R<TSF_TIMER_CFG_SPEC>;
+#[doc = "Register `TSF_TIMER_CFG%s` writer"]
+pub type W = crate::W<TSF_TIMER_CFG_SPEC>;
+#[doc = "Field `SOC_WAKEUP` reader - Wake the SoC when the timer fires, set by tsf_hal_set_timer_soc_wakeup_enable"]
+pub type SOC_WAKEUP_R = crate::BitReader;
+#[doc = "Field `SOC_WAKEUP` writer - Wake the SoC when the timer fires, set by tsf_hal_set_timer_soc_wakeup_enable"]
+pub type SOC_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `ENABLE` reader - Set by tsf_hal_set_timer_enable"]
+pub type ENABLE_R = crate::BitReader;
+#[doc = "Field `ENABLE` writer - Set by tsf_hal_set_timer_enable"]
+pub type ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 30 - Wake the SoC when the timer fires, set by tsf_hal_set_timer_soc_wakeup_enable"]
+    #[inline(always)]
+    pub fn soc_wakeup(&self) -> SOC_WAKEUP_R {
+        SOC_WAKEUP_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Set by tsf_hal_set_timer_enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TSF_TIMER_CFG")
+            .field("soc_wakeup", &self.soc_wakeup())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bit 30 - Wake the SoC when the timer fires, set by tsf_hal_set_timer_soc_wakeup_enable"]
+    #[inline(always)]
+    pub fn soc_wakeup(&mut self) -> SOC_WAKEUP_W<'_, TSF_TIMER_CFG_SPEC> {
+        SOC_WAKEUP_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - Set by tsf_hal_set_timer_enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W<'_, TSF_TIMER_CFG_SPEC> {
+        ENABLE_W::new(self, 31)
+    }
+}
+#[doc = "Configuration of a TSF timer\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_timer_cfg::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_timer_cfg::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_TIMER_CFG_SPEC;
+impl crate::RegisterSpec for TSF_TIMER_CFG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_timer_cfg::R`](R) reader structure"]
+impl crate::Readable for TSF_TIMER_CFG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_timer_cfg::W`](W) writer structure"]
+impl crate::Writable for TSF_TIMER_CFG_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_TIMER_CFG%s to value 0"]
+impl crate::Resettable for TSF_TIMER_CFG_SPEC {}

--- a/esp32c3/src/wifi/tsf_timer_target.rs
+++ b/esp32c3/src/wifi/tsf_timer_target.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TSF_TIMER_TARGET%s` reader"]
+pub type R = crate::R<TSF_TIMER_TARGET_SPEC>;
+#[doc = "Register `TSF_TIMER_TARGET%s` writer"]
+pub type W = crate::W<TSF_TIMER_TARGET_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Target of a TSF timer, written by tsf_hal_set_timer_target\n\nYou can [`read`](crate::Reg::read) this register and get [`tsf_timer_target::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tsf_timer_target::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TSF_TIMER_TARGET_SPEC;
+impl crate::RegisterSpec for TSF_TIMER_TARGET_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tsf_timer_target::R`](R) reader structure"]
+impl crate::Readable for TSF_TIMER_TARGET_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tsf_timer_target::W`](W) writer structure"]
+impl crate::Writable for TSF_TIMER_TARGET_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TSF_TIMER_TARGET%s to value 0"]
+impl crate::Resettable for TSF_TIMER_TARGET_SPEC {}

--- a/esp32c3/src/wifi/tx_pti.rs
+++ b/esp32c3/src/wifi/tx_pti.rs
@@ -1,0 +1,24 @@
+#[doc = "Register `TX_PTI%s` reader"]
+pub type R = crate::R<TX_PTI_SPEC>;
+#[doc = "Register `TX_PTI%s` writer"]
+pub type W = crate::W<TX_PTI_SPEC>;
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl W {}
+#[doc = "Coexistence priorities of the TX slot, written by hal_set_tx_pti\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_pti::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_pti::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_PTI_SPEC;
+impl crate::RegisterSpec for TX_PTI_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_pti::R`](R) reader structure"]
+impl crate::Readable for TX_PTI_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_pti::W`](W) writer structure"]
+impl crate::Writable for TX_PTI_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TX_PTI%s to value 0"]
+impl crate::Resettable for TX_PTI_SPEC {}

--- a/esp32c3/src/wifi/tx_slot_config.rs
+++ b/esp32c3/src/wifi/tx_slot_config.rs
@@ -1,0 +1,27 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "Used to configure the TX slot."]
+pub struct TX_SLOT_CONFIG {
+    config: CONFIG,
+    plcp0: PLCP0,
+}
+impl TX_SLOT_CONFIG {
+    #[doc = "0x00 - Config"]
+    #[inline(always)]
+    pub const fn config(&self) -> &CONFIG {
+        &self.config
+    }
+    #[doc = "0x04 - PLCP0"]
+    #[inline(always)]
+    pub const fn plcp0(&self) -> &PLCP0 {
+        &self.plcp0
+    }
+}
+#[doc = "CONFIG (rw) register accessor: Config\n\nYou can [`read`](crate::Reg::read) this register and get [`config::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`config::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@config`] module"]
+pub type CONFIG = crate::Reg<config::CONFIG_SPEC>;
+#[doc = "Config"]
+pub mod config;
+#[doc = "PLCP0 (rw) register accessor: PLCP0\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp0::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp0::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@plcp0`] module"]
+pub type PLCP0 = crate::Reg<plcp0::PLCP0_SPEC>;
+#[doc = "PLCP0"]
+pub mod plcp0;

--- a/esp32c3/src/wifi/tx_slot_config/config.rs
+++ b/esp32c3/src/wifi/tx_slot_config/config.rs
@@ -1,0 +1,73 @@
+#[doc = "Register `CONFIG` reader"]
+pub type R = crate::R<CONFIG_SPEC>;
+#[doc = "Register `CONFIG` writer"]
+pub type W = crate::W<CONFIG_SPEC>;
+#[doc = "Field `TIMEOUT` reader - "]
+pub type TIMEOUT_R = crate::FieldReader<u16>;
+#[doc = "Field `TIMEOUT` writer - "]
+pub type TIMEOUT_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
+#[doc = "Field `BACKOFF_TIME` reader - "]
+pub type BACKOFF_TIME_R = crate::FieldReader<u16>;
+#[doc = "Field `BACKOFF_TIME` writer - "]
+pub type BACKOFF_TIME_W<'a, REG> = crate::FieldWriter<'a, REG, 10, u16>;
+#[doc = "Field `AIFSN` reader - "]
+pub type AIFSN_R = crate::FieldReader;
+#[doc = "Field `AIFSN` writer - "]
+pub type AIFSN_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+impl R {
+    #[doc = "Bits 0:11"]
+    #[inline(always)]
+    pub fn timeout(&self) -> TIMEOUT_R {
+        TIMEOUT_R::new((self.bits & 0x0fff) as u16)
+    }
+    #[doc = "Bits 12:21"]
+    #[inline(always)]
+    pub fn backoff_time(&self) -> BACKOFF_TIME_R {
+        BACKOFF_TIME_R::new(((self.bits >> 12) & 0x03ff) as u16)
+    }
+    #[doc = "Bits 24:27"]
+    #[inline(always)]
+    pub fn aifsn(&self) -> AIFSN_R {
+        AIFSN_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CONFIG")
+            .field("timeout", &self.timeout())
+            .field("backoff_time", &self.backoff_time())
+            .field("aifsn", &self.aifsn())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:11"]
+    #[inline(always)]
+    pub fn timeout(&mut self) -> TIMEOUT_W<'_, CONFIG_SPEC> {
+        TIMEOUT_W::new(self, 0)
+    }
+    #[doc = "Bits 12:21"]
+    #[inline(always)]
+    pub fn backoff_time(&mut self) -> BACKOFF_TIME_W<'_, CONFIG_SPEC> {
+        BACKOFF_TIME_W::new(self, 12)
+    }
+    #[doc = "Bits 24:27"]
+    #[inline(always)]
+    pub fn aifsn(&mut self) -> AIFSN_W<'_, CONFIG_SPEC> {
+        AIFSN_W::new(self, 24)
+    }
+}
+#[doc = "Config\n\nYou can [`read`](crate::Reg::read) this register and get [`config::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`config::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CONFIG_SPEC;
+impl crate::RegisterSpec for CONFIG_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`config::R`](R) reader structure"]
+impl crate::Readable for CONFIG_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`config::W`](W) writer structure"]
+impl crate::Writable for CONFIG_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets CONFIG to value 0"]
+impl crate::Resettable for CONFIG_SPEC {}

--- a/esp32c3/src/wifi/tx_slot_config/plcp0.rs
+++ b/esp32c3/src/wifi/tx_slot_config/plcp0.rs
@@ -1,0 +1,88 @@
+#[doc = "Register `PLCP0` reader"]
+pub type R = crate::R<PLCP0_SPEC>;
+#[doc = "Register `PLCP0` writer"]
+pub type W = crate::W<PLCP0_SPEC>;
+#[doc = "Field `DMA_ADDR` reader - Bottom bits of address of dma_item"]
+pub type DMA_ADDR_R = crate::FieldReader<u32>;
+#[doc = "Field `DMA_ADDR` writer - Bottom bits of address of dma_item"]
+pub type DMA_ADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `WAIT_FOR_ACK` reader - Enables ACK timeouts"]
+pub type WAIT_FOR_ACK_R = crate::BitReader;
+#[doc = "Field `WAIT_FOR_ACK` writer - Enables ACK timeouts"]
+pub type WAIT_FOR_ACK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLOT_VALID` reader - Marks this slot as valid"]
+pub type SLOT_VALID_R = crate::BitReader;
+#[doc = "Field `SLOT_VALID` writer - Marks this slot as valid"]
+pub type SLOT_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLOT_ENABLED` reader - Marks this slot as ready for transmission"]
+pub type SLOT_ENABLED_R = crate::BitReader;
+#[doc = "Field `SLOT_ENABLED` writer - Marks this slot as ready for transmission"]
+pub type SLOT_ENABLED_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bits 0:19 - Bottom bits of address of dma_item"]
+    #[inline(always)]
+    pub fn dma_addr(&self) -> DMA_ADDR_R {
+        DMA_ADDR_R::new(self.bits & 0x000f_ffff)
+    }
+    #[doc = "Bit 24 - Enables ACK timeouts"]
+    #[inline(always)]
+    pub fn wait_for_ack(&self) -> WAIT_FOR_ACK_R {
+        WAIT_FOR_ACK_R::new(((self.bits >> 24) & 1) != 0)
+    }
+    #[doc = "Bit 30 - Marks this slot as valid"]
+    #[inline(always)]
+    pub fn slot_valid(&self) -> SLOT_VALID_R {
+        SLOT_VALID_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Marks this slot as ready for transmission"]
+    #[inline(always)]
+    pub fn slot_enabled(&self) -> SLOT_ENABLED_R {
+        SLOT_ENABLED_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLCP0")
+            .field("dma_addr", &self.dma_addr())
+            .field("wait_for_ack", &self.wait_for_ack())
+            .field("slot_valid", &self.slot_valid())
+            .field("slot_enabled", &self.slot_enabled())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Bits 0:19 - Bottom bits of address of dma_item"]
+    #[inline(always)]
+    pub fn dma_addr(&mut self) -> DMA_ADDR_W<'_, PLCP0_SPEC> {
+        DMA_ADDR_W::new(self, 0)
+    }
+    #[doc = "Bit 24 - Enables ACK timeouts"]
+    #[inline(always)]
+    pub fn wait_for_ack(&mut self) -> WAIT_FOR_ACK_W<'_, PLCP0_SPEC> {
+        WAIT_FOR_ACK_W::new(self, 24)
+    }
+    #[doc = "Bit 30 - Marks this slot as valid"]
+    #[inline(always)]
+    pub fn slot_valid(&mut self) -> SLOT_VALID_W<'_, PLCP0_SPEC> {
+        SLOT_VALID_W::new(self, 30)
+    }
+    #[doc = "Bit 31 - Marks this slot as ready for transmission"]
+    #[inline(always)]
+    pub fn slot_enabled(&mut self) -> SLOT_ENABLED_W<'_, PLCP0_SPEC> {
+        SLOT_ENABLED_W::new(self, 31)
+    }
+}
+#[doc = "PLCP0\n\nYou can [`read`](crate::Reg::read) this register and get [`plcp0::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`plcp0::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PLCP0_SPEC;
+impl crate::RegisterSpec for PLCP0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`plcp0::R`](R) reader structure"]
+impl crate::Readable for PLCP0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`plcp0::W`](W) writer structure"]
+impl crate::Writable for PLCP0_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets PLCP0 to value 0"]
+impl crate::Resettable for PLCP0_SPEC {}

--- a/esp32c3/src/wifi/txq_state.rs
+++ b/esp32c3/src/wifi/txq_state.rs
@@ -1,0 +1,47 @@
+#[repr(C)]
+#[cfg_attr(feature = "impl-register-debug", derive(Debug))]
+#[doc = "State of transmission queues"]
+pub struct TXQ_STATE {
+    tx_error_clear: TX_ERROR_CLEAR,
+    tx_error_status: TX_ERROR_STATUS,
+    tx_complete_clear: TX_COMPLETE_CLEAR,
+    tx_complete_status: TX_COMPLETE_STATUS,
+}
+impl TXQ_STATE {
+    #[doc = "0x00 - Clear the error status of a slot"]
+    #[inline(always)]
+    pub const fn tx_error_clear(&self) -> &TX_ERROR_CLEAR {
+        &self.tx_error_clear
+    }
+    #[doc = "0x04 - Error status of a slot"]
+    #[inline(always)]
+    pub const fn tx_error_status(&self) -> &TX_ERROR_STATUS {
+        &self.tx_error_status
+    }
+    #[doc = "0x08 - Clear the completion status of a slot"]
+    #[inline(always)]
+    pub const fn tx_complete_clear(&self) -> &TX_COMPLETE_CLEAR {
+        &self.tx_complete_clear
+    }
+    #[doc = "0x0c - Completion status of a slot"]
+    #[inline(always)]
+    pub const fn tx_complete_status(&self) -> &TX_COMPLETE_STATUS {
+        &self.tx_complete_status
+    }
+}
+#[doc = "TX_ERROR_CLEAR (rw) register accessor: Clear the error status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_error_clear::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_error_clear::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_error_clear`] module"]
+pub type TX_ERROR_CLEAR = crate::Reg<tx_error_clear::TX_ERROR_CLEAR_SPEC>;
+#[doc = "Clear the error status of a slot"]
+pub mod tx_error_clear;
+#[doc = "TX_ERROR_STATUS (rw) register accessor: Error status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_error_status::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_error_status::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_error_status`] module"]
+pub type TX_ERROR_STATUS = crate::Reg<tx_error_status::TX_ERROR_STATUS_SPEC>;
+#[doc = "Error status of a slot"]
+pub mod tx_error_status;
+#[doc = "TX_COMPLETE_CLEAR (rw) register accessor: Clear the completion status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_complete_clear::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_complete_clear::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_complete_clear`] module"]
+pub type TX_COMPLETE_CLEAR = crate::Reg<tx_complete_clear::TX_COMPLETE_CLEAR_SPEC>;
+#[doc = "Clear the completion status of a slot"]
+pub mod tx_complete_clear;
+#[doc = "TX_COMPLETE_STATUS (rw) register accessor: Completion status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_complete_status::R`]. You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_complete_status::W`]. You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_complete_status`] module"]
+pub type TX_COMPLETE_STATUS = crate::Reg<tx_complete_status::TX_COMPLETE_STATUS_SPEC>;
+#[doc = "Completion status of a slot"]
+pub mod tx_complete_status;

--- a/esp32c3/src/wifi/txq_state/tx_complete_clear.rs
+++ b/esp32c3/src/wifi/txq_state/tx_complete_clear.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `TX_COMPLETE_CLEAR` reader"]
+pub type R = crate::R<TX_COMPLETE_CLEAR_SPEC>;
+#[doc = "Register `TX_COMPLETE_CLEAR` writer"]
+pub type W = crate::W<TX_COMPLETE_CLEAR_SPEC>;
+#[doc = "Field `SLOT(0-4)` reader - Clear bit for a slot"]
+pub type SLOT_R = crate::BitReader;
+#[doc = "Field `SLOT(0-4)` writer - Clear bit for a slot"]
+pub type SLOT_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot(&self, n: u8) -> SLOT_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_R::new(((self.bits >> n) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_iter(&self) -> impl Iterator<Item = SLOT_R> + '_ {
+        (0..5).map(move |n| SLOT_R::new(((self.bits >> n) & 1) != 0))
+    }
+    #[doc = "Bit 0 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot0(&self) -> SLOT_R {
+        SLOT_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot1(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot2(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot3(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot4(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_COMPLETE_CLEAR")
+            .field("slot0", &self.slot0())
+            .field("slot1", &self.slot1())
+            .field("slot2", &self.slot2())
+            .field("slot3", &self.slot3())
+            .field("slot4", &self.slot4())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot(&mut self, n: u8) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_W::new(self, n)
+    }
+    #[doc = "Bit 0 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot0(&mut self) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        SLOT_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot1(&mut self) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        SLOT_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot2(&mut self) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        SLOT_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot3(&mut self) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        SLOT_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot4(&mut self) -> SLOT_W<'_, TX_COMPLETE_CLEAR_SPEC> {
+        SLOT_W::new(self, 4)
+    }
+}
+#[doc = "Clear the completion status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_complete_clear::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_complete_clear::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_COMPLETE_CLEAR_SPEC;
+impl crate::RegisterSpec for TX_COMPLETE_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_complete_clear::R`](R) reader structure"]
+impl crate::Readable for TX_COMPLETE_CLEAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_complete_clear::W`](W) writer structure"]
+impl crate::Writable for TX_COMPLETE_CLEAR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TX_COMPLETE_CLEAR to value 0"]
+impl crate::Resettable for TX_COMPLETE_CLEAR_SPEC {}

--- a/esp32c3/src/wifi/txq_state/tx_complete_status.rs
+++ b/esp32c3/src/wifi/txq_state/tx_complete_status.rs
@@ -1,0 +1,111 @@
+#[doc = "Register `TX_COMPLETE_STATUS` reader"]
+pub type R = crate::R<TX_COMPLETE_STATUS_SPEC>;
+#[doc = "Register `TX_COMPLETE_STATUS` writer"]
+pub type W = crate::W<TX_COMPLETE_STATUS_SPEC>;
+#[doc = "Field `SLOT(0-4)` reader - Status bit for a slot"]
+pub type SLOT_R = crate::BitReader;
+#[doc = "Field `SLOT(0-4)` writer - Status bit for a slot"]
+pub type SLOT_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot(&self, n: u8) -> SLOT_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_R::new(((self.bits >> n) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_iter(&self) -> impl Iterator<Item = SLOT_R> + '_ {
+        (0..5).map(move |n| SLOT_R::new(((self.bits >> n) & 1) != 0))
+    }
+    #[doc = "Bit 0 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot0(&self) -> SLOT_R {
+        SLOT_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot1(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot2(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot3(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot4(&self) -> SLOT_R {
+        SLOT_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_COMPLETE_STATUS")
+            .field("slot0", &self.slot0())
+            .field("slot1", &self.slot1())
+            .field("slot2", &self.slot2())
+            .field("slot3", &self.slot3())
+            .field("slot4", &self.slot4())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot(&mut self, n: u8) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_W::new(self, n)
+    }
+    #[doc = "Bit 0 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot0(&mut self) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        SLOT_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot1(&mut self) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        SLOT_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot2(&mut self) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        SLOT_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot3(&mut self) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        SLOT_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Status bit for a slot"]
+    #[inline(always)]
+    pub fn slot4(&mut self) -> SLOT_W<'_, TX_COMPLETE_STATUS_SPEC> {
+        SLOT_W::new(self, 4)
+    }
+}
+#[doc = "Completion status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_complete_status::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_complete_status::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_COMPLETE_STATUS_SPEC;
+impl crate::RegisterSpec for TX_COMPLETE_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_complete_status::R`](R) reader structure"]
+impl crate::Readable for TX_COMPLETE_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_complete_status::W`](W) writer structure"]
+impl crate::Writable for TX_COMPLETE_STATUS_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TX_COMPLETE_STATUS to value 0"]
+impl crate::Resettable for TX_COMPLETE_STATUS_SPEC {}

--- a/esp32c3/src/wifi/txq_state/tx_error_clear.rs
+++ b/esp32c3/src/wifi/txq_state/tx_error_clear.rs
@@ -1,0 +1,194 @@
+#[doc = "Register `TX_ERROR_CLEAR` reader"]
+pub type R = crate::R<TX_ERROR_CLEAR_SPEC>;
+#[doc = "Register `TX_ERROR_CLEAR` writer"]
+pub type W = crate::W<TX_ERROR_CLEAR_SPEC>;
+#[doc = "Field `SLOT_COLLISION(0-4)` reader - Collision clear bit for a slot"]
+pub type SLOT_COLLISION_R = crate::BitReader;
+#[doc = "Field `SLOT_COLLISION(0-4)` writer - Collision clear bit for a slot"]
+pub type SLOT_COLLISION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLOT_TIMEOUT(0-4)` reader - Timeout clear bit for a slot"]
+pub type SLOT_TIMEOUT_R = crate::BitReader;
+#[doc = "Field `SLOT_TIMEOUT(0-4)` writer - Timeout clear bit for a slot"]
+pub type SLOT_TIMEOUT_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Collision clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_COLLISION0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_collision(&self, n: u8) -> SLOT_COLLISION_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_COLLISION_R::new(((self.bits >> n) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision_iter(&self) -> impl Iterator<Item = SLOT_COLLISION_R> + '_ {
+        (0..5).map(move |n| SLOT_COLLISION_R::new(((self.bits >> n) & 1) != 0))
+    }
+    #[doc = "Bit 0 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision0(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision1(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision2(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision3(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision4(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Timeout clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_TIMEOUT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_timeout(&self, n: u8) -> SLOT_TIMEOUT_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_TIMEOUT_R::new(((self.bits >> (n + 16)) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout_iter(&self) -> impl Iterator<Item = SLOT_TIMEOUT_R> + '_ {
+        (0..5).map(move |n| SLOT_TIMEOUT_R::new(((self.bits >> (n + 16)) & 1) != 0))
+    }
+    #[doc = "Bit 16 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout0(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout1(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout2(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout3(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout4(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 20) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_ERROR_CLEAR")
+            .field("slot_collision0", &self.slot_collision0())
+            .field("slot_collision1", &self.slot_collision1())
+            .field("slot_collision2", &self.slot_collision2())
+            .field("slot_collision3", &self.slot_collision3())
+            .field("slot_collision4", &self.slot_collision4())
+            .field("slot_timeout0", &self.slot_timeout0())
+            .field("slot_timeout1", &self.slot_timeout1())
+            .field("slot_timeout2", &self.slot_timeout2())
+            .field("slot_timeout3", &self.slot_timeout3())
+            .field("slot_timeout4", &self.slot_timeout4())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Collision clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_COLLISION0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_collision(&mut self, n: u8) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_COLLISION_W::new(self, n)
+    }
+    #[doc = "Bit 0 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision0(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_COLLISION_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision1(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_COLLISION_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision2(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_COLLISION_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision3(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_COLLISION_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Collision clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision4(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_COLLISION_W::new(self, 4)
+    }
+    #[doc = "Timeout clear bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_TIMEOUT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_timeout(&mut self, n: u8) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_TIMEOUT_W::new(self, n + 16)
+    }
+    #[doc = "Bit 16 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout0(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout1(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout2(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 18)
+    }
+    #[doc = "Bit 19 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout3(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 19)
+    }
+    #[doc = "Bit 20 - Timeout clear bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout4(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_CLEAR_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 20)
+    }
+}
+#[doc = "Clear the error status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_error_clear::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_error_clear::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_ERROR_CLEAR_SPEC;
+impl crate::RegisterSpec for TX_ERROR_CLEAR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_error_clear::R`](R) reader structure"]
+impl crate::Readable for TX_ERROR_CLEAR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_error_clear::W`](W) writer structure"]
+impl crate::Writable for TX_ERROR_CLEAR_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TX_ERROR_CLEAR to value 0"]
+impl crate::Resettable for TX_ERROR_CLEAR_SPEC {}

--- a/esp32c3/src/wifi/txq_state/tx_error_status.rs
+++ b/esp32c3/src/wifi/txq_state/tx_error_status.rs
@@ -1,0 +1,194 @@
+#[doc = "Register `TX_ERROR_STATUS` reader"]
+pub type R = crate::R<TX_ERROR_STATUS_SPEC>;
+#[doc = "Register `TX_ERROR_STATUS` writer"]
+pub type W = crate::W<TX_ERROR_STATUS_SPEC>;
+#[doc = "Field `SLOT_COLLISION(0-4)` reader - Collision status bit for a slot"]
+pub type SLOT_COLLISION_R = crate::BitReader;
+#[doc = "Field `SLOT_COLLISION(0-4)` writer - Collision status bit for a slot"]
+pub type SLOT_COLLISION_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `SLOT_TIMEOUT(0-4)` reader - Timeout status bit for a slot"]
+pub type SLOT_TIMEOUT_R = crate::BitReader;
+#[doc = "Field `SLOT_TIMEOUT(0-4)` writer - Timeout status bit for a slot"]
+pub type SLOT_TIMEOUT_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Collision status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_COLLISION0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_collision(&self, n: u8) -> SLOT_COLLISION_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_COLLISION_R::new(((self.bits >> n) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision_iter(&self) -> impl Iterator<Item = SLOT_COLLISION_R> + '_ {
+        (0..5).map(move |n| SLOT_COLLISION_R::new(((self.bits >> n) & 1) != 0))
+    }
+    #[doc = "Bit 0 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision0(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision1(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision2(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision3(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision4(&self) -> SLOT_COLLISION_R {
+        SLOT_COLLISION_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Timeout status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_TIMEOUT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_timeout(&self, n: u8) -> SLOT_TIMEOUT_R {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_TIMEOUT_R::new(((self.bits >> (n + 16)) & 1) != 0)
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout_iter(&self) -> impl Iterator<Item = SLOT_TIMEOUT_R> + '_ {
+        (0..5).map(move |n| SLOT_TIMEOUT_R::new(((self.bits >> (n + 16)) & 1) != 0))
+    }
+    #[doc = "Bit 16 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout0(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout1(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout2(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout3(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout4(&self) -> SLOT_TIMEOUT_R {
+        SLOT_TIMEOUT_R::new(((self.bits >> 20) & 1) != 0)
+    }
+}
+#[cfg(feature = "impl-register-debug")]
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_ERROR_STATUS")
+            .field("slot_collision0", &self.slot_collision0())
+            .field("slot_collision1", &self.slot_collision1())
+            .field("slot_collision2", &self.slot_collision2())
+            .field("slot_collision3", &self.slot_collision3())
+            .field("slot_collision4", &self.slot_collision4())
+            .field("slot_timeout0", &self.slot_timeout0())
+            .field("slot_timeout1", &self.slot_timeout1())
+            .field("slot_timeout2", &self.slot_timeout2())
+            .field("slot_timeout3", &self.slot_timeout3())
+            .field("slot_timeout4", &self.slot_timeout4())
+            .finish()
+    }
+}
+impl W {
+    #[doc = "Collision status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_COLLISION0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_collision(&mut self, n: u8) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_COLLISION_W::new(self, n)
+    }
+    #[doc = "Bit 0 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision0(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_COLLISION_W::new(self, 0)
+    }
+    #[doc = "Bit 1 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision1(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_COLLISION_W::new(self, 1)
+    }
+    #[doc = "Bit 2 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision2(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_COLLISION_W::new(self, 2)
+    }
+    #[doc = "Bit 3 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision3(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_COLLISION_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - Collision status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_collision4(&mut self) -> SLOT_COLLISION_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_COLLISION_W::new(self, 4)
+    }
+    #[doc = "Timeout status bit for a slot"]
+    #[doc = ""]
+    #[doc = "<div class=\"warning\">`n` is number of field in register. `n == 0` corresponds to `SLOT_TIMEOUT0` field.</div>"]
+    #[inline(always)]
+    pub fn slot_timeout(&mut self, n: u8) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        #[allow(clippy::no_effect)]
+        [(); 5][n as usize];
+        SLOT_TIMEOUT_W::new(self, n + 16)
+    }
+    #[doc = "Bit 16 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout0(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 16)
+    }
+    #[doc = "Bit 17 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout1(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 17)
+    }
+    #[doc = "Bit 18 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout2(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 18)
+    }
+    #[doc = "Bit 19 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout3(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 19)
+    }
+    #[doc = "Bit 20 - Timeout status bit for a slot"]
+    #[inline(always)]
+    pub fn slot_timeout4(&mut self) -> SLOT_TIMEOUT_W<'_, TX_ERROR_STATUS_SPEC> {
+        SLOT_TIMEOUT_W::new(self, 20)
+    }
+}
+#[doc = "Error status of a slot\n\nYou can [`read`](crate::Reg::read) this register and get [`tx_error_status::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`tx_error_status::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_ERROR_STATUS_SPEC;
+impl crate::RegisterSpec for TX_ERROR_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_error_status::R`](R) reader structure"]
+impl crate::Readable for TX_ERROR_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tx_error_status::W`](W) writer structure"]
+impl crate::Writable for TX_ERROR_STATUS_SPEC {
+    type Safety = crate::Unsafe;
+}
+#[doc = "`reset()` method sets TX_ERROR_STATUS to value 0"]
+impl crate::Resettable for TX_ERROR_STATUS_SPEC {}

--- a/esp32c3/svd/patches/esp32c3.yaml
+++ b/esp32c3/svd/patches/esp32c3.yaml
@@ -23,6 +23,7 @@ _include:
   - "_system.yml"
   - "_timg.yml"
   - "_xts_aes.yml"
+  - "wifi.yaml"
   - "_mmu_table.yml"
 
 RNG:

--- a/esp32c3/svd/patches/wifi.yaml
+++ b/esp32c3/svd/patches/wifi.yaml
@@ -1,0 +1,236 @@
+# Wi-Fi MAC register block of the ESP32-C3.
+#
+# Derived from the ESP32-S2 definitions by diffing the MMIO accesses of
+# identically named functions in the proprietary libpp/libnet80211 blobs of
+# both chips. The RX side matches the original ESP32 layout, the TX side uses
+# a different slot stride (0x4c instead of 0x3c).
+_add:
+    WIFI:
+        description: MAC controller for Wi-Fi peripheral
+        groupName: WIFI
+        baseAddress: 0x60033000
+        size: 32
+        addressBlock:
+            offset: 0x0
+            size: 0x2200
+            usage: registers
+        registers:
+            RX_CTRL:
+                addressOffset: 0x84
+            FILTER_CONTROL%s:
+                dim: 4
+                dimIncrement: 4
+                addressOffset: 0xd8
+            RX_CTRL_FILTER%s:
+                dim: 4
+                dimIncrement: 4
+                addressOffset: 0x100
+                access: read-write
+            CTRL:
+                description: Exact name and meaning unknown, used for initializing the MAC
+                addressOffset: 0xca0
+                access: read-write
+            PLCP1%s:
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11c8
+            HT_SIG%s:
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11d0
+            HT_UNKNOWN%s:
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11e0
+            PLCP2%s:
+                description: "Misc TX slot control: bit 4 (PLCP2 of the S2), bits 6..13 expected response rate, bits 22..23 HT, bits 24..27 TXOP frame count, bits 28..29 interface"
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11e4
+            DURATION%s:
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11e8
+            PMD%s:
+                description: TX result of the slot, read by hal_mac_get_txq_pmd
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11f0
+            TX_PTI%s:
+                description: Coexistence priorities of the TX slot, written by hal_set_tx_pti
+                dim: 5
+                dimIncrement: 0x4c
+                addressOffset: 0x11cc
+                access: read-write
+            MAC_TIME:
+                addressOffset: 0x2000
+                access: read
+                description: Current value of the MAC timer
+            TSF_CTRL:
+                addressOffset: 0x200c
+                access: read-write
+                description: "Control for the per-interface TSF counters. Written by tsf_hal_get_counter_value, tsf_hal_set_counter_value and tsf_hal_set_tbtt_start_time."
+                fields:
+                    LATCH:
+                        description: Bit n latches the TSF counter of interface n into TSF_TIME for reading. Cleared again after the read.
+                        bitOffset: 0
+                        bitWidth: 4
+                    LOAD:
+                        description: Bit n loads the TSF counter of interface n from TSF_LOAD.
+                        bitOffset: 4
+                        bitWidth: 4
+                    LOAD_TBTT_START:
+                        description: Bit n loads the TBTT start time of interface n from TBTT_START.
+                        bitOffset: 8
+                        bitWidth: 4
+            TSF_LOAD_LOW:
+                addressOffset: 0x2010
+                access: read-write
+                description: Low word of the value loaded into a TSF counter
+            TSF_LOAD_HIGH:
+                addressOffset: 0x2014
+                access: read-write
+                description: High word of the value loaded into a TSF counter
+            TSF_TIME_LOW:
+                addressOffset: 0x2018
+                access: read
+                description: Low word of the latched TSF counter
+            TSF_TIME_HIGH:
+                addressOffset: 0x201c
+                access: read
+                description: High word of the latched TSF counter
+            TBTT_START:
+                addressOffset: 0x2020
+                access: read-write
+                description: TBTT start time, loaded into an interface with TSF_CTRL.LOAD_TBTT_START
+                fields:
+                    START_TIME:
+                        bitOffset: 0
+                        bitWidth: 26
+            TSF_CFG%s:
+                dim: 4
+                dimIncrement: 0xc
+                addressOffset: 0x2028
+                access: read-write
+                description: TSF and TBTT configuration of an interface
+                fields:
+                    TBTT_ENABLE:
+                        description: Set by tsf_hal_set_tbtt_enable
+                        bitOffset: 26
+                        bitWidth: 1
+                    TSF_ENABLE_AUX:
+                        description: Bits 27 and 28 are set together with TSF_ENABLE by tsf_hal_set_tsf_enable, meaning unknown
+                        bitOffset: 27
+                        bitWidth: 2
+                    TSF_ENABLE:
+                        description: Enables the TSF counter, checked by tsf_hal_is_tsf_enabled
+                        bitOffset: 31
+                        bitWidth: 1
+            TBTT_CFG%s:
+                dim: 4
+                dimIncrement: 0xc
+                addressOffset: 0x2030
+                access: read-write
+                description: TBTT interval and early time of an interface
+                fields:
+                    INTERVAL:
+                        description: Beacon interval in TUs (the blob shifts microseconds right by 10)
+                        bitOffset: 0
+                        bitWidth: 16
+                    EARLY_TIME:
+                        description: How much earlier than the TBTT the interrupt fires, set by tsf_hal_set_tbtt_early_time
+                        bitOffset: 16
+                        bitWidth: 16
+            TSF_TIMER_CFG%s:
+                dim: 4
+                dimIncrement: 0x8
+                addressOffset: 0x205c
+                access: read-write
+                description: Configuration of a TSF timer
+                fields:
+                    SOC_WAKEUP:
+                        description: Wake the SoC when the timer fires, set by tsf_hal_set_timer_soc_wakeup_enable
+                        bitOffset: 30
+                        bitWidth: 1
+                    ENABLE:
+                        description: Set by tsf_hal_set_timer_enable
+                        bitOffset: 31
+                        bitWidth: 1
+            TSF_TIMER_TARGET%s:
+                dim: 4
+                dimIncrement: 0x8
+                addressOffset: 0x2060
+                access: read-write
+                description: Target of a TSF timer, written by tsf_hal_set_timer_target
+            PWR_INT_ENABLE:
+                addressOffset: 0x2110
+                access: read-write
+                description: "Interrupt enable for the WIFI_PWR interrupt. TBTT of interface n is bit (4 - n), TSF timer n is bit (8 - n)."
+
+WIFI:
+    _add:
+        _clusters:
+            FILTER_BANK%s:
+                dim: 2
+                dimIncrement: 0x40
+                addressOffset: 0x0
+                description: "
+                    Filter banks for frame reception. Bank zero is for the BSSID and bank one for the RA.
+                    Each filter bank has registers for four interfaces.
+                    "
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            RX_DMA_LIST:
+                addressOffset: 0x88
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            MAC_INTERRUPT:
+                addressOffset: 0xc3c
+                description: Status and clear for the WIFI_MAC interrupt
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            PWR_INTERRUPT:
+                addressOffset: 0x2118
+                description: Status and clear for the WIFI_PWR interrupt
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            TXQ_STATE:
+                addressOffset: 0xca4
+                description: State of transmission queues
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            TX_SLOT_CONFIG%s:
+                dim: 5
+                dimIncrement: 0x8
+                description: Used to configure the TX slot.
+                addressOffset: 0xce4
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            CRYPTO_KEY_SLOT%s:
+                dim: 25
+                dimIncrement: 40
+                addressOffset: 0x1400
+                description: Cryptographic keys for MPDU encapsulation and decapsulation
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+            CRYPTO_CONTROL:
+                addressOffset: 0x800
+                description: Control registers for hardware crypto
+                registers:
+                    DUMMY:
+                        addressOffset: 0x0
+
+_include:
+    - "../../../common_patches/wifi/mac/rx.yaml"
+    - "../../../common_patches/wifi/mac/rx_filter_masked.yaml"
+    - "../../../common_patches/wifi/mac/tx.yaml"
+    - "../../../common_patches/wifi/mac/mac_interrupt.yaml"
+    - "../../../common_patches/wifi/mac/pwr_interrupt.yaml"
+    - "../../../common_patches/wifi/mac/crypto.yaml"


### PR DESCRIPTION
This adds the Wi-Fi MAC register block to the ESP32-C3 PAC, reusing the common Wi-Fi patches from #309 with a chip patch that carries the C3 offsets. The C3 shares its Wi-Fi 4 MAC with the S2 and S3, and the offsets were found by comparing the MMIO accesses of the identically named `hal_*` functions in the proprietary libpp/libnet80211 blobs of both chips in Ghidra. This is the PAC side of an ESP32-C3 port of esp-wifi-hal and FoA.

- `esp32c3/svd/patches/wifi.yaml` describes `WIFI` at 0x60033000 and includes the same `common_patches/wifi/mac/*.yaml` as the S2
- RX, filter, crypto and MAC/PWR interrupt blocks follow the ESP32/S2 layout with shifted offsets; TX slots use a stride of 0x4c instead of 0x3c and gain a `TX_PTI` register
- new registers with no counterpart on the other chips yet: the TSF counters (`TSF_CTRL`, `TSF_LOAD_*`, `TSF_TIME_*`), per-interface `TSF_CFG` and `TBTT_CFG`, four TSF timers (`TSF_TIMER_CFG`, `TSF_TIMER_TARGET`) and `PWR_INT_ENABLE`
- regenerated `esp32c3/src`

Testing: exercised on an ESP32-C3 dev board through the esp-wifi-hal branch at https://github.com/okhsunrog/esp-wifi-hal/tree/esp32c3: frame RX and TX, hardware auto-ACK, hardware CCMP, TX result decoding via `PMD`, TSF timers, TBTT events, and a full WPA2 station connection with DHCP through FoA.
